### PR TITLE
Add editorconfig

### DIFF
--- a/SolastaCommunityExpansion/.editorconfig
+++ b/SolastaCommunityExpansion/.editorconfig
@@ -1,0 +1,133 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/SolastaCommunityExpansion/Feats/AcehighFeats.cs
+++ b/SolastaCommunityExpansion/Feats/AcehighFeats.cs
@@ -179,7 +179,7 @@ namespace SolastaCommunityExpansion.Feats
             protected PowerAttackConditionBuilder(string name, string guid) : base(DatabaseHelper.ConditionDefinitions.ConditionHeraldOfBattle, name, guid)
             {
                 Definition.GuiPresentation.Title = "Feature/&PowerAttackConditionTitle";
-                Definition.GuiPresentation.Description = Gui.Format("Feature/&PowerAttackConditionDescription", Main.Settings.FeatPowerAttackModifier.ToString()); 
+                Definition.GuiPresentation.Description = Gui.Format("Feature/&PowerAttackConditionDescription", Main.Settings.FeatPowerAttackModifier.ToString());
 
                 Definition.SetAllowMultipleInstances(false);
                 Definition.Features.Clear();
@@ -278,11 +278,15 @@ namespace SolastaCommunityExpansion.Feats
                 Definition.SetShortTitleOverride("Feature/&RagePowerTitle");
 
                 //Create the power attack effect
-                EffectForm rageEffect = new EffectForm();
-                rageEffect.ConditionForm = new ConditionForm();
-                rageEffect.FormType = EffectForm.EffectFormType.Condition;
-                rageEffect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
-                rageEffect.ConditionForm.ConditionDefinition = RageFeatConditionBuilder.RageFeatCondition;
+                EffectForm rageEffect = new EffectForm
+                {
+                    ConditionForm = new ConditionForm
+                    {
+                        Operation = ConditionForm.ConditionOperation.Add,
+                        ConditionDefinition = RageFeatConditionBuilder.RageFeatCondition
+                    },
+                    FormType = EffectForm.EffectFormType.Condition
+                };
 
                 //Add to our new effect
                 EffectDescription newEffectDescription = new EffectDescription();
@@ -347,9 +351,13 @@ namespace SolastaCommunityExpansion.Feats
                 Definition.GuiPresentation.Description = "Feature/&RageStrengthSavingThrowAffinityDescription";
 
                 Definition.AffinityGroups.Clear();
-                var strengthSaveAffinityGroup = new SavingThrowAffinityGroup();
-                strengthSaveAffinityGroup.affinity = RuleDefinitions.CharacterSavingThrowAffinity.Advantage;
-                strengthSaveAffinityGroup.abilityScoreName = "Strength";
+
+                Definition.AffinityGroups.Add(
+                    new SavingThrowAffinityGroup
+                    {
+                        affinity = RuleDefinitions.CharacterSavingThrowAffinity.Advantage,
+                        abilityScoreName = "Strength"
+                    });
             }
 
             public static FeatureDefinitionSavingThrowAffinity CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Feats/CasterFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CasterFeats.cs
@@ -3,6 +3,7 @@ using SolastaModApi;
 using SolastaModApi.BuilderHelpers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SolastaCommunityExpansion.Feats
 {
@@ -389,14 +390,11 @@ namespace SolastaCommunityExpansion.Feats
 
         public static FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup BuildAutoPreparedSpellGroup(int classLevel, List<SpellDefinition> spellnames)
         {
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup spellgroup = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup();
-            spellgroup.ClassLevel = classLevel;
-            spellgroup.SpellsList = new List<SpellDefinition>();
-            foreach (SpellDefinition spell in spellnames)
+            return new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
-                spellgroup.SpellsList.Add(spell);
-            }
-            return spellgroup;
+                ClassLevel = classLevel,
+                SpellsList = spellnames.ToList()
+            };
         }
 
         public static FeatureDefinitionProficiency BuildProficiency(RuleDefinitions.ProficiencyType type,

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
@@ -1,30 +1,37 @@
 ﻿using SolastaModApi;
 using SolastaModApi.Extensions;
+using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using static SolastaModApi.DatabaseHelper.SchoolOfMagicDefinitions;
 
 namespace SolastaCommunityExpansion.Features
 {
     public class FeatureDefinitionSavingThrowAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
     {
         public FeatureDefinitionSavingThrowAffinityBuilder(string name, string guid, List<string> abilityScores,
-        RuleDefinitions.CharacterSavingThrowAffinity affinityType, bool againstMagic, GuiPresentation guiPresentation) : base(name, guid)
+            RuleDefinitions.CharacterSavingThrowAffinity affinityType, bool againstMagic, GuiPresentation guiPresentation) : base(name, guid)
         {
             foreach (string ability in abilityScores)
             {
-                FeatureDefinitionSavingThrowAffinity.SavingThrowAffinityGroup group = new FeatureDefinitionSavingThrowAffinity.SavingThrowAffinityGroup();
-                group.abilityScoreName = ability;
-                group.affinity = affinityType;
+                FeatureDefinitionSavingThrowAffinity.SavingThrowAffinityGroup group = new FeatureDefinitionSavingThrowAffinity.SavingThrowAffinityGroup
+                {
+                    abilityScoreName = ability,
+                    affinity = affinityType
+                };
+
                 if (againstMagic)
                 {
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolAbjuration.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolConjuration.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolDivination.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEnchantment.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolIllusion.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolNecromancy.Name);
-                    group.restrictedSchools.Add(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation.Name);
+                    group.restrictedSchools.AddRange(
+                        SchoolAbjuration.Name,
+                        SchoolConjuration.Name,
+                        SchoolDivination.Name,
+                        SchoolEnchantment.Name,
+                        SchoolEvocation.Name,
+                        SchoolIllusion.Name,
+                        SchoolNecromancy.Name,
+                        SchoolTransmutation.Name);
                 }
+
                 Definition.AffinityGroups.Add(group);
             }
 

--- a/SolastaCommunityExpansion/Main.cs
+++ b/SolastaCommunityExpansion/Main.cs
@@ -1,4 +1,4 @@
-using ModKit;
+﻿using ModKit;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -9,7 +9,8 @@ namespace SolastaCommunityExpansion
 {
     public class Main
     {
-        public static bool Enabled = false;
+        public static bool Enabled { get; set; } = false;
+
         public static readonly string MOD_FOLDER = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
         [Conditional("DEBUG")]

--- a/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
     [HarmonyPatch(typeof(GameMenuModal), "SetButtonAvailability")]
     internal static class GameMenuModal_SetButtonAvailability
     {
-        internal static void Postfix(GameMenuModal.MenuButtonIndex index, bool visible, bool interactable, CanvasGroup[] ___buttonCanvases)
+        internal static void Postfix(GameMenuModal.MenuButtonIndex index, CanvasGroup[] ___buttonCanvases)
         {
             if (Main.Settings.EnableCheatMenuDuringGameplay && index == GameMenuModal.MenuButtonIndex.Cheats)
             {

--- a/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
@@ -71,13 +71,12 @@ namespace SolastaCommunityExpansion.Patches
 
             if (foundActivePanel)
             {
-                if (__instance is CharacterControlPanelExploration)
+                if (__instance is CharacterControlPanelExploration exploration)
                 {
-                    panelToActivate = ((CharacterControlPanelExploration)__instance).ExplorationActionPanel;
+                    panelToActivate = exploration.ExplorationActionPanel;
                 }
-                else if (__instance is CharacterControlPanelBattle)
+                else if (__instance is CharacterControlPanelBattle battlePanel)
                 {
-                    CharacterControlPanelBattle battlePanel = ((CharacterControlPanelBattle)__instance);
                     switch (actionId)
                     {
                         case ActionDefinitions.Id.CastMain:

--- a/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
@@ -67,12 +67,13 @@ namespace SolastaCommunityExpansion.Patches
         [HarmonyPatch(typeof(PowerSelectionPanel), "Unbind")]
         internal static class PowerSelectionPanel_Unbind
         {
-            internal static void Postfix(PowerSelectionPanel __instance)
+            internal static void Postfix()
             {
                 if (!Main.Settings.MultiLinePowerPanel)
                 {
                     return;
                 }
+
                 if (secondRow != null && secondRow.gameObject.activeSelf)
                 {
                     Gui.ReleaseChildrenToPool(secondRow);

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
@@ -21,14 +21,13 @@ namespace SolastaCommunityExpansion.Patches.GameUi
                     {
                         if (contentFragmentDescription.Type == ContentFragmentDescription.FragmentType.Body)
                         {
-                            string text = string.Empty;
                             GuiRecipeDefinition guiRecipeDefinition = ServiceRepository.GetService<IGuiWrapperService>().GetGuiRecipeDefinition(item.DocumentDescription.RecipeDefinition.Name);
-                            text = Gui.Format(contentFragmentDescription.Text, new string[]
+
+                            __instance.DescriptionLabel.Text = Gui.Format(contentFragmentDescription.Text, new string[]
                             {
                                 guiRecipeDefinition.Title,
                                 guiRecipeDefinition.IngredientsText
                             });
-                            __instance.DescriptionLabel.Text = text;
                         }
                     }
                 }

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     [HarmonyPatch(typeof(TooltipPanel), "SetupFeatures")]
     internal static class TooltipPanel_SetupFeatures
     {
-        internal static void Prefix(ref TooltipDefinitions.Scope scope, GuiTooltipClassDefinition tooltipClassDefinition, Dictionary<string, TooltipFeature> tooltipsFeatures)
+        internal static void Prefix(ref TooltipDefinitions.Scope scope)
         {
             if (Main.Settings.InvertAltBehaviorOnTooltips)
             {

--- a/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Patches.OnAttackEffects
         [HarmonyPatch(typeof(GameLocationBattleManager), "HandleCharacterAttackDamage")]
         internal static class GameLocationBattleManager_HandleCharacterAttackDamage_Patch
         {
-            internal static void Postfix(GameLocationBattleManager __instance, GameLocationCharacter attacker,
+            internal static void Postfix(GameLocationCharacter attacker,
                 GameLocationCharacter defender, ActionModifier attackModifier, RulesetAttackMode attackMode,
                 bool rangedAttack, RuleDefinitions.AdvantageType advantageType, List<EffectForm> actualEffectForms,
                 RulesetEffect rulesetEffect, bool criticalHit, bool firstTarget)

--- a/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
+++ b/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
@@ -405,4 +405,19 @@
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <EditorConfigFiles Remove="C:\Users\passp\source\repos\SolastaCommunityExpansion\SolastaCommunityExpansion\.editorconfig" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Include="C:\Users\passp\source\repos\SolastaCommunityExpansion\SolastaCommunityExpansion\.editorconfig" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 </Project>

--- a/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
+++ b/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="CheckEnvironmentVars">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="CheckEnvironmentVars">
 
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
@@ -15,6 +15,9 @@
 		<Copyright>Copyright 2021</Copyright>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<Version>1.2.5.0</Version>
+		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>True</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
 	</PropertyGroup>
 
 	<Target Name="CheckEnvironmentVars">
@@ -412,12 +415,5 @@
 
 	<ItemGroup>
 	  <None Include="C:\Users\passp\source\repos\SolastaCommunityExpansion\SolastaCommunityExpansion\.editorconfig" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	</ItemGroup>
 </Project>

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -29,17 +29,23 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon?  This doesn't seem possible
-            EffectForm damageEffect = new EffectForm();
-            damageEffect.DamageForm = new DamageForm();
-            damageEffect.DamageForm.DiceNumber = 1;
-            damageEffect.DamageForm.DieType = RuleDefinitions.DieType.D6;
-            damageEffect.DamageForm.BonusDamage = 2;
-            damageEffect.DamageForm.DamageType = "DamageBludgeoning";
-            damageEffect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None;
+            EffectForm damageEffect = new EffectForm
+            {
+                DamageForm = new DamageForm
+                {
+                    DiceNumber = 1,
+                    DieType = RuleDefinitions.DieType.D6,
+                    BonusDamage = 2,
+                    DamageType = "DamageBludgeoning"
+                },
+                SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None
+            };
 
             //Create the prone effect - Weirdly enough the motion form seems to also automatically apply the prone condition
-            EffectForm proneMotionEffect = new EffectForm();
-            proneMotionEffect.FormType = EffectForm.EffectFormType.Motion;
+            EffectForm proneMotionEffect = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.Motion
+            };
             var proneMotion = new MotionForm();
             proneMotion.SetType(MotionForm.MotionType.FallProne);
             proneMotion.SetDistance(1);
@@ -79,12 +85,16 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the temp hp form
-            EffectForm healingEffect = new EffectForm();
-            healingEffect.FormType = EffectForm.EffectFormType.TemporaryHitPoints;
-            var tempHPForm = new TemporaryHitPointsForm();
-            tempHPForm.DiceNumber = 1;
-            tempHPForm.DieType = RuleDefinitions.DieType.D6;
-            tempHPForm.BonusHitPoints = 2;
+            EffectForm healingEffect = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.TemporaryHitPoints
+            };
+            var tempHPForm = new TemporaryHitPointsForm
+            {
+                DiceNumber = 1,
+                DieType = RuleDefinitions.DieType.D6,
+                BonusHitPoints = 2
+            };
             healingEffect.SetTemporaryHitPointsForm(tempHPForm);
 
             //Create the bless effect - A fun test, unfortunately the two effects can't have varying durations AFAIK so a bless or similar effect might be overpowered (was thinking a bless for 1 round).  Alternatively both could last 1 minute instead and be intended for in battle.
@@ -131,13 +141,17 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon (seems impossible with current tools, would need to use the AdditionalDamage feature but I'm not sure how to combine that with this to make it a reaction ability).
-            EffectForm damageEffect = new EffectForm();
-            damageEffect.DamageForm = new DamageForm();
-            damageEffect.DamageForm.DiceNumber = 1;
-            damageEffect.DamageForm.DieType = RuleDefinitions.DieType.D6;
-            damageEffect.DamageForm.BonusDamage = 2;
-            damageEffect.DamageForm.DamageType = "DamageBludgeoning";
-            damageEffect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None;
+            EffectForm damageEffect = new EffectForm
+            {
+                DamageForm = new DamageForm
+                {
+                    DiceNumber = 1,
+                    DieType = RuleDefinitions.DieType.D6,
+                    BonusDamage = 2,
+                    DamageType = "DamageBludgeoning"
+                },
+                SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None
+            };
 
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -231,25 +231,35 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
 
         private static Dictionary<int, FeatureDefinitionPower> CreateArcanePulseDict()
         {
-            var marked_effect = new EffectForm();
-            marked_effect.ConditionForm = new ConditionForm();
-            marked_effect.FormType = EffectForm.EffectFormType.Condition;
+            var marked_effect = new EffectForm
+            {
+                ConditionForm = new ConditionForm(),
+                FormType = EffectForm.EffectFormType.Condition
+            };
             marked_effect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             marked_effect.ConditionForm.ConditionDefinition = ConditionMarkedByArcanistBuilder.GetOrAdd();
 
-            var damage_effect = new EffectForm();
-            damage_effect.DamageForm = new DamageForm();
-            damage_effect.DamageForm.DamageType = "DamageForce";
-            damage_effect.DamageForm.DieType = RuleDefinitions.DieType.D8;
-            damage_effect.DamageForm.DiceNumber = 4;
+            var damage_effect = new EffectForm
+            {
+                DamageForm = new DamageForm
+                {
+                    DamageType = "DamageForce",
+                    DieType = RuleDefinitions.DieType.D8,
+                    DiceNumber = 4
+                }
+            };
             damage_effect.DamageForm.SetHealFromInflictedDamage(RuleDefinitions.HealFromInflictedDamage.Never);
             damage_effect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None;
 
-            var damage_upgrade_effect = new EffectForm();
-            damage_upgrade_effect.DamageForm = new DamageForm();
-            damage_upgrade_effect.DamageForm.DamageType = "DamageForce";
-            damage_upgrade_effect.DamageForm.DieType = RuleDefinitions.DieType.D8;
-            damage_upgrade_effect.DamageForm.DiceNumber = 8;
+            var damage_upgrade_effect = new EffectForm
+            {
+                DamageForm = new DamageForm
+                {
+                    DamageType = "DamageForce",
+                    DieType = RuleDefinitions.DieType.D8,
+                    DiceNumber = 8
+                }
+            };
             damage_upgrade_effect.DamageForm.SetHealFromInflictedDamage(RuleDefinitions.HealFromInflictedDamage.Never);
             damage_upgrade_effect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.None;
 

--- a/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
@@ -114,7 +114,7 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
             return builder.AddToDB();
         }
 
-        // Should concentrationAffinity be used?  If not remove.
+        // TODO: Should concentrationAffinity be used?  If not remove.
         public static FeatureDefinitionMagicAffinity BuildMagicAffinityConcentration(RuleDefinitions.ConcentrationAffinity concentrationAffinity, int threshold, string name, GuiPresentation guiPresentation)
         {
             FeatureDefinitionMagicAffinityBuilder builder = new FeatureDefinitionMagicAffinityBuilder(name, GuidHelper.Create(SubclassNamespace, name).ToString(),

--- a/SolastaCommunityExpansion/Viewers/Displays/FeatsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/FeatsDisplay.cs
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("General:".yellow());
 
             intValue = Main.Settings.FeatPowerAttackModifier;
-            if (UI.Slider("Power Attack modifier ".white() + reqRestart, ref intValue, 1, 6, 3, ""))
+            if (UI.Slider("Power Attack modifier ".white() + RequiresRestart, ref intValue, 1, 6, 3, ""))
             {
                 Main.Settings.FeatPowerAttackModifier = intValue;
             }

--- a/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
@@ -1,4 +1,4 @@
-using ModKit;
+﻿using ModKit;
 using UnityModManagerNet;
 using static SolastaCommunityExpansion.Viewers.Displays.CreditsDisplay;
 using static SolastaCommunityExpansion.Viewers.Displays.Level20HelpDisplay;
@@ -21,7 +21,9 @@ namespace SolastaCommunityExpansion.Viewers
             //AddDumpDescriptionToLogButton();
         }
 
-        private void AddDumpDescriptionToLogButton()
+#pragma warning disable IDE0051 // Remove unused private members
+        private static void AddDumpDescriptionToLogButton()
+#pragma warning restore IDE0051 // Remove unused private members
         {
             UI.ActionButton("Dump Description to Logs", () =>
             {


### PR DESCRIPTION
I've added a default '.editorconfig' file and the standard Microsoft .net analyzer package.
I've then gone through and fixed all remaining warnings and messages (except one on unused 'concentrationAffinity' which may indicate a bug).
Double click on the editorconfig file in the solution explorer to see the available options. We can enable more as required.