### PR TITLE
Fix 'hide monster hit points affects wild-shaped druid'

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUi/HideMonsterHitPoints.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/HideMonsterHitPoints.cs
@@ -153,7 +153,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi
                     return false;
                 }
 
-                if (__instance.RulesetCharacter?.IsSubstitute == true)
+                if (__instance.RulesetCharacter.IsSubstitute)
                 {
                     // It's a hero wildshaping (probably).
                     return false;


### PR DESCRIPTION
This will close https://github.com/ChrisPJohn/SolastaCommunityExpansion/issues/170
Please check my 'IsMonster' logic.