### PR TITLE
Warning suppressions

### DIFF
--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionPowerSharedPool.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionPowerSharedPool.cs
@@ -30,14 +30,17 @@ namespace SolastaCommunityExpansion.CustomFeatureDefinitions
 
     public class FeatureDefinitionPowerPoolModifier : FeatureDefinitionPower, IPowerPoolModifier
     {
-        public FeatureDefinitionPower PoolPower;
-        public int poolChangeAmount;
+        public FeatureDefinitionPower PoolPower { get; set; }
+
+        // TODO: unassigned - remove or use
+        private int poolChangeAmount;
 
         public FeatureDefinitionPower GetUsagePoolPower()
         {
             return PoolPower;
         }
 
+        // TODO: unused  - remove or use
         public int PoolChangeAmount()
         {
             return poolChangeAmount;

--- a/SolastaCommunityExpansion/Feats/ArmorFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ArmorFeats.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class ArmorFeats
     {
-        public static Guid ArmorNamespace = new Guid("d37cf3a0-6dbe-461f-8af5-58761414ef6b");
+        public static readonly Guid ArmorNamespace = new Guid("d37cf3a0-6dbe-461f-8af5-58761414ef6b");
 
         public static void CreateArmorFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/CasterFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CasterFeats.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class CasterFeats
     {
-        public static Guid CasterFeatsNamespace = new Guid("bf70984d-e7b9-446a-9ae3-0f2039de833d");
+        public static readonly Guid CasterFeatsNamespace = new Guid("bf70984d-e7b9-446a-9ae3-0f2039de833d");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {
@@ -282,7 +282,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowIntFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder intShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedInt", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedInt").ToString(),
-                shadowIntFeatures, intShadowTouchedPresentation.Build()); ;
+                shadowIntFeatures, intShadowTouchedPresentation.Build());
             feats.Add(intShadowTouched.AddToDB());
             // shadow touched wis
             GuiPresentationBuilder wisShadowTouchedPresentation = new GuiPresentationBuilder(
@@ -297,7 +297,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowWisFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder wisShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedWis", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedWis").ToString(),
-              shadowWisFeatures, wisShadowTouchedPresentation.Build()); ;
+              shadowWisFeatures, wisShadowTouchedPresentation.Build());
             feats.Add(wisShadowTouched.AddToDB());
             // shadow touched cha
             GuiPresentationBuilder chaShadowTouchedPresentation = new GuiPresentationBuilder(
@@ -312,7 +312,7 @@ namespace SolastaCommunityExpansion.Feats
             };
             shadowChaFeatures.AddRange(shadowTouchedClassesPreparedSpells);
             FeatDefinitionBuilder chaShadowTouched = new FeatDefinitionBuilder("FeatShadowTouchedCha", GuidHelper.Create(CasterFeatsNamespace, "FeatShadowTouchedCha").ToString(),
-                shadowChaFeatures, chaShadowTouchedPresentation.Build()); ;
+                shadowChaFeatures, chaShadowTouchedPresentation.Build());
             feats.Add(chaShadowTouched.AddToDB());
 
             // fey touched? but it'd be 12 feats

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -18,7 +18,7 @@ namespace SolastaCommunityExpansion.Feats
 
     internal class DualFlurryFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
     {
-        public static Guid DualFlurryGuid = new Guid("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
+        public static readonly Guid DualFlurryGuid = new Guid("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
         private const string DualFlurryFeatName = "DualFlurryFeat";
         private static readonly string DualFlurryFeatNameGuid = GuidHelper.Create(DualFlurryGuid, DualFlurryFeatName).ToString();
 

--- a/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
+++ b/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
@@ -7,9 +7,9 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Feats
 {
-    internal class FightingStlyeFeats
+    internal static class FightingStlyeFeats
     {
-        public static Guid FightingStyleFeatsNamespace = new Guid("db157827-0f8a-4fbb-bb87-6d54689a587a");
+        public static readonly Guid FightingStyleFeatsNamespace = new Guid("db157827-0f8a-4fbb-bb87-6d54689a587a");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/HealingFeats.cs
+++ b/SolastaCommunityExpansion/Feats/HealingFeats.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class HealingFeats
     {
-        public static Guid HealingFeatNamespace = new Guid("501448fd-3c84-4031-befe-84c2ae75123b");
+        public static readonly Guid HealingFeatNamespace = new Guid("501448fd-3c84-4031-befe-84c2ae75123b");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Feats/OtherFeats.cs
+++ b/SolastaCommunityExpansion/Feats/OtherFeats.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Feats
 {
     internal static class OtherFeats
     {
-        public static Guid OtherFeatNamespace = new Guid("655e8588-4d6e-42f3-9564-69e7345d5620");
+        public static readonly Guid OtherFeatNamespace = new Guid("655e8588-4d6e-42f3-9564-69e7345d5620");
 
         public static void CreateFeats(List<FeatDefinition> feats)
         {

--- a/SolastaCommunityExpansion/Features/ItemBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ItemBuilder.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Features
 {
     internal static class ItemBuilder
     {
-        private class ItemDefinitionBuilder : BaseDefinitionBuilder<ItemDefinition>
+        private sealed class ItemDefinitionBuilder : BaseDefinitionBuilder<ItemDefinition>
         {
             public ItemDefinitionBuilder(ItemDefinition original, string name, string guid) : base(original, name, guid)
             {

--- a/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.ItemCrafting
 {
-    internal class ItemRecipeGenerationHelper
+    internal static class ItemRecipeGenerationHelper
     {
         public static void AddRecipesForArmor(ItemCollection itemCollection)
         {

--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -58,7 +58,7 @@ namespace SolastaCommunityExpansion.Level20
             }
         }
 
-        internal static List<string> SpellListDefinitionList = new List<string>()
+        internal static readonly List<string> SpellListDefinitionList = new List<string>()
         {
             "SpellListCleric",
             "SpellListDruid",

--- a/SolastaCommunityExpansion/Main.cs
+++ b/SolastaCommunityExpansion/Main.cs
@@ -7,7 +7,7 @@ using UnityModManagerNet;
 
 namespace SolastaCommunityExpansion
 {
-    public class Main
+    public static class Main
     {
         public static bool Enabled { get; set; } = false;
 
@@ -19,8 +19,8 @@ namespace SolastaCommunityExpansion
         internal static void Error(string msg) => Logger?.Error(msg);
         internal static void Warning(string msg) => Logger?.Warning(msg);
         internal static UnityModManager.ModEntry.ModLogger Logger { get; private set; }
-        internal static ModManager<Core, Settings> Mod;
-        internal static MenuManager Menu;
+        internal static ModManager<Core, Settings> Mod { get; private set; }
+        internal static MenuManager Menu { get; private set; }  
         internal static Settings Settings { get { return Mod.Settings; } }
 
         internal static bool Load(UnityModManager.ModEntry modEntry)

--- a/SolastaCommunityExpansion/Models/FeatsContext.cs
+++ b/SolastaCommunityExpansion/Models/FeatsContext.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class FeatsContext
     {
-        public static Dictionary<string, FeatDefinition> Feats = new Dictionary<string, FeatDefinition>();
+        public static Dictionary<string, FeatDefinition> Feats { get; private set; } = new Dictionary<string, FeatDefinition>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Models/FightingStyleContext.cs
+++ b/SolastaCommunityExpansion/Models/FightingStyleContext.cs
@@ -6,7 +6,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class FightingStyleContext
     {
-        public static Dictionary<string, AbstractFightingStyle> Styles = new Dictionary<string, AbstractFightingStyle>();
+        public static Dictionary<string, AbstractFightingStyle> Styles { get; private set; } = new Dictionary<string, AbstractFightingStyle>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
@@ -7,9 +7,9 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class ItemCraftingContext
     {
-        public static Dictionary<string, List<ItemDefinition>> RecipeBooks = new Dictionary<string, List<ItemDefinition>>();
+        public static Dictionary<string, List<ItemDefinition>> RecipeBooks { get; private set; } = new Dictionary<string, List<ItemDefinition>>();
 
-        public static Dictionary<string, string> RecipeTitles = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> RecipeTitles = new Dictionary<string, string>
         {
             { "PrimedItems", "Primed Items" },
             { "EnchantingIngredients", "Enchanting Ingredients" },

--- a/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
+++ b/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
@@ -63,7 +63,7 @@ namespace SolastaCommunityExpansion.Models
                         monster.GuiPresentation.SetSpriteReference(brownBear.GuiPresentation.SpriteReference);
                         monster.SetBestiarySpriteReference(brownBear.BestiarySpriteReference);
                         monster.MonsterPresentation.SetMonsterPresentationDefinitions(brownBear.MonsterPresentation.MonsterPresentationDefinitions);
-                    };
+                    }
 
                     // swap apes for remorhaz
                     if (value.AssetGUID == assetReference_Remorhaz)
@@ -73,7 +73,7 @@ namespace SolastaCommunityExpansion.Models
                         monster.GuiPresentation.SetSpriteReference(ape.GuiPresentation.SpriteReference);
                         monster.SetBestiarySpriteReference(ape.BestiarySpriteReference);
                         monster.MonsterPresentation.SetMonsterPresentationDefinitions(ape.MonsterPresentation.MonsterPresentationDefinitions);
-                    };
+                    }
 
                     // swap wolves for beetles
                     if (value.AssetGUID == assetReference_beetle)
@@ -87,10 +87,8 @@ namespace SolastaCommunityExpansion.Models
                         // changing beetlw scale to suit replacement model
                         monster.MonsterPresentation.SetMaleModelScale(0.655f);
                         monster.MonsterPresentation.SetMaleModelScale(0.655f);
-                    };
-
-                };
-
+                    }
+                }
             }
         }
     }

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class SubclassesContext
     {
-        public static Dictionary<string, AbstractSubclass> Subclasses = new Dictionary<string, AbstractSubclass>();
+        public static Dictionary<string, AbstractSubclass> Subclasses { get; private set; } = new Dictionary<string, AbstractSubclass>();
 
         internal static void Load()
         {

--- a/SolastaCommunityExpansion/Patches/AutoPreparedSpells/SpellsByLevelGroupPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AutoPreparedSpells/SpellsByLevelGroupPatcher.cs
@@ -1,9 +1,11 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.AutoPreparedSpells
 {
     [HarmonyPatch(typeof(SpellsByLevelGroup), "CommonBind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class SpellsByLevelGroup_CommonBind
     {
         /**

--- a/SolastaCommunityExpansion/Patches/CharacterExport/CharacterInspectionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/CharacterInspectionScreenPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.CharacterExport
 {
     // uses this patch to trap the input hotkey and start export process
     [HarmonyPatch(typeof(CharacterInspectionScreen), "HandleInput")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterInspectionScreen_HandleInput
     {
         public static void Prefix(CharacterInspectionScreen __instance, InputCommands.Id command, ref bool __result)

--- a/SolastaCommunityExpansion/Patches/CharacterExport/MessageModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/MessageModalPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using TMPro;
 using UnityEngine.EventSystems;
 using static SolastaCommunityExpansion.Models.CharacterExportContext;
@@ -8,6 +9,7 @@ namespace SolastaCommunityExpansion.Patches.CharacterExport
     // uses this patch to offer an input field when in the context of character export which is set if message content equals to \n\n\n
 
     [HarmonyPatch(typeof(MessageModal), "Show")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class MessageModal_Show
     {
         internal static void Postfix(string content, GuiLabel ___contentLabel)
@@ -33,6 +35,7 @@ namespace SolastaCommunityExpansion.Patches.CharacterExport
     }
 
     [HarmonyPatch(typeof(MessageModal), "OnEndShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class MessageModal_OnEndShow
     {
         internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/CharacterExport/RulesetInventoryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CharacterExport/RulesetInventoryPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.CharacterExport
 {
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.CharacterExport
     // We need to temporarily add the dummy RulesetEntityService and then remove it.
     // We don't want to register it or remove it when the real one has been registered.
     [HarmonyPatch(typeof(RulesetInventory), "SerializeElements")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetInventory_SerializeElements
     {
         static readonly object Locker = new object();

--- a/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Cheats/GameMenuModalPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.Cheats
 {
     // use this patch to enable the cheats window during gameplay
     [HarmonyPatch(typeof(GameMenuModal), "SetButtonAvailability")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameMenuModal_SetButtonAvailability
     {
         internal static void Postfix(GameMenuModal.MenuButtonIndex index, CanvasGroup[] ___buttonCanvases)

--- a/SolastaCommunityExpansion/Patches/Cheats/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Cheats/RulesetCharacterHeroPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static SolastaModApi.DatabaseHelper.QuestTreeDefinitions;
 
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
 {
     // use this patch to enable the No Experience on Level up cheat
     [HarmonyPatch(typeof(RulesetCharacterHero), "CanLevelUp", MethodType.Getter)]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_CanLevelUp
     {
         internal static bool Prefix(RulesetCharacterHero __instance, ref bool __result)
@@ -24,6 +26,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
     }
 
     [HarmonyPatch(typeof(RulesetCharacterHero), "GrantExperience")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_GrantExperience
     {
         internal static void Prefix(ref int experiencePoints)
@@ -45,6 +48,7 @@ namespace SolastaCommunityExpansion.Patches.Cheats
     /// At certain quest specific points the level up must not be scaled.
     /// </summary>
     [HarmonyPatch(typeof(RulesetCharacterHero), "ComputeNeededExperienceToReachLevel")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_ComputeNeededExperienceToReachLevel
     {
         internal static void Postfix(ref int __result)

--- a/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.ClassHoldingFeature
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "FindClassHoldingFeature")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_FindClassHoldingFeature
     {
         internal static void Postfix(

--- a/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/ConditionRemovedOnSourceTurnStart/RulesetActorPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches.ConditionRemovedOnSourceTurnStart
 {
     // Yes, the actual method name has a typo
     [HarmonyPatch(typeof(RulesetActor), "ProcessConditionsMatchingOccurenceType")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetActor_ProcessConditionsMatchingOccurenceType
     {
         internal static void Postfix(RulesetActor __instance, RuleDefinitions.TurnOccurenceType occurenceType)

--- a/SolastaCommunityExpansion/Patches/CustomFightingStyle/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFightingStyle/RulesetCharacterHeroPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.CustomFightingStyle
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "RefreshActiveFightingStyles")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_RefreshActiveFightingStyles
     {
         internal static void Postfix(RulesetCharacterHero __instance)

--- a/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
@@ -3,11 +3,13 @@ using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaCommunityExpansion.Patches.PowerSharedPool;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace SolastaCommunityExpansion.Patches.ConditionalPowers
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "RefreshAll")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_RefreshAll
     {
         internal static void Postfix(RulesetCharacterHero __instance)

--- a/SolastaCommunityExpansion/Patches/FightingStyleFeats/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/FightingStyleFeats/RulesetCharacterHeroPatcher.cs
@@ -1,9 +1,11 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.FightingStyleFeats
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "TrainFeats")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_TrainFeats
     {
         internal static void Postfix(RulesetCharacterHero __instance, List<FeatDefinition> feats)

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class GameManagerPatcher
     {
         [HarmonyPatch(typeof(GameManager), "BindPostDatabase")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameManager_BindPostDatabase_Patch
         {
             internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/BattleState_VictoryUpdatePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/BattleState_VictoryUpdatePatcher.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi
 {
     [HarmonyPatch(typeof(BattleState_Victory), "Update")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class BattleState_VictoryUpdatePatcher
     {
         public static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharacterControlPanelPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(CharacterControlPanel), "OnConfigurationSwitchedHandler")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterControlPanel_OnConfigurationSwitchedHandler
     {
         private static CharacterActionPanel panelToActivate;
@@ -77,6 +79,7 @@ namespace SolastaCommunityExpansion.Patches
                 }
                 else if (__instance is CharacterControlPanelBattle battlePanel)
                 {
+#pragma warning disable S3458 // Empty "case" clauses that fall through to the "default" should be omitted
                     switch (actionId)
                     {
                         case ActionDefinitions.Id.CastMain:
@@ -160,6 +163,7 @@ namespace SolastaCommunityExpansion.Patches
                             panelToActivate = battlePanel.GetField<CharacterActionPanel>("otherActionPanel");
                             break;
                     }
+#pragma warning restore S3458 // Empty "case" clauses that fall through to the "default" should be omitted
                 }
             }
         }

--- a/SolastaCommunityExpansion/Patches/GameUi/EquipmentDefinitions_ScaleAndRoundCostsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/EquipmentDefinitions_ScaleAndRoundCostsPatcher.cs
@@ -1,21 +1,26 @@
 ﻿using HarmonyLib;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
     //Original method - if cost is say '1' and the multiplier is less than one, it ends up as zero.
     //For the Spear it starts out costing 1gp and ends up costing 0gp.
+
+#pragma warning disable S125 // Sections of code should not be commented out
     /*
-    public static void ScaleAndRoundCosts(float priceMultiplier, int[] baseCosts, int[] scaledCosts)
-    {
-        for (int index = 0; index< 5; ++index)
-            scaledCosts[index] = Mathf.RoundToInt(priceMultiplier* (float) baseCosts[index]);
-    }
-    */
+        public static void ScaleAndRoundCosts(float priceMultiplier, int[] baseCosts, int[] scaledCosts)
+        {
+            for (int index = 0; index< 5; ++index)
+                scaledCosts[index] = Mathf.RoundToInt(priceMultiplier* (float) baseCosts[index]);
+        }
+        */
+#pragma warning restore S125 // Sections of code should not be commented out
 
     /// <summary>
     /// </summary>
     [HarmonyPatch(typeof(EquipmentDefinitions), "ScaleAndRoundCosts")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class EquipmentDefinitions_ScaleAndRoundCosts
     {
         internal static bool Prefix(float priceMultiplier, int[] baseCosts, int[] scaledCosts)

--- a/SolastaCommunityExpansion/Patches/GameUi/FeatSubPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/FeatSubPanelPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(FeatSubPanel), "RuntimeLoaded")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class FeatSubPanell_RuntimeLoaded
     {
         internal static void Sort(List<FeatDefinition> relevantFeats)
@@ -20,8 +22,10 @@ namespace SolastaCommunityExpansion.Patches
 
                 if (Main.Settings.EnableFeatsSorting && instruction.opcode == OpCodes.Pop)
                 {
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
                     System.Reflection.FieldInfo relevantFeatsField = typeof(FeatSubPanel).GetField("relevantFeats", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                     System.Reflection.MethodInfo sortMethod = typeof(FeatSubPanell_RuntimeLoaded).GetMethod("Sort", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, relevantFeatsField);

--- a/SolastaCommunityExpansion/Patches/GameUi/FutureFeatureSortingPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/FutureFeatureSortingPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class FutureFeatureSortingPatcher
     {
         [HarmonyPatch(typeof(CharacterStageSubclassSelectionPanel), "FillSubclassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageSubclassSelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterSubclassDefinition subclassDefinition)
@@ -20,6 +22,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(CharacterStageDeitySelectionPanel), "FillSubclassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageDeitySelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterSubclassDefinition currentSubclassDefinition)
@@ -33,6 +36,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(ArchetypesPreviewModal), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class ArchetypesPreviewModal_Bind
         {
             internal static void Postfix(ArchetypesPreviewModal __instance)
@@ -50,6 +54,7 @@ namespace SolastaCommunityExpansion.Patches
         }
 
         [HarmonyPatch(typeof(CharacterStageClassSelectionPanel), "FillClassFeatures")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageClassSelectionPanel_FillSubclassFeatures
         {
             internal static void Prefix(CharacterClassDefinition classDefinition)

--- a/SolastaCommunityExpansion/Patches/GameUi/GameLocationScreenExplorationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/GameLocationScreenExplorationPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     internal static class GameLocationScreenExplorationPatcher
     {
         [HarmonyPatch(typeof(GameLocationScreenExploration), "HandleInput")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameLocationScreenExploration_HandleInput
         {
             internal static bool Prefix(

--- a/SolastaCommunityExpansion/Patches/GameUi/GameTimeSetTimeScalePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/GameTimeSetTimeScalePatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches
@@ -6,6 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     internal static class GameTimeSetTimeScalePatcher
     {
         [HarmonyPatch(typeof(GameTime), "SetTimeScale")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class GameTime_SetTimeScale
         {
             internal static bool Prefix(ref float ___timeScale, ref bool ___fasterTimeMode)

--- a/SolastaCommunityExpansion/Patches/GameUi/HideMonsterHitPoints.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/HideMonsterHitPoints.cs
@@ -15,7 +15,9 @@ namespace SolastaCommunityExpansion.Patches.GameUi
         internal static bool UpdateHealthStatus(this GuiCharacter __instance)
         {
             // call badly named method
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             var rb = typeof(GuiCharacter).GetMethod("HasHealthUpdated", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
             bool retval = false;
 

--- a/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/PowerSelectionPanelPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,6 +14,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line bind
         [HarmonyPatch(typeof(PowerSelectionPanel), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class PowerSelectionPanel_Bind
         {
             internal static void Postfix(PowerSelectionPanel __instance)
@@ -65,6 +67,7 @@ namespace SolastaCommunityExpansion.Patches
 
         // second line unbind
         [HarmonyPatch(typeof(PowerSelectionPanel), "Unbind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class PowerSelectionPanel_Unbind
         {
             internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/GameUi/RulesetCharacterHero_GrantItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/RulesetCharacterHero_GrantItemPatcher.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches
 {
     [HarmonyPatch(typeof(RulesetCharacterHero), "GrantItem")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_GrantItem
     {
         public static void Prefix(ref bool tryToEquip)

--- a/SolastaCommunityExpansion/Patches/GameUi/SubclassSelectionSpacingPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/SubclassSelectionSpacingPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaModApi.Infrastructure;
 using UnityEngine;
 using UnityEngine.UI;
@@ -9,6 +10,7 @@ namespace SolastaUIUpdates.Patches
     internal static class SubclassSelectionSpacingPatcher
     {
         [HarmonyPatch(typeof(CharacterStageSubclassSelectionPanel), "EnterStage")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterStageSubclassSelectionPanel_EnterStage
         {
             public static void Postfix(CharacterStageSubclassSelectionPanel __instance)

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipFeatureRecipeDescriptionPatcher.cs
@@ -1,9 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi
 {
-
     [HarmonyPatch(typeof(TooltipFeatureDescription), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class TooltipFeatureDescription_Bind
     {
         internal static void Postfix(TooltipFeatureDescription __instance, ITooltip tooltip)

--- a/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/TooltipPanelPatcher.cs
@@ -1,10 +1,11 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // always alt
     [HarmonyPatch(typeof(TooltipPanel), "SetupFeatures")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class TooltipPanel_SetupFeatures
     {
         internal static void Prefix(ref TooltipDefinitions.Scope scope)

--- a/SolastaCommunityExpansion/Patches/HeroName/CharacterPoolManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/HeroName/CharacterPoolManagerPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.HeroName
 {
     internal static class CharacterPoolManagerPatcher
     {
         [HarmonyPatch(typeof(CharacterPoolManager), "SaveCharacter")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterPoolManager_SaveCharacter
         {
             public static void Prefix(RulesetCharacterHero heroCharacter, [HarmonyArgument("addToPool")] bool _ = false)

--- a/SolastaCommunityExpansion/Patches/HeroName/CharacterStageIdentityDefinitionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/HeroName/CharacterStageIdentityDefinitionPanelPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using TMPro;
 
 namespace SolastaCommunityExpansion.Patches.HeroName
 {
     [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "EnterStage")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterStageIdentityDefinitionPanel_EnterStage
     {
         public static void Postfix(TMP_InputField ___firstNameInputField, TMP_InputField ___lastNameInputField)
@@ -17,6 +19,7 @@ namespace SolastaCommunityExpansion.Patches.HeroName
     }
 
     [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "RemoveUselessSpaces")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterStageIdentityDefinitionPanel_RemoveUselessSpaces
     {
         public static bool Prefix(TMP_InputField textField)

--- a/SolastaCommunityExpansion/Patches/InitialChoices/GuiFeatDefinitionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/InitialChoices/GuiFeatDefinitionPatcher.cs
@@ -1,17 +1,22 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.InitialChoices
 {
     [HarmonyPatch(typeof(GuiFeatDefinition), "IsFeatMacthingPrerequisites")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GuiFeatDefinition_IsFeatMacthingPrerequisites
     {
+#pragma warning disable S125 // Sections of code should not be commented out
         //internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-        //{
-        //    var code = new List<CodeInstruction>(instructions);
-        //    code.Find(x => x.opcode == OpCodes.Ldc_I4_1).opcode = OpCodes.Ldc_I4_0;
+
+                            //{
+                            //    var code = new List<CodeInstruction>(instructions);
+                            //    code.Find(x => x.opcode == OpCodes.Ldc_I4_1).opcode = OpCodes.Ldc_I4_0;
 
         //    return code;
         //}
+#pragma warning restore S125 // Sections of code should not be commented out
 
         internal static void Postfix(FeatDefinition feat, RulesetCharacterHero hero, ref bool __result)
         {

--- a/SolastaCommunityExpansion/Patches/InventoryManagement/InventoryPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/InventoryManagement/InventoryPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.InventoryManagement
 {
     internal static class InventoryPanelPatcher
     {
         [HarmonyPatch(typeof(InventoryPanel), "Bind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class InventoryPanel_Bind
         {
             internal static void Postfix(InventoryPanel __instance)
@@ -14,6 +16,7 @@ namespace SolastaCommunityExpansion.Patches.InventoryManagement
         }
 
         [HarmonyPatch(typeof(InventoryPanel), "Unbind")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class InventoryPanel_Unbind
         {
             internal static void Prefix(InventoryPanel __instance)

--- a/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     // replaces the hard coded experience
     [HarmonyPatch(typeof(ArchetypesPreviewModal), "Refresh")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class ArchetypesPreviewModal_Refresh
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     // replaces the hard-coded level
     [HarmonyPatch(typeof(CharactersPanel), "Refresh")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharactersPanel_Refresh
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/GameCampaignPartyPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/GameCampaignPartyPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     // replaces the hard-coded level and max experience
     [HarmonyPatch(typeof(GameCampaignParty), "UpdateLevelCaps")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameCampaignParty_UpdateLevelCaps
     {
         internal static bool Prefix(GameCampaignParty __instance)

--- a/SolastaCommunityExpansion/Patches/Level20/HeroDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/HeroDefinitionsPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     // overrides the max experience returned
     [HarmonyPatch(typeof(HeroDefinitions), "MaxHeroExperience")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class HeroDefinitions_MaxHeroExperience
     {
         internal static bool Prefix(ref int __result)

--- a/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     // replaces the hard coded experience
     [HarmonyPatch(typeof(HigherLevelFeaturesModal), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class HigherLevelFeaturesModal_Bind
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
@@ -1,12 +1,14 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches
 {
     // replaces the hard coded experience
     [HarmonyPatch(typeof(RulesetCharacterHero), "RegisterAttributes")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_RegisterAttributes
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
@@ -1,11 +1,13 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {
     [HarmonyPatch(typeof(UserLocationSettingsModal), "OnMinLevelEndEdit")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     public static class UserLocationSettingsModal_OnMinLevelEndEdit
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -27,6 +29,7 @@ namespace SolastaCommunityExpansion.Patches.Level20
     }
 
     [HarmonyPatch(typeof(UserLocationSettingsModal), "OnMaxLevelEndEdit")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     public static class UserLocationSettingsModal_OnMaxLevelEndEdit
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/LoadFixers/GameLoreManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/LoadFixers/GameLoreManagerPatcher.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.LoadFixers
 {
     [HarmonyPatch(typeof(GameLoreManager), "SerializeElements")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameLoreManager_SerializeElements
     {
         // If a recipe can't be found in the database but was previously known, the serialization

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetActorPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
 {
     [HarmonyPatch(typeof(RulesetActor), "RemoveCondition")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetActor_RemoveCondition
     {
         internal static void Postfix(RulesetActor __instance, RulesetCondition rulesetCondition)

--- a/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NotifyConditionRemoval/RulesetCharacterPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.NotifyConditionRemoval
 {
     [HarmonyPatch(typeof(RulesetCharacter), "Kill")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacter_Kill
     {
         internal static void Prefix(RulesetCharacter __instance)

--- a/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/OnAttackEffects/GameLocationBattleManagerPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.OnAttackEffects
 {
     [HarmonyPatch(typeof(GameLocationBattleManager), "HandleCharacterAttackDamage")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameLocationBattleManager_HandleCharacterAttackDamage
     {
         internal static void Postfix(GameLocationCharacter attacker,
@@ -16,6 +18,7 @@ namespace SolastaCommunityExpansion.Patches.OnAttackEffects
             {
                 return;
             }
+
             List<FeatureDefinition> features = new List<FeatureDefinition>();
             attacker.RulesetCharacter.EnumerateFeaturesToBrowse<IOnAttackHitEffect>(features);
 

--- a/SolastaCommunityExpansion/Patches/PointBuy/AttributeDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PointBuy/AttributeDefinitionsPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.PointBuy
 {
     // extends the cost buy table
     [HarmonyPatch(typeof(AttributeDefinitions), "ComputeCostToRaiseAbility")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class AttributeDefinitions_ComputeCostToRaiseAbility 
     {
         internal static void Postfix(int previousValue, ref int __result)

--- a/SolastaCommunityExpansion/Patches/PointBuy/CharacterStageAbilityScoresPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PointBuy/CharacterStageAbilityScoresPanelPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using HarmonyLib;
 
@@ -7,6 +8,7 @@ namespace SolastaCommunityExpansion.Patches.PointBuy
 {
     // enables epic points
     [HarmonyPatch(typeof(CharacterStageAbilityScoresPanel), "Reset")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameManager_Reset
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -34,6 +36,7 @@ namespace SolastaCommunityExpansion.Patches.PointBuy
 
     // enables epic points
     [HarmonyPatch(typeof(CharacterStageAbilityScoresPanel), "Refresh")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameManager_Refresh
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/SolastaCommunityExpansion/Patches/PowerSharedPool/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PowerSharedPool/RulesetCharacterPatcher.cs
@@ -2,6 +2,7 @@
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.PowerSharedPool
@@ -9,6 +10,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
     internal static class RulesetCharacterPatcher
     {
         [HarmonyPatch(typeof(RulesetCharacter), "UsePower")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_UsePower
         {
             public static void Postfix(RulesetCharacter __instance, RulesetUsablePower usablePower)
@@ -18,6 +20,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "RepayPowerUse")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_RepayPowerUse
         {
             public static void Postfix(RulesetCharacter __instance, RulesetUsablePower usablePower)
@@ -47,6 +50,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "GrantPowers")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_GrantPowers
         {
             public static void Postfix(RulesetCharacter __instance)
@@ -56,6 +60,7 @@ namespace SolastaCommunityExpansion.Patches.PowerSharedPool
         }
 
         [HarmonyPatch(typeof(RulesetCharacter), "ApplyRest")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class RulesetCharacter_ApplyRest
         {
             internal static void Postfix(

--- a/SolastaCommunityExpansion/Patches/Respec/CharacterEditionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/CharacterEditionScreenPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.Respec
 {
     // use this patch to track if Respec was aborted
     [HarmonyPatch(typeof(CharacterEditionScreen), "DoAbort")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterEditionScreen_DoAbort
     {
         internal static void Postfix()

--- a/SolastaCommunityExpansion/Patches/Respec/CharacterStageAbilityScoresPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/CharacterStageAbilityScoresPanelPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.Respec
 {
     // use this patch to avoid issues during RESPEC if a hero with same name is in the pool
     [HarmonyPatch(typeof(CharacterStageIdentityDefinitionPanel), "CanProceedToNextStage")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterStageIdentityDefinitionPanel_CanProceedToNextStage
     {
         internal static void Postfix(CharacterStageIdentityDefinitionPanel __instance, ref bool __result)

--- a/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
@@ -1,10 +1,12 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.Respec
 {
     // use this patch to enable the after rest actions
     [HarmonyPatch(typeof(RulesetCharacterHero), "EnumerateAfterRestActions")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_EnumerateAfterRestActions
     {
         internal static void Postfix(RuleDefinitions.RestType restType, List<RestActivityDefinition> ___afterRestActions)

--- a/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/StartOfTurnRecharge/RulesetCharacterPatcher.cs
@@ -1,9 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.StartOfTurnRecharge
 {
     [HarmonyPatch(typeof(RulesetCharacter), "RechargePowersForTurnStart")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacter_RechargePowersForTurnStart
     {
         internal static void Postfix(RulesetCharacter __instance)

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -117,7 +117,7 @@ namespace SolastaCommunityExpansion
         /* Character Export hotkey */
         public const InputCommands.Id CTRL_E = (InputCommands.Id)44440004;
 
-        public const RestActivityDefinition.ActivityCondition ActivityConditionCanRespec = (RestActivityDefinition.ActivityCondition)(int)-1001;
+        public const RestActivityDefinition.ActivityCondition ActivityConditionCanRespec = (RestActivityDefinition.ActivityCondition)(-1001);
 
         public bool EnableRespec = false;
 

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -509,7 +509,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
 
         // Helper classes
 
-        private class IlluminatedConditionDefinition : ConditionDefinition, IConditionRemovedOnSourceTurnStart, INotifyConditionRemoval
+        private sealed class IlluminatedConditionDefinition : ConditionDefinition, IConditionRemovedOnSourceTurnStart, INotifyConditionRemoval
         {
             public void AfterConditionRemoved(RulesetActor removedFrom, RulesetCondition rulesetCondition)
             {
@@ -522,7 +522,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             }
         }
 
-        private class IlluminatedByBurstConditionDefinition : ConditionDefinition, INotifyConditionRemoval
+        private sealed class IlluminatedByBurstConditionDefinition : ConditionDefinition, INotifyConditionRemoval
         {
             public void AfterConditionRemoved(RulesetActor removedFrom, RulesetCondition rulesetCondition)
             {
@@ -535,13 +535,13 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             }
         }
 
-        private class IlluminatingStrikeAdditionalDamage : FeatureDefinitionAdditionalDamage, IClassHoldingFeature
+        private sealed class IlluminatingStrikeAdditionalDamage : FeatureDefinitionAdditionalDamage, IClassHoldingFeature
         {
             // Allows Illuminating Strike damage to scale with barbarian level
             public CharacterClassDefinition Class => DatabaseHelper.CharacterClassDefinitions.Barbarian;
         }
 
-        private class IlluminatingStrikeFeatureBuilder : BaseDefinitionBuilder<IlluminatingStrikeAdditionalDamage>
+        private sealed class IlluminatingStrikeFeatureBuilder : BaseDefinitionBuilder<IlluminatingStrikeAdditionalDamage>
         {
             public IlluminatingStrikeFeatureBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition) : base(name, guid)
             {
@@ -638,7 +638,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
         /// <summary>
         /// Builds the power that enables Illuminating Strike while you're raging.
         /// </summary>
-        private class IlluminatingStrikeInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        private sealed class IlluminatingStrikeInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
         {
             public IlluminatingStrikeInitiatorBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition) : base(name, guid)
             {
@@ -716,12 +716,12 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             }
         }
 
-        private class IlluminatingBurstPower : FeatureDefinitionPower, IStartOfTurnRecharge
+        private sealed class IlluminatingBurstPower : FeatureDefinitionPower, IStartOfTurnRecharge
         {
             public bool IsRechargeSilent => true;
         }
 
-        private class IlluminatingBurstBuilder : BaseDefinitionBuilder<IlluminatingBurstPower>
+        private sealed class IlluminatingBurstBuilder : BaseDefinitionBuilder<IlluminatingBurstPower>
         {
             public IlluminatingBurstBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatedCondition, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
             {
@@ -852,7 +852,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
         /// <summary>
         /// Builds the power that enables Illuminating Burst on the turn you enter a rage (by removing the condition disabling it).
         /// </summary>
-        private class IlluminatingBurstInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        private sealed class IlluminatingBurstInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
         {
             public IlluminatingBurstInitiatorBuilder(string name, string guid, string description, string title, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Fighter/SpellShield.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/SpellShield.cs
@@ -121,7 +121,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             Subclass = spellShield.AddToDB();
         }
 
-        private class SpellShieldRangedDeflection : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+        private sealed class SpellShieldRangedDeflection : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
         {
             public SpellShieldRangedDeflection(FeatureDefinitionActionAffinity original, string name, string guid, GuiPresentation guiPresentation) : base(original, name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -21,12 +21,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
     }
 
-    internal class KnockDownPowerBuilder
+    internal static class KnockDownPowerBuilder
     {
         private const string KnockDownPowerName = "KnockDownPower";
         private const string KnockDownPowerNameGuid = "90dd5e81-40d7-4824-89b4-45bcf4c05218";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon?  This doesn't seem possible
             EffectForm damageEffect = new EffectForm
@@ -77,12 +77,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(KnockDownPowerName, KnockDownPowerNameGuid);
     }
 
-    internal class InspirePowerBuilder
+    internal static class InspirePowerBuilder
     {
         private const string InspirePowerName = "InspirePower";
         private const string InspirePowerNameGuid = "163c28de-48e5-4f75-bdd0-d42374a75ef8";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the temp hp form
             EffectForm healingEffect = new EffectForm
@@ -133,12 +133,12 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(InspirePowerName, InspirePowerNameGuid);
     }
 
-    internal class CounterStrikePowerBuilder
+    internal static class CounterStrikePowerBuilder
     {
         private const string CounterStrikePowerName = "CounterStrikePower";
         private const string CounterStrikePowerNameGuid = "88c294ce-14fa-4f7e-8b81-ea4d289e3d8b";
 
-        protected static FeatureDefinitionPowerSharedPool Build(string name, string guid)
+        public static FeatureDefinitionPowerSharedPool Build(string name, string guid)
         {
             //Create the damage form - TODO make it do the same damage as the wielded weapon (seems impossible with current tools, would need to use the AdditionalDamage feature but I'm not sure how to combine that with this to make it a reaction ability).
             EffectForm damageEffect = new EffectForm
@@ -172,7 +172,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             => Build(CounterStrikePowerName, CounterStrikePowerNameGuid);
     }
 
-    internal class GambitResourcePoolBuilder
+    internal static class GambitResourcePoolBuilder
     {
         private const string GambitResourcePoolName = "GambitResourcePool";
         private const string GambitResourcePoolNameGuid = "00da2b27-139a-4ca0-a285-aaa70d108bc8";
@@ -183,7 +183,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 new GuiPresentationBuilder("Feature/&GambitResourcePoolDescription", "Feature/&GambitResourcePoolTitle").Build()).AddToDB();
     }
 
-    internal class GambitResourcePoolAddBuilder
+    internal static class GambitResourcePoolAddBuilder
     {
         private const string GambitResourcePoolAddName = "GambitResourcePoolAdd";
         private const string GambitResourcePoolAddNameGuid = "056d786a-2611-4981-a652-704fa5056375";

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -111,7 +111,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
                 FeatureDefinitionFeatureSet.FeatureSetMode.Union, arcanistMagicGui).AddToDB();
         }
 
-        private class FeatureDefinitionAutoPreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+        private sealed class FeatureDefinitionAutoPreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
         {
             public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid, List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists,
             CharacterClassDefinition characterclass, GuiPresentation guiPresentation) : base(name, guid)
@@ -122,7 +122,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
             }
         }
 
-        private class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+        private sealed class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
         {
             public FeatureDefinitionFeatureSetBuilder(string name, string guid, List<FeatureDefinition> features,
                 FeatureDefinitionFeatureSet.FeatureSetMode mode, GuiPresentation guiPresentation) : base(name, guid)
@@ -221,7 +221,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
             return blank_feature;
         }
 
-        private class FeatureDefinitionBuilder : BaseDefinitionBuilder<FeatureDefinition>
+        private sealed class FeatureDefinitionBuilder : BaseDefinitionBuilder<FeatureDefinition>
         {
             public FeatureDefinitionBuilder(string name, string guid, GuiPresentation guiPresentation) : base(name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -82,7 +82,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             feintBuilder.AddEffectForm(new EffectFormBuilder().CreatedByCharacter().SetConditionForm(new AdvantageBuilder("RogueConArtistFeintCondition",
                 GuidHelper.Create(SubclassNamespace, "RogueConArtistFeintCondition").ToString(),
                 DatabaseHelper.ConditionDefinitions.ConditionTrueStrike, feintGuiCondition.Build()).AddToDB(), ConditionForm.ConditionOperation.Add,
-                false, false, new List<ConditionDefinition>()).Build()); ;
+                false, false, new List<ConditionDefinition>()).Build());
             //feintBuilder.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.))
             FeatureDefinitionPower feint = new FeatureDefinitionPowerBuilder("RoguishConArtistFeint", GuidHelper.Create(SubclassNamespace, "RoguishConArtistFeint").ToString(),
                 0, RuleDefinitions.UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Charisma, RuleDefinitions.ActivationTime.BonusAction, 0, RuleDefinitions.RechargeRate.AtWill,

--- a/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
@@ -5,7 +5,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class CreditsDisplay
     {
-        internal static Dictionary<string, string> CreditsTable = new Dictionary<string, string>
+        internal static readonly Dictionary<string, string> CreditsTable = new Dictionary<string, string>
         {
             { "ChrisJohnDigital".orange().bold(), "head developer, feats, items, subclasses, progression, etc." },
             { "Zappastuff", "mod UI work, integration, community organization, level 20, respec" },


### PR DESCRIPTION
Suppress warnings about non-Pascal casing on patch classes.
Add readonly, static etc where required.
Make some fields properties.