### PR TITLE
Suppress Pascal case issues for patches.

### DIFF
--- a/SolastaCommunityExpansion/Feats/ArmorFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ArmorFeats.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class ArmorFeats
     {
-        public static Guid ArmorNamespace = new Guid("d37cf3a0-6dbe-461f-8af5-58761414ef6b");
+        public static readonly Guid ArmorNamespace = new Guid("d37cf3a0-6dbe-461f-8af5-58761414ef6b");
 
         public static void CreateArmorFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/CasterFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CasterFeats.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class CasterFeats
     {
-        public static Guid CasterFeatsNamespace = new Guid("bf70984d-e7b9-446a-9ae3-0f2039de833d");
+        public static readonly Guid CasterFeatsNamespace = new Guid("bf70984d-e7b9-446a-9ae3-0f2039de833d");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {
@@ -282,7 +282,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowIntFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder intShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedInt", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedInt").ToString(),
-                shadowIntFeatures, intShadowTouchedPresentation.Build()); ;
+                shadowIntFeatures, intShadowTouchedPresentation.Build()); 
             feats.Add(intShadowTouched.AddToDB());
             // shadow touched wis
             GuiPresentationBuilder wisShadowTouchedPresentation = new GuiPresentationBuilder(
@@ -297,7 +297,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowWisFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder wisShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedWis", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedWis").ToString(),
-              shadowWisFeatures, wisShadowTouchedPresentation.Build()); ;
+              shadowWisFeatures, wisShadowTouchedPresentation.Build());
             feats.Add(wisShadowTouched.AddToDB());
             // shadow touched cha
             GuiPresentationBuilder chaShadowTouchedPresentation = new GuiPresentationBuilder(
@@ -312,7 +312,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowChaFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder chaShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedCha", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedCha").ToString(),
-                shadowChaFeatures, chaShadowTouchedPresentation.Build()); ;
+                shadowChaFeatures, chaShadowTouchedPresentation.Build());
             feats.Add(chaShadowTouched.AddToDB());
 
             // fey touched? but it'd be 12 feats

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -18,7 +18,7 @@ namespace SolastaCommunityExpansion.Feats
 
     internal class DualFlurryFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
     {
-        public static Guid DualFlurryGuid = new Guid("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
+        public static readonly Guid DualFlurryGuid = new Guid("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
         private const string DualFlurryFeatName = "DualFlurryFeat";
         private static readonly string DualFlurryFeatNameGuid = GuidHelper.Create(DualFlurryGuid, DualFlurryFeatName).ToString();
 

--- a/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
+++ b/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
@@ -7,9 +7,9 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Feats
 {
-    internal class FightingStlyeFeats
+    internal static class FightingStlyeFeats
     {
-        public static Guid FightingStyleFeatsNamespace = new Guid("db157827-0f8a-4fbb-bb87-6d54689a587a");
+        public static readonly Guid FightingStyleFeatsNamespace = new Guid("db157827-0f8a-4fbb-bb87-6d54689a587a");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/HealingFeats.cs
+++ b/SolastaCommunityExpansion/Feats/HealingFeats.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class HealingFeats
     {
-        public static Guid HealingFeatNamespace = new Guid("501448fd-3c84-4031-befe-84c2ae75123b");
+        public static readonly Guid HealingFeatNamespace = new Guid("501448fd-3c84-4031-befe-84c2ae75123b");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/OtherFeats.cs
+++ b/SolastaCommunityExpansion/Feats/OtherFeats.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class OtherFeats
     {
-        public static Guid OtherFeatNamespace = new Guid("655e8588-4d6e-42f3-9564-69e7345d5620");
+        public static readonly Guid OtherFeatNamespace = new Guid("655e8588-4d6e-42f3-9564-69e7345d5620");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.ItemCrafting
 {
-    internal class ItemRecipeGenerationHelper
+    internal static class ItemRecipeGenerationHelper
     {
         public static void AddRecipesForArmor(ItemCollection itemCollection)
         {

--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -58,7 +58,7 @@ namespace SolastaCommunityExpansion.Level20
             }
         }
 
-        internal static List<string> SpellListDefinitionList = new List<string>()
+        internal static readonly List<string> SpellListDefinitionList = new List<string>()
         {
             "SpellListCleric",
             "SpellListDruid",

--- a/SolastaCommunityExpansion/Main.cs
+++ b/SolastaCommunityExpansion/Main.cs
@@ -7,7 +7,7 @@ using UnityModManagerNet;
 
 namespace SolastaCommunityExpansion
 {
-    public class Main
+    public static class Main
     {
         public static bool Enabled { get; set; } = false;
 

--- a/SolastaCommunityExpansion/Models/FeatsContext.cs
+++ b/SolastaCommunityExpansion/Models/FeatsContext.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class FeatsContext
     {
-        public static Dictionary<string, FeatDefinition> Feats = new Dictionary<string, FeatDefinition>();
+        public static Dictionary<string, FeatDefinition> Feats { get; private set; } = new Dictionary<string, FeatDefinition>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Models/FightingStyleContext.cs
+++ b/SolastaCommunityExpansion/Models/FightingStyleContext.cs
@@ -6,7 +6,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class FightingStyleContext
     {
-        public static Dictionary<string, AbstractFightingStyle> Styles = new Dictionary<string, AbstractFightingStyle>();
+        public static Dictionary<string, AbstractFightingStyle> Styles { get; private set; } = new Dictionary<string, AbstractFightingStyle>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
@@ -7,9 +7,9 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class ItemCraftingContext
     {
-        public static Dictionary<string, List<ItemDefinition>> RecipeBooks = new Dictionary<string, List<ItemDefinition>>();
+        public static readonly Dictionary<string, List<ItemDefinition>> RecipeBooks = new Dictionary<string, List<ItemDefinition>>();
 
-        public static Dictionary<string, string> RecipeTitles = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> RecipeTitles = new Dictionary<string, string>
         {
             { "PrimedItems", "Primed Items" },
             { "EnchantingIngredients", "Enchanting Ingredients" },

--- a/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
+++ b/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
@@ -63,7 +63,7 @@ namespace SolastaCommunityExpansion.Models
                         monster.GuiPresentation.SetSpriteReference(brownBear.GuiPresentation.SpriteReference);
                         monster.SetBestiarySpriteReference(brownBear.BestiarySpriteReference);
                         monster.MonsterPresentation.SetMonsterPresentationDefinitions(brownBear.MonsterPresentation.MonsterPresentationDefinitions);
-                    };
+                    }
 
                     // swap apes for remorhaz
                     if (value.AssetGUID == assetReference_Remorhaz)
@@ -73,7 +73,7 @@ namespace SolastaCommunityExpansion.Models
                         monster.GuiPresentation.SetSpriteReference(ape.GuiPresentation.SpriteReference);
                         monster.SetBestiarySpriteReference(ape.BestiarySpriteReference);
                         monster.MonsterPresentation.SetMonsterPresentationDefinitions(ape.MonsterPresentation.MonsterPresentationDefinitions);
-                    };
+                    }
 
                     // swap wolves for beetles
                     if (value.AssetGUID == assetReference_beetle)
@@ -87,10 +87,8 @@ namespace SolastaCommunityExpansion.Models
                         // changing beetlw scale to suit replacement model
                         monster.MonsterPresentation.SetMaleModelScale(0.655f);
                         monster.MonsterPresentation.SetMaleModelScale(0.655f);
-                    };
-
-                };
-
+                    }
+                }
             }
         }
     }

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class SubclassesContext
     {
-        public static Dictionary<string, AbstractSubclass> Subclasses = new Dictionary<string, AbstractSubclass>();
+        public static Dictionary<string, AbstractSubclass> Subclasses { get; private set; } = new Dictionary<string, AbstractSubclass>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Patches/AutoPreparedSpells/SpellsByLevelGroupPatch.cs
+++ b/SolastaCommunityExpansion/Patches/AutoPreparedSpells/SpellsByLevelGroupPatch.cs
@@ -1,11 +1,13 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.AutoPreparedSpells
 {
     internal static class SpellsByLevelGroupPatch
     {
         [HarmonyPatch(typeof(SpellsByLevelGroup), "CommonBind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class SpellsByLevelGroup_CommonBind_Patch
         {
             /**

--- a/SolastaCommunityExpansion/Patches/CharacterExport/CharacterInspectionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/CharacterInspectionScreenPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // uses this patch to trap the input hotkey and start export process
     [HarmonyPatch(typeof(CharacterInspectionScreen), "HandleInput")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterInspectionScreen_HandleInput
     {
         public static void Prefix(CharacterInspectionScreen __instance, InputCommands.Id command, ref bool __result)

--- a/SolastaCommunityExpansion/Patches/CharacterExport/MessageModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/MessageModalPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using TMPro;
 using UnityEngine.EventSystems;
 using static SolastaCommunityExpansion.Models.CharacterExportContext;
@@ -10,6 +11,7 @@ namespace SolastaCommunityExpansion.Patches
     {
 
         [HarmonyPatch(typeof(MessageModal), "Show")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class MessageModal_Show
         {
             internal static void Postfix(string content, GuiLabel ___contentLabel)

--- a/SolastaCommunityExpansion/Patches/CharacterExport/RulesetInventoryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/RulesetInventoryPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     // We need to temporarily add the dummy RulesetEntityService and then remove it.
     // We don't want to register it or remove it when the real one has been registered.
     [HarmonyPatch(typeof(RulesetInventory), "SerializeElements")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetInventory_SerializeElements
     {
         static readonly object Locker = new object();

--- a/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.Cheats
 {
     // use this patch to enable the cheats window during gameplay
     [HarmonyPatch(typeof(GameMenuModal), "SetButtonAvailability")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameMenuModal_SetButtonAvailability
     {
         internal static void Postfix(GameMenuModal.MenuButtonIndex index, CanvasGroup[] ___buttonCanvases)

--- a/SolastaCommunityExpansion/Patches/Cheats/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Cheats/RulesetCharacterHeroPatcher.cs
@@ -1,14 +1,17 @@
 ﻿using HarmonyLib;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static SolastaModApi.DatabaseHelper.QuestTreeDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.Cheats
 {
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static partial class RulesetCharacterHeroPatcher_LevelUp
     {
         // use this patch to enable the No Experience on Level up cheat
         [HarmonyPatch(typeof(RulesetCharacterHero), "CanLevelUp", MethodType.Getter)]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_CanLevelUp_Patch
         {
             internal static bool Prefix(RulesetCharacterHero __instance, ref bool __result)
@@ -26,6 +29,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
         }
 
         [HarmonyPatch(typeof(RulesetCharacterHero), "GrantExperience")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_GrantExperience_Patch
         {
             internal static void Prefix(ref int experiencePoints)
@@ -47,6 +51,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
         /// At certain quest specific points the level up must not be scaled.
         /// </summary>
         [HarmonyPatch(typeof(RulesetCharacterHero), "ComputeNeededExperienceToReachLevel")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_ComputeNeededExperienceToReachLevel_Patch
         {
             internal static void Postfix(ref int __result)

--- a/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.ClassHoldingFeature
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.ClassHoldingFeature
     internal static class RulesetCharacterHeroPatcher
     {
         [HarmonyPatch(typeof(RulesetCharacterHero), "FindClassHoldingFeature")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_FindClassHoldingFeature
         {
             internal static void Postfix(

--- a/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
@@ -8,6 +9,7 @@ namespace SolastaCommunityExpansion.Patches.ConditionRemovedOnSourceTurnStart
     {
         // Yes, the actual method name has a typo
         [HarmonyPatch(typeof(RulesetActor), "ProcessConditionsMatchingOccurenceType")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetActor_ProcessConditionsMatchingOccurenceType
         {
             internal static void Postfix(RulesetActor __instance, RuleDefinitions.TurnOccurenceType occurenceType)

--- a/SolastaCommunityExpansion/Patches/CustomFightingStyle/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFightingStyle/RulesetCharacterHeroPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.CustomFightingStyle
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFightingStyle
     internal static class RulesetCharacterHeroPatcher
     {
         [HarmonyPatch(typeof(RulesetCharacterHero), "RefreshActiveFightingStyles")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_RefreshActiveFightingStyles
         {
             internal static void Postfix(RulesetCharacterHero __instance)

--- a/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
@@ -3,11 +3,13 @@ using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaCommunityExpansion.Patches.PowerSharedPool;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace SolastaCommunityExpansion.Patches.ConditionalPowers
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "RefreshAll")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_RefreshAll_Patch
     {
         internal static void Postfix(RulesetCharacterHero __instance)

--- a/SolastaCommunityExpansion/Patches/FightingStyleFeats/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/FightingStyleFeats/RulesetCharacterHeroPatcher.cs
@@ -1,9 +1,11 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.FightingStyleFeats
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "TrainFeats")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_TrainFeatsFightingStyles_Patch
     {
         internal static void Postfix(RulesetCharacterHero __instance, List<FeatDefinition> feats)

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class GameManagerPatcher
     {
         [HarmonyPatch(typeof(GameManager), "BindPostDatabase")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameManager_BindPostDatabase_Patch
         {
             internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/BattleState_VictoryUpdatePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/BattleState_VictoryUpdatePatcher.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi
 {
     [HarmonyPatch(typeof(BattleState_Victory), "Update")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class BattleState_VictoryUpdatePatcher
     {
         public static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(CharacterControlPanel), "OnConfigurationSwitchedHandler")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterControlPanel_OnConfigurationSwitchedHandler
     {
         private static CharacterActionPanel panelToActivate;
@@ -77,6 +79,7 @@ namespace SolastaCommunityExpansion.Patches
                 }
                 else if (__instance is CharacterControlPanelBattle battlePanel)
                 {
+#pragma warning disable S3458 // Empty "case" clauses that fall through to the "default" should be omitted
                     switch (actionId)
                     {
                         case ActionDefinitions.Id.CastMain:
@@ -160,6 +163,7 @@ namespace SolastaCommunityExpansion.Patches
                             panelToActivate = battlePanel.GetField<CharacterActionPanel>("otherActionPanel");
                             break;
                     }
+#pragma warning restore S3458 // Empty "case" clauses that fall through to the "default" should be omitted
                 }
             }
         }

--- a/SolastaCommunityExpansion/Patches/GameUi/EquipmentDefinitions_ScaleAndRoundCostsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/EquipmentDefinitions_ScaleAndRoundCostsPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
@@ -16,6 +17,7 @@ namespace SolastaCommunityExpansion.Patches
     /// <summary>
     /// </summary>
     [HarmonyPatch(typeof(EquipmentDefinitions), "ScaleAndRoundCosts")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class EquipmentDefinitions_ScaleAndRoundCosts
     {
         internal static bool Prefix(float priceMultiplier, int[] baseCosts, int[] scaledCosts)

--- a/SolastaCommunityExpansion/Patches/GameUi/FeatSubPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/FeatSubPanelPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(FeatSubPanel), "RuntimeLoaded")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class FeatSubPanell_RuntimeLoaded
     {
         internal static void Sort(List<FeatDefinition> relevantFeats)

--- a/SolastaCommunityExpansion/Patches/GameUi/FutureFeatureSortingPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/FutureFeatureSortingPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class FutureFeatureSortingPatcher
     {
         [HarmonyPatch(typeof(CharacterStageSubclassSelectionPanel), "FillSubclassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageSubclassSelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterSubclassDefinition subclassDefinition)
@@ -20,6 +22,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(CharacterStageDeitySelectionPanel), "FillSubclassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageDeitySelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterSubclassDefinition currentSubclassDefinition)
@@ -33,6 +36,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(ArchetypesPreviewModal), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class ArchetypesPreviewModal_Bind
         {
             internal static void Postfix(ArchetypesPreviewModal __instance)
@@ -50,6 +54,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(CharacterStageClassSelectionPanel), "FillClassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageClassSelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterClassDefinition classDefinition)

--- a/SolastaCommunityExpansion/Patches/GameUi/GameLocationScreenExplorationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/GameLocationScreenExplorationPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class GameLocationScreenExplorationPatcher
     {
         [HarmonyPatch(typeof(GameLocationScreenExploration), "HandleInput")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameLocationScreenExploration_HandleInput
         {
             internal static bool Prefix(

--- a/SolastaCommunityExpansion/Patches/GameUi/GameTimeSetTimeScalePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/GameTimeSetTimeScalePatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     internal static class GameTimeSetTimeScalePatcher
     {
         [HarmonyPatch(typeof(GameTime), "SetTimeScale")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameTime_SetTimeScale
         {
             internal static bool Prefix(ref float ___timeScale, ref bool ___fasterTimeMode)

--- a/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,6 +14,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line bind
         [HarmonyPatch(typeof(PowerSelectionPanel), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class PowerSelectionPanel_Bind
         {
             internal static void Postfix(PowerSelectionPanel __instance)
@@ -65,6 +67,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line unbind
         [HarmonyPatch(typeof(PowerSelectionPanel), "Unbind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class PowerSelectionPanel_Unbind
         {
             internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/RulesetCharacterHero_GrantItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/RulesetCharacterHero_GrantItemPatcher.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "GrantItem")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_GrantItem
     {
         public static void Prefix(ref bool tryToEquip)

--- a/SolastaCommunityExpansion/Patches/GameUi/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/SpellSelectionPanelPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -13,6 +14,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line bind
         [HarmonyPatch(typeof(SpellSelectionPanel), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class SpellSelectionPanel_SecondLine
         {
             internal static void Postfix(SpellSelectionPanel __instance, GameLocationCharacter caster, SpellsByLevelBox.SpellCastEngagedHandler spellCastEngaged, ActionDefinitions.ActionType actionType, bool cantripOnly)
@@ -202,6 +204,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line unbind
         [HarmonyPatch(typeof(SpellSelectionPanel), "Unbind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class SpellSelectionPanel_Unbind
         {
             internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/SubclassSelectionSpacingPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/SubclassSelectionSpacingPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,6 +10,7 @@ namespace SolastaUIUpdates.Patches
     internal static class SubclassSelectionSpacingPatcher
     {
         [HarmonyPatch(typeof(CharacterStageSubclassSelectionPanel), "EnterStage")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageSubclassSelectionPanel_EnterStage
         {
             public static void Postfix(CharacterStageSubclassSelectionPanel __instance)

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi
 {
 
     [HarmonyPatch(typeof(TooltipFeatureDescription), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class TooltipFeatureDescription_Bind
     {
         internal static void Postfix(TooltipFeatureDescription __instance, ITooltip tooltip)

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
@@ -1,10 +1,11 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // always alt
     [HarmonyPatch(typeof(TooltipPanel), "SetupFeatures")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class TooltipPanel_SetupFeatures
     {
         internal static void Prefix(ref TooltipDefinitions.Scope scope)

--- a/SolastaCommunityExpansion/Patches/HeroName/CharacterPoolManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/HeroName/CharacterPoolManagerPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patch
 {
     internal static class CharacterPoolManagerPatcher
     {
         [HarmonyPatch(typeof(CharacterPoolManager), "SaveCharacter")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterPoolManager_SaveCharacter
         {
             public static void Prefix(RulesetCharacterHero heroCharacter, [HarmonyArgument("addToPool")] bool _ = false)

--- a/SolastaCommunityExpansion/Patches/HeroName/CharacterStageIdentityDefinitionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/HeroName/CharacterStageIdentityDefinitionPanelPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using TMPro;
 
 namespace SolastaCommunityExpansion.Patches
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     internal static class CharacterStageIdentityDefinitionPanelPatcher
     {
         [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "EnterStage")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageIdentityDefinitionPanel_EnterStage_Patch
         {
             public static void Postfix(TMP_InputField ___firstNameInputField, TMP_InputField ___lastNameInputField)
@@ -20,6 +22,7 @@ namespace SolastaCommunityExpansion.Patches
     }
 
     [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "RemoveUselessSpaces")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterStageIdentityDefinitionPanel_RemoveUselessSpaces_Patch
     {
         public static bool Prefix(TMP_InputField textField)

--- a/SolastaCommunityExpansion/Patches/InitialChoices/GuiFeatDefinitionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/InitialChoices/GuiFeatDefinitionPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.InitialChoices
 {
-    internal class GuiFeatDefinitionPatcher
+    internal static class GuiFeatDefinitionPatcher
     {
         [HarmonyPatch(typeof(GuiFeatDefinition), "IsFeatMacthingPrerequisites")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GuiFeatDefinition_IsFeatMacthingPrerequisites
         {
             //internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/InventoryManagement/InventoryPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/InventoryManagement/InventoryPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class InventoryPanelPatcher
     {
         [HarmonyPatch(typeof(InventoryPanel), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class InventoryPanel_Bind
         {
             internal static void Postfix(InventoryPanel __instance)
@@ -14,6 +16,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(InventoryPanel), "Unbind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class InventoryPanel_Unbind
         {
             internal static void Prefix(InventoryPanel __instance)

--- a/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches.Level20
     {
         // replaces the hard coded experience
         [HarmonyPatch(typeof(ArchetypesPreviewModal), "Refresh")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class ArchetypesPreviewModal_Refresh_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches
     {
         // replaces the hard-coded level
         [HarmonyPatch(typeof(CharactersPanel), "Refresh")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharactersPanel_Refresh_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/GameCampaignPartyPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/GameCampaignPartyPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches
     {
         // replaces the hard-coded level and max experience
         [HarmonyPatch(typeof(GameCampaignParty), "UpdateLevelCaps")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameCampaignParty_UpdateLevelCaps_Patch
         {
             internal static bool Prefix(GameCampaignParty __instance)

--- a/SolastaCommunityExpansion/Patches/Level20/HeroDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/HeroDefinitionsPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches
     {
         // overrides the max experience returned
         [HarmonyPatch(typeof(HeroDefinitions), "MaxHeroExperience")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class HeroDefinitions_MaxHeroExperience_Patch
         {
             internal static bool Prefix(ref int __result)

--- a/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -10,6 +11,7 @@ namespace SolastaCommunityExpansion.Patches
     {
         // replaces the hard coded experience
         [HarmonyPatch(typeof(HigherLevelFeaturesModal), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class HigherLevelFeaturesModal_Bind_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches
     {
         // replaces the hard coded experience
         [HarmonyPatch(typeof(RulesetCharacterHero), "RegisterAttributes")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_RegisterAttributes_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetSpellRepertoirePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetSpellRepertoirePatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class RulesetSpellRepertoirePatcher
     {
         [HarmonyPatch(typeof(RulesetSpellRepertoire), "MaxSpellLevelOfSpellCastingLevel", MethodType.Getter)]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetSpellRepertoire_MaxSpellLevelOfSpellCastingLevel_Getter_Patch
         {
             internal static void Postfix(RulesetSpellRepertoire __instance, ref int __result)

--- a/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches
     internal static class UserLocationSettingsModalPatcher
     {
         [HarmonyPatch(typeof(UserLocationSettingsModal), "OnMinLevelEndEdit")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         public static class UserLocationSettingsModal_OnMinLevelEndEdit_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -30,6 +32,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(UserLocationSettingsModal), "OnMaxLevelEndEdit")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         public static class UserLocationSettingsModal_OnMaxLevelEndEdit_Patch
         {
             internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/LoadFixers/GameLoreManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/LoadFixers/GameLoreManagerPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.LoadFixers
 {
     internal static class GameLoreManagerPatcher
     {
         [HarmonyPatch(typeof(GameLoreManager), "SerializeElements")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameLoreManager_SerializeElements_Patch
         {
             // If a recipe can't be found in the database but was previously known, the serialization

--- a/SolastaCommunityExpansion/Patches/LongActivationPowers/GameLocationCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/LongActivationPowers/GameLocationCharacterPatcher.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.LongActivationPowers
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches.LongActivationPowers
     {
         // Yes the actual game typos this it is "OnPower" and not the expected "OnePower".
         [HarmonyPatch(typeof(GameLocationCharacter), "CanUseAtLeastOnPower")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameLocationCharacter_CanUseAtLeastOnPowerShowLong
         {
             // This makes it so that if a character only has powers that take longer than an action to activate the "Use Power" button is available.

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
     internal static class RulesetActorPatcher
     {
         [HarmonyPatch(typeof(RulesetActor), "RemoveCondition")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetActor_RemoveCondition
         {
             internal static void Postfix(RulesetActor __instance, RulesetCondition rulesetCondition)

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
     internal static class RulesetCharacterPatcher
     {
         [HarmonyPatch(typeof(RulesetCharacter), "Kill")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_Kill
         {
             internal static void Prefix(RulesetCharacter __instance)

--- a/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.OnAttackEffects
 {
     internal static class GameLocationBattleManagerPatcher
     {
         [HarmonyPatch(typeof(GameLocationBattleManager), "HandleCharacterAttackDamage")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameLocationBattleManager_HandleCharacterAttackDamage_Patch
         {
             internal static void Postfix(GameLocationCharacter attacker,

--- a/SolastaCommunityExpansion/Patches/PointBuy/AttributeDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PointBuy/AttributeDefinitionsPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // extends the cost buy table
     [HarmonyPatch(typeof(AttributeDefinitions), "ComputeCostToRaiseAbility")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class AttributeDefinitions_ComputeCostToRaiseAbility 
     {
         internal static void Postfix(int previousValue, ref int __result)

--- a/SolastaCommunityExpansion/Patches/PointBuy/CharacterStageAbilityScoresPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PointBuy/CharacterStageAbilityScoresPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using HarmonyLib;
 
@@ -7,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches
 {
     // enables epic points
     [HarmonyPatch(typeof(CharacterStageAbilityScoresPanel), "Reset")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameManager_Reset
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -34,6 +35,7 @@ namespace SolastaCommunityExpansion.Patches
 
     // enables epic points
     [HarmonyPatch(typeof(CharacterStageAbilityScoresPanel), "Refresh")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameManager_Refresh
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/PowerSharedPool/RulesetCharacterPatch.cs
+++ b/SolastaCommunityExpansion/Patches/PowerSharedPool/RulesetCharacterPatch.cs
@@ -2,6 +2,7 @@
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.PowerSharedPool
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
     internal static class RulesetCharacterPatch
     {
         [HarmonyPatch(typeof(RulesetCharacter), "UsePower")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_UsePower
         {
             public static void Postfix(RulesetCharacter __instance, RulesetUsablePower usablePower)
@@ -18,6 +20,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "RepayPowerUse")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_RepayPowerUse
         {
             public static void Postfix(RulesetCharacter __instance, RulesetUsablePower usablePower)
@@ -47,6 +50,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "GrantPowers")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_GrantPowers
         {
             public static void Postfix(RulesetCharacter __instance)
@@ -56,6 +60,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "ApplyRest")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_ApplyRest
         {
             internal static void Postfix(

--- a/SolastaCommunityExpansion/Patches/Respec/CharacterEditionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/CharacterEditionScreenPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // use this patch to track if Respec was aborted
     [HarmonyPatch(typeof(CharacterEditionScreen), "DoAbort")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterEditionScreen_DoAbort
     {
         internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/Respec/CharacterStageAbilityScoresPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/CharacterStageAbilityScoresPanelPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // use this patch to avoid issues during RESPEC if a hero with same name is in the pool
     [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "CanProceedToNextStage")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterStageIdentityDefinitionPanel_UpdateRelevance
     {
         internal static void Postfix(CharacterStageIdentityDefinitionPanel __instance, ref bool __result)

--- a/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
@@ -1,12 +1,15 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHeroPatcher_Respec
     {
         // use this patch to enable the after rest actions
         [HarmonyPatch(typeof(RulesetCharacterHero), "EnumerateAfterRestActions")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacterHero_EnumerateAfterRestActions
         {
             internal static void Postfix(RuleDefinitions.RestType restType, List<RestActivityDefinition> ___afterRestActions)

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/RuleDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/RuleDefinitionsPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
     internal static class RuleDefinitionsPatcher
     {
         [HarmonyPatch(typeof(RuleDefinitions), "ComputeAdvantage")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RuleDefinitions_ComputeAdvantage_Patch
         {
             public static void Postfix(List<RuleDefinitions.TrendInfo> trends, RuleDefinitions.AdvantageType __result)

--- a/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.StartOfTurnRecharge
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.StartOfTurnRecharge
     internal static class RulesetCharacterPatcher
     {
         [HarmonyPatch(typeof(RulesetCharacter), "RechargePowersForTurnStart")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_RechargePowersForTurnStart
         {
             internal static void Postfix(RulesetCharacter __instance)

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -21,12 +21,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
     }
 
-    internal class KnockDownPowerBuilder
+    internal static class KnockDownPowerBuilder
     {
         private const string KnockDownPowerName = "KnockDownPower";
         private const string KnockDownPowerNameGuid = "90dd5e81-40d7-4824-89b4-45bcf4c05218";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon?  This doesn't seem possible
             EffectForm damageEffect = new EffectForm
@@ -77,12 +77,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(KnockDownPowerName, KnockDownPowerNameGuid);
     }
 
-    internal class InspirePowerBuilder
+    internal static class InspirePowerBuilder
     {
         private const string InspirePowerName = "InspirePower";
         private const string InspirePowerNameGuid = "163c28de-48e5-4f75-bdd0-d42374a75ef8";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the temp hp form
             EffectForm healingEffect = new EffectForm
@@ -133,12 +133,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(InspirePowerName, InspirePowerNameGuid);
     }
 
-    internal class CounterStrikePowerBuilder
+    internal static class CounterStrikePowerBuilder
     {
         private const string CounterStrikePowerName = "CounterStrikePower";
         private const string CounterStrikePowerNameGuid = "88c294ce-14fa-4f7e-8b81-ea4d289e3d8b";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon (seems impossible with current tools, would need to use the AdditionalDamage feature but I'm not sure how to combine that with this to make it a reaction ability).
             EffectForm damageEffect = new EffectForm
@@ -172,7 +172,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(CounterStrikePowerName, CounterStrikePowerNameGuid);
     }
 
-    internal class GambitResourcePoolBuilder
+    internal static class GambitResourcePoolBuilder
     {
         private const string GambitResourcePoolName = "GambitResourcePool";
         private const string GambitResourcePoolNameGuid = "00da2b27-139a-4ca0-a285-aaa70d108bc8";
@@ -183,7 +183,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 new GuiPresentationBuilder("Feature/&GambitResourcePoolDescription", "Feature/&GambitResourcePoolTitle").Build()).AddToDB();
     }
 
-    internal class GambitResourcePoolAddBuilder
+    internal static class GambitResourcePoolAddBuilder
     {
         private const string GambitResourcePoolAddName = "GambitResourcePoolAdd";
         private const string GambitResourcePoolAddNameGuid = "056d786a-2611-4981-a652-704fa5056375";

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -82,7 +82,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             feintBuilder.AddEffectForm(new EffectFormBuilder().CreatedByCharacter().SetConditionForm(new AdvantageBuilder("RogueConArtistFeintCondition",
                 GuidHelper.Create(SubclassNamespace, "RogueConArtistFeintCondition").ToString(),
                 DatabaseHelper.ConditionDefinitions.ConditionTrueStrike, feintGuiCondition.Build()).AddToDB(), ConditionForm.ConditionOperation.Add,
-                false, false, new List<ConditionDefinition>()).Build()); ;
+                false, false, new List<ConditionDefinition>()).Build());
             //feintBuilder.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.))
             FeatureDefinitionPower feint = new FeatureDefinitionPowerBuilder("RoguishConArtistFeint", GuidHelper.Create(SubclassNamespace, "RoguishConArtistFeint").ToString(),
                 0, RuleDefinitions.UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Charisma, RuleDefinitions.ActivationTime.BonusAction, 0, RuleDefinitions.RechargeRate.AtWill,

--- a/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
@@ -5,7 +5,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class CreditsDisplay
     {
-        internal static Dictionary<string, string> CreditsTable = new Dictionary<string, string>
+        internal static readonly Dictionary<string, string> CreditsTable = new Dictionary<string, string>
         {
             { "ChrisJohnDigital".orange().bold(), "head developer, feats, items, subclasses, progression, etc." },
             { "Zappastuff", "mod UI work, integration, community organization, level 20, respec" },


### PR DESCRIPTION
Fix further warnings.  
1) Suppress Pascal case naming warnings on patches
2) more readonly, static etc