### PR TITLE
Removes superfluous Tinkerer spell list reference on Level 20

### DIFF
--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -66,7 +66,6 @@ namespace SolastaCommunityExpansion.Level20
             "SpellListRanger",
             "SpellListShockArcanist",
             "SpellListSorcerer",
-            "SpellListTinkerer",
             "SpellListWizard",
             "SpellListWizardGreenmage",
         };


### PR DESCRIPTION
Tinkerer depends on CE so that list will never be there by the time Level 20 fixes other lists. Tinkerer is also already set for Level 20. No changes required on its spell lists.