### PR TITLE
Added Path of the Light barbarian subclass

### DIFF
--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/AttackDisadvantageAgainstNonSource.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/AttackDisadvantageAgainstNonSource.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+
+namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Imposes disadvantage when attacking anyone but the source of the specified condition.
+    /// </summary>
+    public class AttackDisadvantageAgainstNonSource : FeatureDefinition, ICombatAffinityProvider
+    {
+        public string ConditionName { get; set; }
+
+        public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
+        public bool CanRageToOvercomeSurprise => false;
+        public bool AutoCritical => false;
+        public bool CriticalHitImmunity => false;
+        public ConditionDefinition RequiredTargetCondition => null;
+        public bool IgnoreCover => false;
+
+        public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            foreach (KeyValuePair<string, List<RulesetCondition>> keyValuePair in myself.ConditionsByCategory)
+            {
+                foreach (RulesetCondition rulesetCondition in keyValuePair.Value)
+                {
+                    if (rulesetCondition.ConditionDefinition.IsSubtypeOf(ConditionName) && rulesetCondition.SourceGuid != defender.Guid)
+                    {
+                        attackModifier.AttackAdvantageTrends.Add(new RuleDefinitions.TrendInfo(-1, featureOrigin.sourceType, featureOrigin.sourceName, featureOrigin.source));
+                        return;
+                    }
+                }
+            }
+        }
+
+        public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            return;
+        }
+
+        public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
+        {
+            return RuleDefinitions.AdvantageType.None;
+        }
+
+        public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
+        {
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/ClassHoldingFeature.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/ClassHoldingFeature.cs
@@ -1,0 +1,10 @@
+﻿namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Implement on an IAdditionalDamageProvider feature to allow its damage to scale with class level (using DiceByRankTable), even if it isn't directly added to the class (via AddFeatureAtLevel).
+    /// </summary>
+    public interface IClassHoldingFeature
+    {
+        CharacterClassDefinition Class { get; }
+    }
+}

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/ConditionRemovedOnSourceTurnStart.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/ConditionRemovedOnSourceTurnStart.cs
@@ -1,0 +1,9 @@
+﻿namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Implement on a ConditionDefinition to make it be removed when its source's turn starts.
+    /// </summary>
+    public interface IConditionRemovedOnSourceTurnStart
+    {
+    }
+}

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/NotifyConditionRemoval.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/NotifyConditionRemoval.cs
@@ -1,0 +1,11 @@
+﻿namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Implement on a ConditionDefinition to be notified when a condition is removed, or when a creature is about to die with a condition.
+    /// </summary>
+    public interface INotifyConditionRemoval
+    {
+        void AfterConditionRemoved(RulesetActor removedFrom, RulesetCondition rulesetCondition);
+        void BeforeDyingWithCondition(RulesetActor rulesetActor, RulesetCondition rulesetCondition);
+    }
+}

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/OpportunityAttackImmunityIfAttackerHasCondition.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/OpportunityAttackImmunityIfAttackerHasCondition.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+
+namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Grants you immunity to opportunity attacks when the attacker has the specified condition (inflicted by you).
+    /// </summary>
+    public class OpportunityAttackImmunityIfAttackerHasCondition : FeatureDefinition, ICombatAffinityProvider
+    {
+        public string ConditionName { get; set; }
+
+        public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
+        public bool CanRageToOvercomeSurprise => false;
+        public bool AutoCritical => false;
+        public bool CriticalHitImmunity => false;
+        public ConditionDefinition RequiredTargetCondition => null;
+        public bool IgnoreCover => false;
+
+        public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            return;
+        }
+
+        public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            return;
+        }
+
+        public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
+        {
+            return RuleDefinitions.AdvantageType.None;
+        }
+
+        public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
+        {
+            foreach (KeyValuePair<string, List<RulesetCondition>> keyValuePair in attacker.ConditionsByCategory)
+            {
+                foreach (RulesetCondition rulesetCondition in keyValuePair.Value)
+                {
+                    if (rulesetCondition.SourceGuid == myself.Guid && rulesetCondition.ConditionDefinition.IsSubtypeOf(ConditionName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/StartOfTurnRecharge.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/StartOfTurnRecharge.cs
@@ -1,0 +1,10 @@
+﻿namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    /// <summary>
+    /// Implement on a FeatureDefinitionPower to allow it to recharge at the start of your turn.
+    /// </summary>
+    public interface IStartOfTurnRecharge
+    {
+        bool IsRechargeSilent { get; }
+    }
+}

--- a/SolastaCommunityExpansion/Features/ConditionDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ConditionDefinitionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using SolastaModApi;
+﻿using System;
+using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
@@ -6,8 +7,43 @@ using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Features
 {
-    public class ConditionDefinitionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    public class ConditionDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : ConditionDefinition
     {
+        public ConditionDefinitionBuilder(string name, string guid, Action<TDefinition> modifyDefinition = null) : base(name, guid)
+        {
+            Definition
+                .SetConditionType(RuleDefinitions.ConditionType.Beneficial)
+                .SetAllowMultipleInstances(false)
+                .SetDurationType(RuleDefinitions.DurationType.Minute)
+                .SetDurationParameter(1)
+                .SetConditionStartParticleReference(new AssetReference())
+                .SetConditionParticleReference(new AssetReference())
+                .SetConditionEndParticleReference(new AssetReference())
+                .SetCharacterShaderReference(new AssetReference());
+
+            Definition.SetField("recurrentEffectForms", new List<EffectForm>());
+            Definition.SetField("cancellingConditions", new List<ConditionDefinition>());
+
+            if (modifyDefinition != null)
+            {
+                modifyDefinition(Definition);
+            }
+        }
+
+        public static TDefinition Build(string name, string guid, Action<TDefinition> modifyDefinition = null)
+        {
+            var conditionDefinitionBuilder = new ConditionDefinitionBuilder<TDefinition>(name, guid, modifyDefinition);
+
+            return conditionDefinitionBuilder.AddToDB();
+        }
+    }
+
+    public class ConditionDefinitionBuilder : ConditionDefinitionBuilder<ConditionDefinition>
+    {
+        public ConditionDefinitionBuilder(string name, string guid, Action<ConditionDefinition> modifyDefinition = null) : base(name, guid, modifyDefinition)
+        {
+        }
+
         public ConditionDefinitionBuilder(string name, string guid, List<FeatureDefinition> conditionFeatures, RuleDefinitions.DurationType durationType,
         int durationParameter, bool silent, GuiPresentation guiPresentation) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionBuilder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using SolastaModApi;
+using SolastaModApi.Extensions;
+
+namespace SolastaCommunityExpansion.Features
+{
+    public class FeatureDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : FeatureDefinition
+    {
+        public FeatureDefinitionBuilder(string name, string guid, Action<TDefinition> modifyDefinition = null) : base(name, guid)
+        {
+            if (modifyDefinition != null)
+            {
+                modifyDefinition(Definition);
+            }
+        }
+
+        public FeatureDefinitionBuilder(string name, string guid, string description, string title, Action<TDefinition> modifyDefinition = null) : base(name, guid)
+        {
+            var guiPresentationBuilder = new GuiPresentationBuilder(description, title);
+
+            Definition.SetGuiPresentation(guiPresentationBuilder.Build());
+
+            if (modifyDefinition != null)
+            {
+                modifyDefinition(Definition);
+            }
+        }
+
+        public static TDefinition Build(string name, string guid, Action<TDefinition> modifyDefinition = null)
+        {
+            var featureDefinitionBuilder = new FeatureDefinitionBuilder<TDefinition>(name, guid, modifyDefinition);
+
+            return featureDefinitionBuilder.AddToDB();
+        }
+
+        public static TDefinition Build(string name, string guid, string description, string title, Action<TDefinition> modifyDefinition = null)
+        {
+            var featureDefinitionBuilder = new FeatureDefinitionBuilder<TDefinition>(name, guid, description, title, modifyDefinition);
+
+            return featureDefinitionBuilder.AddToDB();
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -1,4 +1,5 @@
 ﻿using SolastaCommunityExpansion.Subclasses;
+using SolastaCommunityExpansion.Subclasses.Barbarian;
 using SolastaCommunityExpansion.Subclasses.Fighter;
 using SolastaCommunityExpansion.Subclasses.Ranger;
 using SolastaCommunityExpansion.Subclasses.Rogue;
@@ -23,6 +24,7 @@ namespace SolastaCommunityExpansion.Models
             LoadSubclass(new Arcanist());
             LoadSubclass(new Tactician());
             LoadSubclass(new RoyalKnight());
+            LoadSubclass(new PathOfTheLight());
         }
 
         private static void LoadSubclass(AbstractSubclass subclassBuilder)

--- a/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.ClassHoldingFeature
+{
+    internal static class RulesetCharacterHeroPatcher
+    {
+        [HarmonyPatch(typeof(RulesetCharacterHero), "FindClassHoldingFeature")]
+        internal static class RulesetCharacterHero_FindClassHoldingFeature
+        {
+            internal static void Postfix(
+                RulesetCharacterHero __instance,
+                FeatureDefinition featureDefinition,
+                ref CharacterClassDefinition __result)
+            {
+                var overrideClassHoldingFeature = featureDefinition as IClassHoldingFeature;
+
+                if (overrideClassHoldingFeature?.Class == null)
+                {
+                    return;
+                }
+
+                // Only override if the character actually has levels in the class, to prevent errors
+                if (__instance.ClassesAndLevels.TryGetValue(overrideClassHoldingFeature.Class, out int levelsInClass) && levelsInClass > 0)
+                {
+                    __result = overrideClassHoldingFeature.Class;
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.ConditionRemovedOnSourceTurnStart
+{
+    internal static class RulesetActorPatcher
+    {
+        // Yes, the actual method name has a typo
+        [HarmonyPatch(typeof(RulesetActor), "ProcessConditionsMatchingOccurenceType")]
+        internal static class RulesetActor_ProcessConditionsMatchingOccurenceType
+        {
+            internal static void Postfix(RulesetActor __instance, RuleDefinitions.TurnOccurenceType occurenceType)
+            {
+                if (occurenceType == RuleDefinitions.TurnOccurenceType.StartOfTurn)
+                {
+                    var battleService = ServiceRepository.GetService<IGameLocationBattleService>();
+
+                    if (battleService?.Battle != null)
+                    {
+                        foreach (GameLocationCharacter contender in battleService.Battle.AllContenders)
+                        {
+                            if (contender == null || !contender.Valid || contender.RulesetActor == null)
+                            {
+                                continue;
+                            }
+
+                            var conditionsToRemove = new List<RulesetCondition>();
+
+                            foreach (KeyValuePair<string, List<RulesetCondition>> keyValuePair in contender.RulesetActor.ConditionsByCategory)
+                            {
+                                foreach (RulesetCondition rulesetCondition in keyValuePair.Value)
+                                {
+                                    if (rulesetCondition.SourceGuid == __instance.Guid && rulesetCondition.ConditionDefinition is IConditionRemovedOnSourceTurnStart)
+                                    {
+                                        conditionsToRemove.Add(rulesetCondition);
+                                    }
+                                }
+                            }
+
+                            foreach (RulesetCondition conditionToRemove in conditionsToRemove)
+                            {
+                                contender.RulesetActor.RemoveCondition(conditionToRemove);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
+{
+    internal static class RulesetActorPatcher
+    {
+        [HarmonyPatch(typeof(RulesetActor), "RemoveCondition")]
+        internal static class RulesetActor_RemoveCondition
+        {
+            internal static void Postfix(RulesetActor __instance, RulesetCondition rulesetCondition)
+            {
+                var notifiedDefinition = rulesetCondition?.ConditionDefinition as INotifyConditionRemoval;
+
+                if (notifiedDefinition != null)
+                {
+                    notifiedDefinition.AfterConditionRemoved(__instance, rulesetCondition);
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
+{
+    internal static class RulesetCharacterPatcher
+    {
+        [HarmonyPatch(typeof(RulesetCharacter), "Kill")]
+        internal static class RulesetCharacter_Kill
+        {
+            internal static void Prefix(RulesetCharacter __instance)
+            {
+                foreach (KeyValuePair<string, List<RulesetCondition>> keyValuePair in __instance.ConditionsByCategory)
+                {
+                    foreach (RulesetCondition rulesetCondition in keyValuePair.Value)
+                    {
+                        var notifiedDefinition = rulesetCondition?.ConditionDefinition as INotifyConditionRemoval;
+
+                        if (notifiedDefinition != null)
+                        {
+                            notifiedDefinition.BeforeDyingWithCondition(__instance, rulesetCondition);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.StartOfTurnRecharge
+{
+    internal static class RulesetCharacterPatcher
+    {
+        [HarmonyPatch(typeof(RulesetCharacter), "RechargePowersForTurnStart")]
+        internal static class RulesetCharacter_RechargePowersForTurnStart
+        {
+            internal static void Postfix(RulesetCharacter __instance)
+            {
+                foreach (RulesetUsablePower usablePower in __instance.UsablePowers)
+                {
+                    var startOfTurnRecharge = usablePower?.PowerDefinition as IStartOfTurnRecharge;
+
+                    if (startOfTurnRecharge != null)
+                    {
+                        if (usablePower.RemainingUses < usablePower.MaxUses)
+                        {
+                            usablePower.Recharge();
+
+                            if (!startOfTurnRecharge.IsRechargeSilent && __instance.PowerRecharged != null)
+                            {
+                                __instance.PowerRecharged(__instance, usablePower);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -1,0 +1,966 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
+using SolastaCommunityExpansion.Features;
+using SolastaModApi;
+using SolastaModApi.Extensions;
+using SolastaModApi.Infrastructure;
+
+namespace SolastaCommunityExpansion.Subclasses.Barbarian
+{
+    internal class PathOfTheLight : AbstractSubclass
+    {
+        private static readonly Guid SubclassNamespace = new Guid("c2067110-5086-45c0-b0c2-4c140599605c");
+        private const string IlluminatedConditionName = "PathOfTheLightIlluminatedCondition";
+        private const string IlluminatingStrikeName = "PathOfTheLightIlluminatingStrike";
+        private const string IlluminatingBurstName = "PathOfTheLightIlluminatingBurst";
+
+        private static readonly List<ConditionDefinition> InvisibleConditions =
+            new List<ConditionDefinition>
+            {
+                DatabaseHelper.ConditionDefinitions.ConditionInvisibleBase,
+                DatabaseHelper.ConditionDefinitions.ConditionInvisible,
+                DatabaseHelper.ConditionDefinitions.ConditionInvisibleGreater
+            };
+
+        private readonly CharacterSubclassDefinition _subclass;
+
+        private static readonly Dictionary<int, int> LightsProtectionAmountHealedByClassLevel = new Dictionary<int, int>
+        {
+            {6, 3},
+            {7, 3},
+            {8, 4},
+            {9, 4},
+            {10, 5},
+            {11, 5},
+            {12, 6},
+            {13, 6},
+            {14, 7},
+            {15, 7},
+            {16, 8},
+            {17, 8},
+            {18, 9},
+            {19, 9},
+            {20, 10}
+        };
+
+        internal override FeatureDefinitionSubclassChoice GetSubclassChoiceList()
+        {
+            return DatabaseHelper.FeatureDefinitionSubclassChoices.SubclassChoiceBarbarianPrimalPath;
+        }
+
+        internal override CharacterSubclassDefinition GetSubclass()
+        {
+            return _subclass;
+        }
+
+        internal PathOfTheLight()
+        {
+            var subclassBuilder = new CharacterSubclassDefinitionBuilder("PathOfTheLight", CreateNamespacedGuid("PathOfTheLight"));
+
+            ConditionDefinition illuminatedCondition = CreateIlluminatedCondition();
+
+            subclassBuilder
+                .SetGuiPresentation(CreateSubclassGuiPresentation())
+                .AddFeatureAtLevel(CreateIlluminatingStrike(illuminatedCondition), 3)
+                .AddFeatureAtLevel(CreatePierceTheDarkness(), 3)
+                .AddFeatureAtLevel(CreateLightsProtection(), 6)
+                .AddFeatureAtLevel(CreateEyesOfTruth(), 10)
+                .AddFeatureAtLevel(CreateIlluminatingStrikeImprovement(), 10)
+                .AddFeatureAtLevel(CreateIlluminatingBurst(illuminatedCondition), 14);
+
+            _subclass = subclassBuilder.AddToDB();
+        }
+
+        private static string CreateNamespacedGuid(string featureName)
+        {
+            return GuidHelper.Create(SubclassNamespace, featureName).ToString();
+        }
+
+        private static GuiPresentation CreateSubclassGuiPresentation()
+        {
+            var subclassGuiPresentation = new GuiPresentationBuilder("Subclass/&BarbarianPathOfTheLightDescription", "Subclass/&BarbarianPathOfTheLightTitle");
+
+            subclassGuiPresentation.SetSpriteReference(DatabaseHelper.CharacterSubclassDefinitions.DomainSun.GuiPresentation.SpriteReference);
+
+            return subclassGuiPresentation.Build();
+        }
+
+        private static FeatureDefinition CreateIlluminatingStrike(ConditionDefinition illuminatedCondition)
+        {
+            var illuminatingStrikeFeatureSet = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightIlluminatingStrikeFeatureSet",
+                CreateNamespacedGuid("PathOfTheLightIlluminatingStrikeFeatureSet"),
+                "Subclass/&BarbarianPathOfTheLightIlluminatingStrikeDescription",
+                "Subclass/&BarbarianPathOfTheLightIlluminatingStrikeTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    var illuminatingStrikeInitiatorBuilder = new IlluminatingStrikeInitiatorBuilder(
+                        "PathOfTheLightIlluminatingStrikeInitiator",
+                        CreateNamespacedGuid("PathOfTheLightIlluminatingStrikeInitiator"),
+                        "Feature/&NoContentTitle",
+                        "Feature/&NoContentTitle",
+                        illuminatedCondition);
+
+                    featureSetDefinition.FeatureSet.Add(illuminatingStrikeInitiatorBuilder.AddToDB());
+                });
+
+            return illuminatingStrikeFeatureSet;
+        }
+
+        private static FeatureDefinition CreateIlluminatingStrikeImprovement()
+        {
+            // Dummy feature to show in UI
+
+            var illuminatingStrikeImprovement = FeatureDefinitionBuilder<FeatureDefinition>.Build(
+                "PathOfTheLightIlluminatingStrikeImprovement",
+                CreateNamespacedGuid("PathOfTheLightIlluminatingStrikeImprovement"),
+                "Subclass/&BarbarianPathOfTheLightIlluminatingStrikeImprovementDescription",
+                "Subclass/&BarbarianPathOfTheLightIlluminatingStrikeImprovementTitle");
+
+            return illuminatingStrikeImprovement;
+        }
+
+        private static FeatureDefinition CreatePierceTheDarkness()
+        {
+            var pierceTheDarkness = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightPierceTheDarkness",
+                CreateNamespacedGuid("PathOfTheLightPierceTheDarkness"),
+                "Subclass/&BarbarianPathOfTheLightPierceTheDarknessDescription",
+                "Subclass/&BarbarianPathOfTheLightPierceTheDarknessTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    featureSetDefinition.FeatureSet.Add(DatabaseHelper.FeatureDefinitionSenses.SenseSuperiorDarkvision);
+                });
+
+            return pierceTheDarkness;
+        }
+
+        private static FeatureDefinition CreateLightsProtection()
+        {
+            var lightsProtection = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightLightsProtection",
+                CreateNamespacedGuid("PathOfTheLightLightsProtection"),
+                "Subclass/&BarbarianPathOfTheLightLightsProtectionDescription",
+                "Subclass/&BarbarianPathOfTheLightLightsProtectionTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    var conditionalOpportunityAttackImmunity = FeatureDefinitionBuilder<OpportunityAttackImmunityIfAttackerHasCondition>.Build(
+                        "PathOfTheLightLightsProtectionOpportunityAttackImmunity",
+                        CreateNamespacedGuid("PathOfTheLightLightsProtectionOpportunityAttackImmunity"),
+                        "Feature/&NoContentTitle",
+                        "Feature/&NoContentTitle",
+                        definition =>
+                        {
+                            definition.ConditionName = IlluminatedConditionName;
+                        });
+
+                    featureSetDefinition.FeatureSet.Add(conditionalOpportunityAttackImmunity);
+                });
+
+            return lightsProtection;
+        }
+
+        private static void ApplyLightsProtectionHealing(ulong sourceGuid)
+        {
+            var conditionSource = RulesetEntity.GetEntity<RulesetCharacter>(sourceGuid) as RulesetCharacterHero;
+
+            if (conditionSource == null || conditionSource.IsDead)
+            {
+                return;
+            }
+
+            if (!conditionSource.ClassesAndLevels.TryGetValue(DatabaseHelper.CharacterClassDefinitions.Barbarian, out int levelsInClass))
+            {
+                // Character doesn't have levels in class
+                return;
+            }
+
+            if (!LightsProtectionAmountHealedByClassLevel.TryGetValue(levelsInClass, out int amountHealed))
+            {
+                // Character doesn't heal at the current level
+                return;
+            }
+
+            if (amountHealed > 0)
+            {
+                conditionSource.ReceiveHealing(amountHealed, notify: true, sourceGuid);
+            }
+        }
+
+        private static FeatureDefinition CreateEyesOfTruth()
+        {
+            var seeingInvisibleCondition = ConditionDefinitionBuilder.Build(
+                "PathOfTheLightEyesOfTruthSeeingInvisible",
+                CreateNamespacedGuid("PathOfTheLightEyesOfTruthSeeingInvisible"),
+                definition =>
+                {
+                    var gpb = new GuiPresentationBuilder(
+                        "Subclass/&BarbarianPathOfTheLightSeeingInvisibleConditionDescription",
+                        "Subclass/&BarbarianPathOfTheLightSeeingInvisibleConditionTitle");
+
+                    gpb.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionSeeInvisibility.GuiPresentation.SpriteReference);
+
+                    definition
+                        .SetGuiPresentation(gpb.Build())
+                        .SetDurationType(RuleDefinitions.DurationType.Permanent)
+                        .SetConditionType(RuleDefinitions.ConditionType.Beneficial)
+                        .SetSilentWhenAdded(true)
+                        .SetSilentWhenRemoved(true);
+
+                    definition.Features.Add(DatabaseHelper.FeatureDefinitionSenses.SenseSeeInvisible16);
+                });
+
+            var seeInvisibleEffectBuilder = new EffectDescriptionBuilder();
+
+            var seeInvisibleConditionForm = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.Condition,
+                ConditionForm = new ConditionForm
+                {
+                    Operation = ConditionForm.ConditionOperation.Add,
+                    ConditionDefinition = seeingInvisibleCondition
+                }
+            };
+
+            seeInvisibleEffectBuilder
+                .SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.StartOfTurn)
+                .SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Self, 1, 0, ActionDefinitions.ItemSelectionType.None)
+                .AddEffectForm(seeInvisibleConditionForm);
+
+            var seeInvisiblePower = FeatureDefinitionBuilder<FeatureDefinitionPower>.Build(
+                "PathOfTheLightEyesOfTruthPower",
+                CreateNamespacedGuid("PathOfTheLightEyesOfTruthPower"),
+                definition =>
+                {
+                    var gpb = new GuiPresentationBuilder(
+                        "Subclass/&BarbarianPathOfTheLightEyesOfTruthDescription",
+                        "Subclass/&BarbarianPathOfTheLightEyesOfTruthTitle");
+
+                    gpb.SetSpriteReference(DatabaseHelper.SpellDefinitions.SeeInvisibility.GuiPresentation.SpriteReference);
+
+                    definition
+                        .SetGuiPresentation(gpb.Build())
+                        .SetActivationTime(RuleDefinitions.ActivationTime.Permanent)
+                        .SetEffectDescription(seeInvisibleEffectBuilder.Build())
+                        .SetRechargeRate(RuleDefinitions.RechargeRate.AtWill)
+                        .SetShowCasting(false);
+                });
+
+            var eyesOfTruth = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightEyesOfTruth",
+                CreateNamespacedGuid("PathOfTheLightEyesOfTruth"),
+                "Subclass/&BarbarianPathOfTheLightEyesOfTruthDescription",
+                "Subclass/&BarbarianPathOfTheLightEyesOfTruthTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    featureSetDefinition.FeatureSet.Add(seeInvisiblePower);
+                });
+
+            return eyesOfTruth;
+        }
+
+        private static FeatureDefinition CreateIlluminatingBurst(ConditionDefinition illuminatedCondition)
+        {
+            var illuminatingBurstFeatureSet = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightIlluminatingBurstFeatureSet",
+                CreateNamespacedGuid("PathOfTheLightIlluminatingBurstFeatureSet"),
+                "Subclass/&BarbarianPathOfTheLightIlluminatingBurstDescription",
+                "Subclass/&BarbarianPathOfTheLightIlluminatingBurstTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    ConditionDefinition illuminatingBurstSuppressedCondition = CreateIlluminatingBurstSuppressedCondition();
+
+                    var illuminatingBurstBuilder = new IlluminatingBurstInitiatorBuilder(
+                        "PathOfTheLightIlluminatingBurstInitiator",
+                        CreateNamespacedGuid("PathOfTheLightIlluminatingBurstInitiator"),
+                        "Feature/&NoContentTitle",
+                        "Feature/&NoContentTitle",
+                        illuminatingBurstSuppressedCondition);
+
+                    featureSetDefinition.FeatureSet.Add(illuminatingBurstBuilder.AddToDB());
+
+                    var illuminatingBurstPowerBuilder = new IlluminatingBurstBuilder(
+                        IlluminatingBurstName,
+                        CreateNamespacedGuid(IlluminatingBurstName),
+                        "Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerDescription",
+                        "Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerTitle",
+                        illuminatedCondition,
+                        illuminatingBurstSuppressedCondition);
+
+                    featureSetDefinition.FeatureSet.Add(illuminatingBurstPowerBuilder.AddToDB());
+
+                    featureSetDefinition.FeatureSet.Add(CreateIlluminatingBurstSuppressor(illuminatingBurstSuppressedCondition));
+                });
+
+            return illuminatingBurstFeatureSet;
+        }
+
+        private static FeatureDefinition CreateIlluminatingBurstSuppressor(ConditionDefinition illuminatingBurstSuppressedCondition)
+        {
+            var illuminatingBurstSuppressor = FeatureDefinitionBuilder<FeatureDefinitionPower>.Build(
+                "PathOfTheLightIlluminatingBurstSuppressor",
+                CreateNamespacedGuid("PathOfTheLightIlluminatingBurstSuppressor"),
+                definition =>
+                {
+                    var guiPresentationBuilder = new GuiPresentationBuilder(
+                        "Feature/&NoContentTitle",
+                        "Feature/&NoContentTitle");
+
+                    var guiPresentation = guiPresentationBuilder.Build();
+                    guiPresentation.SetHidden(true);
+
+                    var suppressIlluminatingBurst = new EffectForm
+                    {
+                        FormType = EffectForm.EffectFormType.Condition,
+                        ConditionForm = new ConditionForm
+                        {
+                            Operation = ConditionForm.ConditionOperation.Add,
+                            ConditionDefinition = illuminatingBurstSuppressedCondition
+                        }
+                    };
+
+                    var effectDescriptionBuilder = new EffectDescriptionBuilder();
+
+                    effectDescriptionBuilder
+                        .SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.StartOfTurn)
+                        .SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Self, 1, 0, ActionDefinitions.ItemSelectionType.None)
+                        .SetRecurrentEffect(RuleDefinitions.RecurrentEffect.OnActivation | RuleDefinitions.RecurrentEffect.OnTurnStart)
+                        .AddEffectForm(suppressIlluminatingBurst);
+
+                    definition
+                        .SetGuiPresentation(guiPresentation)
+                        .SetActivationTime(RuleDefinitions.ActivationTime.Permanent)
+                        .SetEffectDescription(effectDescriptionBuilder.Build())
+                        .SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
+                });
+
+            return illuminatingBurstSuppressor;
+        }
+
+        private static ConditionDefinition CreateIlluminatedCondition()
+        {
+            var illuminatedCondition = ConditionDefinitionBuilder<IlluminatedConditionDefinition>.Build(
+                IlluminatedConditionName,
+                CreateNamespacedGuid(IlluminatedConditionName),
+                definition =>
+                {
+                    var gpb = new GuiPresentationBuilder(
+                        "Subclass/&BarbarianPathOfTheLightIlluminatedConditionDescription",
+                        "Subclass/&BarbarianPathOfTheLightIlluminatedConditionTitle");
+
+                    gpb.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBranded.GuiPresentation.SpriteReference);
+
+                    definition
+                        .SetGuiPresentation(gpb.Build())
+                        .SetSpecialDuration(true)
+                        .SetDurationType(RuleDefinitions.DurationType.Irrelevant)
+                        .SetConditionType(RuleDefinitions.ConditionType.Detrimental)
+                        .SetAllowMultipleInstances(true)
+                        .SetSilentWhenAdded(true)
+                        .SetSilentWhenRemoved(false);
+
+                    definition.Features.Add(CreateDisadvantageAgainstNonCaster());
+                    definition.Features.Add(CreatePreventInvisibility());
+                });
+
+            return illuminatedCondition;
+        }
+
+        private static AttackDisadvantageAgainstNonCaster CreateDisadvantageAgainstNonCaster()
+        {
+            var disadvantageAgainstNonCaster = FeatureDefinitionBuilder<AttackDisadvantageAgainstNonCaster>.Build(
+                "PathOfTheLightIlluminatedDisadvantage",
+                CreateNamespacedGuid("PathOfTheLightIlluminatedDisadvantage"),
+                "Subclass/&BarbarianPathOfTheLightIlluminatedDisadvantageDescription",
+                "Feature/&NoContentTitle",
+                definition =>
+                {
+                    definition.ConditionName = IlluminatedConditionName;
+                });
+
+            return disadvantageAgainstNonCaster;
+        }
+
+        private static FeatureDefinition CreatePreventInvisibility()
+        {
+            // Prevents a creature from turning invisible by "granting" immunity to invisibility
+
+            var preventInvisibility = FeatureDefinitionBuilder<FeatureDefinitionFeatureSet>.Build(
+                "PathOfTheLightIlluminatedPreventInvisibility",
+                CreateNamespacedGuid("PathOfTheLightIlluminatedPreventInvisibility"),
+                "Subclass/&BarbarianPathOfTheLightIlluminatedPreventInvisibilityDescription",
+                "Feature/&NoContentTitle",
+                featureSetDefinition =>
+                {
+                    featureSetDefinition
+                        .SetEnumerateInDescription(false)
+                        .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
+                        .SetUniqueChoices(false);
+
+                    featureSetDefinition.SetField("featureSet", new List<FeatureDefinition>());
+
+                    foreach (ConditionDefinition invisibleCondition in InvisibleConditions)
+                    {
+                        FeatureDefinition preventInvisibilitySubFeature = FeatureDefinitionBuilder<FeatureDefinitionConditionAffinity>.Build(
+                            "PathOfTheLightIlluminatedPreventInvisibility" + invisibleCondition.Name,
+                            CreateNamespacedGuid("PathOfTheLightIlluminatedPreventInvisibility" + invisibleCondition.Name),
+                            "Feature/&NoContentTitle",
+                            "Feature/&NoContentTitle",
+                            conditionAffinityDefinition =>
+                            {
+                                conditionAffinityDefinition
+                                    .SetConditionAffinityType(RuleDefinitions.ConditionAffinityType.Immunity)
+                                    .SetConditionType(invisibleCondition.Name);
+                            });
+
+                        featureSetDefinition.FeatureSet.Add(preventInvisibilitySubFeature);
+                    }
+                });
+
+            return preventInvisibility;
+        }
+
+        private static ConditionDefinition CreateIlluminatingBurstSuppressedCondition()
+        {
+            ConditionDefinition illuminatingBurstSuppressedCondition = ConditionDefinitionBuilder.Build(
+                "PathOfTheLightIlluminatingBurstSuppressedCondition",
+                CreateNamespacedGuid("PathOfTheLightIlluminatingBurstSuppressedCondition"),
+                definition =>
+                {
+                    var gpb = new GuiPresentationBuilder(
+                        "Feature/&NoContentTitle",
+                        "Feature/&NoContentTitle");
+
+                    var guiPresentation = gpb.Build();
+
+                    guiPresentation.SetHidden(true);
+
+                    definition
+                        .SetGuiPresentation(guiPresentation)
+                        .SetDurationType(RuleDefinitions.DurationType.Permanent)
+                        .SetConditionType(RuleDefinitions.ConditionType.Neutral)
+                        .SetSilentWhenAdded(true)
+                        .SetSilentWhenRemoved(true);
+                });
+
+            return illuminatingBurstSuppressedCondition;
+        }
+
+        private static void HandleAfterIlluminatedConditionRemoved(RulesetActor removedFrom)
+        {
+            var character = removedFrom as RulesetCharacter;
+
+            if (character == null)
+            {
+                return;
+            }
+
+            // Intentionally *includes* conditions that have Illuminated as their parent (like the Illuminating Burst condition)
+            if (!character.HasConditionOfTypeOrSubType(IlluminatedConditionName))
+            {
+                if (character.PersonalLightSource?.SourceName == IlluminatingStrikeName ||
+                    character.PersonalLightSource?.SourceName == IlluminatingBurstName)
+                {
+                    var visibilityService = ServiceRepository.GetService<IGameLocationVisibilityService>();
+
+                    visibilityService.RemoveCharacterLightSource(GameLocationCharacter.GetFromActor(removedFrom), character.PersonalLightSource);
+                    character.PersonalLightSource = null;
+                }
+            }
+        }
+
+
+        // Helper classes
+
+        private class IlluminatedConditionDefinition : ConditionDefinition, IConditionRemovedOnSourceTurnStart, INotifyConditionRemoval
+        {
+            public void AfterConditionRemoved(RulesetActor removedFrom, RulesetCondition rulesetCondition)
+            {
+                HandleAfterIlluminatedConditionRemoved(removedFrom);
+            }
+
+            public void BeforeDyingWithCondition(RulesetActor rulesetActor, RulesetCondition rulesetCondition)
+            {
+                ApplyLightsProtectionHealing(rulesetCondition.SourceGuid);
+            }
+        }
+
+        private class IlluminatedByBurstConditionDefinition : ConditionDefinition, INotifyConditionRemoval
+        {
+            public void AfterConditionRemoved(RulesetActor removedFrom, RulesetCondition rulesetCondition)
+            {
+                HandleAfterIlluminatedConditionRemoved(removedFrom);
+            }
+
+            public void BeforeDyingWithCondition(RulesetActor rulesetActor, RulesetCondition rulesetCondition)
+            {
+                ApplyLightsProtectionHealing(rulesetCondition.SourceGuid);
+            }
+        }
+
+        private class AttackDisadvantageAgainstNonCaster : FeatureDefinition, ICombatAffinityProvider
+        {
+            public string ConditionName { get; set; }
+
+            public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
+            public bool CanRageToOvercomeSurprise => false;
+            public bool AutoCritical => false;
+            public bool CriticalHitImmunity => false;
+            public ConditionDefinition RequiredTargetCondition => null;
+            public bool IgnoreCover => false;
+
+            public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+            {
+                if (myself.AllConditions.Any(c => c.ConditionDefinition.IsSubtypeOf(ConditionName) && c.SourceGuid != defender.Guid))
+                {
+                    attackModifier.AttackAdvantageTrends.Add(new RuleDefinitions.TrendInfo(-1, featureOrigin.sourceType, featureOrigin.sourceName, featureOrigin.source));
+                }
+            }
+
+            public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+            {
+                return;
+            }
+
+            public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
+            {
+                return RuleDefinitions.AdvantageType.None;
+            }
+
+            public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
+            {
+                return false;
+            }
+        }
+
+        private class OpportunityAttackImmunityIfAttackerHasCondition : FeatureDefinition, ICombatAffinityProvider
+        {
+            public string ConditionName { get; set; }
+
+            public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
+            public bool CanRageToOvercomeSurprise => false;
+            public bool AutoCritical => false;
+            public bool CriticalHitImmunity => false;
+            public ConditionDefinition RequiredTargetCondition => null;
+            public bool IgnoreCover => false;
+
+            public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+            {
+                return;
+            }
+
+            public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+            {
+                return;
+            }
+
+            public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
+            {
+                return RuleDefinitions.AdvantageType.None;
+            }
+
+            public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
+            {
+                return attacker.AllConditions.Any(c => c.SourceGuid == myself.Guid && c.ConditionDefinition.IsSubtypeOf(ConditionName));
+            }
+        }
+
+        private class IlluminatingStrikeAdditionalDamage : FeatureDefinitionAdditionalDamage, IClassHoldingFeature
+        {
+            // Allows Illuminating Strike damage to scale with barbarian level
+            public CharacterClassDefinition Class => DatabaseHelper.CharacterClassDefinitions.Barbarian;
+        }
+
+        private class IlluminatingStrikeFeatureBuilder : BaseDefinitionBuilder<IlluminatingStrikeAdditionalDamage>
+        {
+            public IlluminatingStrikeFeatureBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition) : base(name, guid)
+            {
+                Definition
+                    .SetGuiPresentation(CreatePowerGuiPresentation(description, title))
+                    .SetAdditionalDamageType(RuleDefinitions.AdditionalDamageType.Specific)
+                    .SetSpecificDamageType("DamageRadiant")
+                    .SetTriggerCondition(RuleDefinitions.AdditionalDamageTriggerCondition.AlwaysActive)
+                    .SetDamageValueDetermination(RuleDefinitions.AdditionalDamageValueDetermination.Die)
+                    .SetDamageDiceNumber(1)
+                    .SetDamageDieType(RuleDefinitions.DieType.D6)
+                    .SetDamageSaveAffinity(RuleDefinitions.EffectSavingThrowType.None)
+                    .SetDamageAdvancement(RuleDefinitions.AdditionalDamageAdvancement.ClassLevel)
+                    .SetLimitedUsage(RuleDefinitions.FeatureLimitedUsage.OnceInMyturn)
+                    .SetNotificationTag("BarbarianPathOfTheLightIlluminatingStrike")
+                    .SetRequiredProperty(RuleDefinitions.AdditionalDamageRequiredProperty.None)
+                    .SetAddLightSource(true)
+                    .SetLightSourceForm(CreateIlluminatedLightSource());
+
+                Definition.DiceByRankTable.AddRange(new[]
+                {
+                    BuildDiceByRank(3, 1),
+                    BuildDiceByRank(4, 1),
+                    BuildDiceByRank(5, 1),
+                    BuildDiceByRank(6, 1),
+                    BuildDiceByRank(7, 1),
+                    BuildDiceByRank(8, 1),
+                    BuildDiceByRank(9, 1),
+                    BuildDiceByRank(10, 2),
+                    BuildDiceByRank(11, 2),
+                    BuildDiceByRank(12, 2),
+                    BuildDiceByRank(13, 2),
+                    BuildDiceByRank(14, 2),
+                    BuildDiceByRank(15, 2),
+                    BuildDiceByRank(16, 2),
+                    BuildDiceByRank(17, 2),
+                    BuildDiceByRank(18, 2),
+                    BuildDiceByRank(19, 2),
+                    BuildDiceByRank(20, 2)
+                });
+
+                Definition.SetField("conditionOperations", new List<ConditionOperationDescription>());
+
+                Definition.ConditionOperations.Add(
+                    new ConditionOperationDescription
+                    {
+                        Operation = ConditionOperationDescription.ConditionOperation.Add,
+                        ConditionDefinition = illuminatedCondition
+                    });
+
+                foreach (ConditionDefinition invisibleCondition in InvisibleConditions)
+                {
+                    Definition.ConditionOperations.Add(
+                        new ConditionOperationDescription
+                        {
+                            Operation = ConditionOperationDescription.ConditionOperation.Remove,
+                            ConditionDefinition = invisibleCondition
+                        });
+                }
+            }
+
+            private static GuiPresentation CreatePowerGuiPresentation(string description, string title)
+            {
+                var guiPresentationBuilder = new GuiPresentationBuilder(description, title);
+
+                guiPresentationBuilder.SetSpriteReference(DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamageDomainLifeDivineStrike.GuiPresentation.SpriteReference);
+
+                return guiPresentationBuilder.Build();
+            }
+
+            private static LightSourceForm CreateIlluminatedLightSource()
+            {
+                EffectForm faerieFireLightSource = DatabaseHelper.SpellDefinitions.FaerieFire.EffectDescription.GetFirstFormOfType(EffectForm.EffectFormType.LightSource);
+
+                var lightSourceForm = new LightSourceForm();
+                lightSourceForm.Copy(faerieFireLightSource.LightSourceForm);
+
+                lightSourceForm
+                    .SetBrightRange(4)
+                    .SetDimAdditionalRange(4);
+
+                return lightSourceForm;
+            }
+
+            private static DiceByRank BuildDiceByRank(int rank, int dice)
+            {
+                DiceByRank diceByRank = new DiceByRank();
+                diceByRank.SetField("rank", rank);
+                diceByRank.SetField("diceNumber", dice);
+                return diceByRank;
+            }
+        }
+
+        /// <summary>
+        /// Builds the power that enables Illuminating Strike while you're raging.
+        /// </summary>
+        private class IlluminatingStrikeInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        {
+            public IlluminatingStrikeInitiatorBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition) : base(name, guid)
+            {
+                Definition
+                    .SetGuiPresentation(CreatePowerGuiPresentation(description, title))
+                    .SetActivationTime(RuleDefinitions.ActivationTime.OnRageStartAutomatic)
+                    .SetEffectDescription(CreatePowerEffect(illuminatedCondition))
+                    .SetRechargeRate(RuleDefinitions.RechargeRate.AtWill)
+                    .SetShowCasting(false);
+            }
+
+            private static GuiPresentation CreatePowerGuiPresentation(string description, string title)
+            {
+                var guiPresentationBuilder = new GuiPresentationBuilder(description, title);
+
+                guiPresentationBuilder.SetSpriteReference(DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamageDomainLifeDivineStrike.GuiPresentation.SpriteReference);
+
+                var guiPresentation = guiPresentationBuilder.Build();
+                guiPresentation.SetHidden(true);
+
+                return guiPresentation;
+            }
+
+            private static EffectDescription CreatePowerEffect(ConditionDefinition illuminatedCondition)
+            {
+                var initiatorCondition = ConditionDefinitionBuilder.Build(
+                    "PathOfTheLightIlluminatingStrikeInitiatorCondition",
+                    CreateNamespacedGuid("PathOfTheLightIlluminatingStrikeInitiatorCondition"),
+                    definition =>
+                    {
+                        var gpb = new GuiPresentationBuilder("Feature/&NoContentTitle", "Feature/&NoContentTitle");
+
+                        GuiPresentation guiPresentation = gpb.Build();
+
+                        guiPresentation.SetHidden(true);
+
+                        definition
+                            .SetGuiPresentation(guiPresentation)
+                            .SetDurationType(RuleDefinitions.DurationType.Minute)
+                            .SetDurationParameter(1)
+                            .SetConditionType(RuleDefinitions.ConditionType.Beneficial)
+                            .SetTerminateWhenRemoved(true)
+                            .SetSilentWhenAdded(true)
+                            .SetSilentWhenRemoved(true);
+
+                        var illuminatingStrikeFeature = new IlluminatingStrikeFeatureBuilder(
+                            IlluminatingStrikeName,
+                            CreateNamespacedGuid(IlluminatingStrikeName),
+                            "Feature/&NoContentTitle",
+                            "Feature/&NoContentTitle",
+                            illuminatedCondition);
+
+                        definition.Features.Add(illuminatingStrikeFeature.AddToDB());
+
+                        definition.SetField("specialInterruptions", new List<RuleDefinitions.ConditionInterruption> { RuleDefinitions.ConditionInterruption.RageStop });
+                    });
+
+                var enableIlluminatingStrike = new EffectForm
+                {
+                    FormType = EffectForm.EffectFormType.Condition,
+                    ConditionForm = new ConditionForm
+                    {
+                        Operation = ConditionForm.ConditionOperation.Add,
+                        ConditionDefinition = initiatorCondition
+                    }
+                };
+
+                var effectDescriptionBuilder = new EffectDescriptionBuilder();
+
+                effectDescriptionBuilder
+                    .SetDurationData(RuleDefinitions.DurationType.Minute, 1, RuleDefinitions.TurnOccurenceType.StartOfTurn)
+                    .AddEffectForm(enableIlluminatingStrike);
+
+                return effectDescriptionBuilder.Build();
+            }
+        }
+
+        private class IlluminatingBurstPower : FeatureDefinitionPower, IStartOfTurnRecharge
+        {
+            public bool IsRechargeSilent => true;
+        }
+
+        private class IlluminatingBurstBuilder : BaseDefinitionBuilder<IlluminatingBurstPower>
+        {
+            public IlluminatingBurstBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
+            {
+                Definition
+                    .SetGuiPresentation(CreatePowerGuiPresentation(description, title))
+                    .SetActivationTime(RuleDefinitions.ActivationTime.NoCost)
+                    .SetEffectDescription(CreatePowerEffect(illuminatedCondition))
+                    .SetRechargeRate(RuleDefinitions.RechargeRate.OneMinute) // Actually recharges at the start of your turn, using IStartOfTurnRecharge
+                    .SetFixedUsesPerRecharge(1)
+                    .SetUsesDetermination(RuleDefinitions.UsesDetermination.Fixed)
+                    .SetCostPerUse(1)
+                    .SetShowCasting(false)
+                    .SetDisableIfConditionIsOwned(illuminatingBurstSuppressedCondition); // Only enabled on the turn you enter a rage
+            }
+
+            private static GuiPresentation CreatePowerGuiPresentation(string description, string title)
+            {
+                var guiPresentationBuilder = new GuiPresentationBuilder(description, title);
+
+                guiPresentationBuilder.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerDomainSunHeraldOfTheSun.GuiPresentation.SpriteReference);
+
+                return guiPresentationBuilder.Build();
+            }
+
+            private static EffectDescription CreatePowerEffect(ConditionDefinition illuminatedCondition)
+            {
+                var effectDescriptionBuilder = new EffectDescriptionBuilder();
+
+                var dealDamage = new EffectForm
+                {
+                    FormType = EffectForm.EffectFormType.Damage,
+                    DamageForm = new DamageForm
+                    {
+                        DamageType = "DamageRadiant",
+                        DiceNumber = 4,
+                        DieType = RuleDefinitions.DieType.D6
+                    },
+                    SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.Negates
+                };
+
+                var illuminatedByBurstCondition = ConditionDefinitionBuilder<IlluminatedByBurstConditionDefinition>.Build(
+                    "PathOfTheLightIlluminatedByBurstCondition",
+                    CreateNamespacedGuid("PathOfTheLightIlluminatedByBurstCondition"),
+                    definition =>
+                    {
+                        var gpb = new GuiPresentationBuilder(
+                            "Subclass/&BarbarianPathOfTheLightIlluminatedConditionDescription",
+                            "Subclass/&BarbarianPathOfTheLightIlluminatedConditionTitle");
+
+                        gpb.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBranded.GuiPresentation.SpriteReference);
+
+                        definition
+                            .SetGuiPresentation(gpb.Build())
+                            .SetDurationType(RuleDefinitions.DurationType.Minute)
+                            .SetDurationParameter(1)
+                            .SetConditionType(RuleDefinitions.ConditionType.Detrimental)
+                            .SetAllowMultipleInstances(true)
+                            .SetSilentWhenAdded(true)
+                            .SetSilentWhenRemoved(false)
+                            .SetParentCondition(illuminatedCondition);
+                    });
+
+                var addIlluminatedCondition = new EffectForm
+                {
+                    FormType = EffectForm.EffectFormType.Condition,
+                    ConditionForm = new ConditionForm
+                    {
+                        Operation = ConditionForm.ConditionOperation.Add,
+                        ConditionDefinition = illuminatedByBurstCondition
+                    },
+                    CanSaveToCancel = true,
+                    SaveOccurence = RuleDefinitions.TurnOccurenceType.EndOfTurn,
+                    SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.Negates
+                };
+
+                EffectForm faerieFireLightSource = DatabaseHelper.SpellDefinitions.FaerieFire.EffectDescription.GetFirstFormOfType(EffectForm.EffectFormType.LightSource);
+
+                var lightSourceForm = new LightSourceForm();
+                lightSourceForm.Copy(faerieFireLightSource.LightSourceForm);
+
+                lightSourceForm
+                    .SetBrightRange(4)
+                    .SetDimAdditionalRange(4);
+
+                var addLightSource = new EffectForm
+                {
+                    FormType = EffectForm.EffectFormType.LightSource,
+                    SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.Negates
+                };
+
+                addLightSource.SetLightSourceForm(lightSourceForm);
+
+                effectDescriptionBuilder
+                    .SetSavingThrowData(
+                        hasSavingThrow: true,
+                        disableSavingThrowOnAllies: false,
+                        savingThrowAbility: "Constitution",
+                        ignoreCover: false,
+                        RuleDefinitions.EffectDifficultyClassComputation.AbilityScoreAndProficiency,
+                        savingThrowDifficultyAbility: "Constitution",
+                        fixedSavingThrowDifficultyClass: 10,
+                        advantageForEnemies: false,
+                        new List<SaveAffinityBySenseDescription>())
+                    .SetDurationData(
+                        RuleDefinitions.DurationType.Minute,
+                        durationParameter: 1,
+                        RuleDefinitions.TurnOccurenceType.EndOfTurn)
+                    .SetTargetingData(
+                        RuleDefinitions.Side.Enemy,
+                        RuleDefinitions.RangeType.Distance,
+                        rangeParameter: 6,
+                        RuleDefinitions.TargetType.IndividualsUnique,
+                        targetParameter: 3,
+                        targetParameter2: 0,
+                        ActionDefinitions.ItemSelectionType.None)
+                    .SetSpeed(
+                        RuleDefinitions.SpeedType.CellsPerSeconds,
+                        speedParameter: 9.5f)
+                    .SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.GuidingBolt.EffectDescription.EffectParticleParameters)
+                    .AddEffectForm(dealDamage)
+                    .AddEffectForm(addIlluminatedCondition)
+                    .AddEffectForm(addLightSource);
+
+                return effectDescriptionBuilder.Build();
+            }
+        }
+
+        /// <summary>
+        /// Builds the power that enables Illuminating Burst on the turn you enter a rage (by removing the condition disabling it).
+        /// </summary>
+        private class IlluminatingBurstInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        {
+            public IlluminatingBurstInitiatorBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
+            {
+                Definition
+                    .SetGuiPresentation(CreatePowerGuiPresentation(description, title))
+                    .SetActivationTime(RuleDefinitions.ActivationTime.OnRageStartAutomatic)
+                    .SetEffectDescription(CreatePowerEffect(illuminatingBurstSuppressedCondition))
+                    .SetRechargeRate(RuleDefinitions.RechargeRate.AtWill)
+                    .SetShowCasting(false);
+            }
+
+            private static GuiPresentation CreatePowerGuiPresentation(string description, string title)
+            {
+                var guiPresentationBuilder = new GuiPresentationBuilder(description, title);
+
+                var guiPresentation = guiPresentationBuilder.Build();
+                guiPresentation.SetHidden(true);
+
+                return guiPresentation;
+            }
+
+            private static EffectDescription CreatePowerEffect(ConditionDefinition illuminatingBurstSuppressedCondition)
+            {
+                var enableIlluminatingBurst = new EffectForm
+                {
+                    FormType = EffectForm.EffectFormType.Condition,
+                    ConditionForm = new ConditionForm
+                    {
+                        Operation = ConditionForm.ConditionOperation.Remove,
+                        ConditionDefinition = illuminatingBurstSuppressedCondition
+                    }
+                };
+
+                var effectDescriptionBuilder = new EffectDescriptionBuilder();
+
+                effectDescriptionBuilder
+                    .SetDurationData(RuleDefinitions.DurationType.Round, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn)
+                    .AddEffectForm(enableIlluminatingBurst);
+
+                return effectDescriptionBuilder.Build();
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -396,16 +396,16 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                         .SetSilentWhenAdded(true)
                         .SetSilentWhenRemoved(false);
 
-                    definition.Features.Add(CreateDisadvantageAgainstNonCaster());
+                    definition.Features.Add(CreateDisadvantageAgainstNonSource());
                     definition.Features.Add(CreatePreventInvisibility());
                 });
 
             return illuminatedCondition;
         }
 
-        private static AttackDisadvantageAgainstNonCaster CreateDisadvantageAgainstNonCaster()
+        private static AttackDisadvantageAgainstNonSource CreateDisadvantageAgainstNonSource()
         {
-            var disadvantageAgainstNonCaster = FeatureDefinitionBuilder<AttackDisadvantageAgainstNonCaster>.Build(
+            var disadvantageAgainstNonSource = FeatureDefinitionBuilder<AttackDisadvantageAgainstNonSource>.Build(
                 "PathOfTheLightIlluminatedDisadvantage",
                 CreateNamespacedGuid("PathOfTheLightIlluminatedDisadvantage"),
                 "Subclass/&BarbarianPathOfTheLightIlluminatedDisadvantageDescription",
@@ -415,7 +415,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                     definition.ConditionName = IlluminatedConditionName;
                 });
 
-            return disadvantageAgainstNonCaster;
+            return disadvantageAgainstNonSource;
         }
 
         private static FeatureDefinition CreatePreventInvisibility()
@@ -532,73 +532,6 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             public void BeforeDyingWithCondition(RulesetActor rulesetActor, RulesetCondition rulesetCondition)
             {
                 ApplyLightsProtectionHealing(rulesetCondition.SourceGuid);
-            }
-        }
-
-        private class AttackDisadvantageAgainstNonCaster : FeatureDefinition, ICombatAffinityProvider
-        {
-            public string ConditionName { get; set; }
-
-            public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
-            public bool CanRageToOvercomeSurprise => false;
-            public bool AutoCritical => false;
-            public bool CriticalHitImmunity => false;
-            public ConditionDefinition RequiredTargetCondition => null;
-            public bool IgnoreCover => false;
-
-            public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
-            {
-                if (myself.AllConditions.Any(c => c.ConditionDefinition.IsSubtypeOf(ConditionName) && c.SourceGuid != defender.Guid))
-                {
-                    attackModifier.AttackAdvantageTrends.Add(new RuleDefinitions.TrendInfo(-1, featureOrigin.sourceType, featureOrigin.sourceName, featureOrigin.source));
-                }
-            }
-
-            public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
-            {
-                return;
-            }
-
-            public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
-            {
-                return RuleDefinitions.AdvantageType.None;
-            }
-
-            public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
-            {
-                return false;
-            }
-        }
-
-        private class OpportunityAttackImmunityIfAttackerHasCondition : FeatureDefinition, ICombatAffinityProvider
-        {
-            public string ConditionName { get; set; }
-
-            public RuleDefinitions.SituationalContext SituationalContext => RuleDefinitions.SituationalContext.None;
-            public bool CanRageToOvercomeSurprise => false;
-            public bool AutoCritical => false;
-            public bool CriticalHitImmunity => false;
-            public ConditionDefinition RequiredTargetCondition => null;
-            public bool IgnoreCover => false;
-
-            public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
-            {
-                return;
-            }
-
-            public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
-            {
-                return;
-            }
-
-            public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(RulesetCharacter myself, RulesetCharacter attacker)
-            {
-                return RuleDefinitions.AdvantageType.None;
-            }
-
-            public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker)
-            {
-                return attacker.AllConditions.Any(c => c.SourceGuid == myself.Guid && c.ConditionDefinition.IsSubtypeOf(ConditionName));
             }
         }
 

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -588,3 +588,27 @@ Message/&CharacterExportEmptyNameErrorDescription	Export Cancelled:\n\nPlease tr
 Message/&CharacterExportDuplicateNameErrorDescription	Export Cancelled:\n\nA hero with this name already exists in the pool.\nPlease try a different name.
 Message/&CharacterExportModalContentDescription	Enter the hero name to export:
 Message/&CharacterExportModalTitleDescription	Character Export
+Subclass/&BarbarianPathOfTheLightDescription	Barbarians who follow the Path of the Light illuminate the darkness and protect their allies from dangers that lurk within it.
+Subclass/&BarbarianPathOfTheLightTitle	Path of the Light
+Subclass/&BarbarianPathOfTheLightIlluminatingStrikeDescription	While you're raging, the first creature you hit with an attack on your turn takes an additional 1d6 radiant damage and becomes magically illuminated until the start of your next turn. Additionally, the creature has disadvantage on any attack roll that isn't against you and cannot become invisible.
+Subclass/&BarbarianPathOfTheLightIlluminatingStrikeTitle	Illuminating Strike
+Subclass/&BarbarianPathOfTheLightIlluminatedConditionDescription	Distracted by Illuminating Strike.
+Subclass/&BarbarianPathOfTheLightIlluminatedConditionTitle	Illuminated
+Subclass/&BarbarianPathOfTheLightIlluminatedDisadvantageDescription	Disadvantage on any attack roll that isn't against the Path of the Light barbarian.
+Subclass/&BarbarianPathOfTheLightIlluminatedPreventInvisibilityDescription	Cannot become invisible.
+Subclass/&BarbarianPathOfTheLightPierceTheDarknessDescription	You gain superior darkvision.
+Subclass/&BarbarianPathOfTheLightPierceTheDarknessTitle	Pierce the Darkness
+Subclass/&BarbarianPathOfTheLightLightsProtectionDescription	You regain hit points equal to half your barbarian level when a hostile creature affected by your Illuminating Strike dies. Additionally, you no longer provoke opportunity attacks from creatures affected by your Illuminating Strike.
+Subclass/&BarbarianPathOfTheLightLightsProtectionTitle	Light's Protection
+Subclass/&BarbarianPathOfTheLightEyesOfTruthDescription	You are always under the effects of a See Invisibility spell.
+Subclass/&BarbarianPathOfTheLightEyesOfTruthTitle	Eyes of Truth
+Subclass/&BarbarianPathOfTheLightSeeingInvisibleConditionDescription	Can perceive invisible creatures.
+Subclass/&BarbarianPathOfTheLightSeeingInvisibleConditionTitle	Invisibility Sight
+Subclass/&BarbarianPathOfTheLightIlluminatingStrikeImprovementDescription	The additional damage dealt by Illuminating Strike increases to 2d6.
+Subclass/&BarbarianPathOfTheLightIlluminatingStrikeImprovementTitle	Illuminating Strike Improvement
+Subclass/&BarbarianPathOfTheLightIlluminatingBurstDescription	On the turn that you enter your rage, you can choose to illuminate up to three enemies within 30 feet of you. They must succeed on a Constitution saving throw (DC equal to 8 + your proficiency bonus + your Constitution modifier) or take 4d6 radiant damage and be illuminated by your Illuminating Strike for 1 minute. A creature illuminated in this way makes another Constitution saving throw at the end of each of its turns. On a successful save, the effect ends for it.
+Subclass/&BarbarianPathOfTheLightIlluminatingBurstTitle	Illuminating Burst
+Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerDescription	Up to three enemies take 4d6 radiant damage and become illuminated by your Illuminating Strike. (Constitution saving throw negates.)
+Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerTitle	Illuminating Burst
+Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeLine	Illuminating Strike deals extra damage to the target!
+Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeFormat Illuminating Strike!


### PR DESCRIPTION
- Path of the Light barbarian subclass.
- Generic ConditionDefinitionBuilder that supports any class that inherits from ConditionDefinition.
- Generic FeatureDefinitionBuilder that supports any class that inherits from FeatureDefinition.
- IClassHoldingFeature to allow IAdditionalDamageProvider features (like FeatureDefinitionAdditionalDamage) to scale with class level even if the feature isn't directly added to the class.
- IConditionRemovedOnSourceTurnStart to add support for conditions that last until the start of your next turn.
- INotifyConditionRemoval to support arbitrary behavior when a condition is removed (or the target dies).
- IStartOfTurnRecharge to add support for powers that recharge at the start of your next turn.