### PR TITLE
Combat surprise

### DIFF
--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -55,13 +55,22 @@ namespace SolastaCommunityExpansion.Models
                     {
                         if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
                         {
-                            int perceptionOnTarget = surprisedCharacter.ComputePassivePerceptionOnTarget(surprisingCharacter, out bool _);
+                            int perceptionOnTarget = SURPRISE_CHECK_DC_BASE;
+                            
+                            if (surprisedCharacter.RulesetCharacter is RulesetCharacterMonster monster)
+                            {
+                                perceptionOnTarget = monster.MonsterDefinition.ComputePassivePerceptionScore();
+                            }
+                            else if (surprisedCharacter.RulesetCharacter is RulesetCharacterHero hero)
+                            {
+                                perceptionOnTarget = hero.ComputePassivePerception();
+                            }
 
-                            surprisingCharacter.RollAbilityCheck("Dexterity", "Stealth", SURPRISE_CHECK_DC_BASE + perceptionOnTarget, RuleDefinitions.AdvantageType.None, new ActionModifier(), false, -1, out RuleDefinitions.RollOutcome outcome, true);
+                            surprisingCharacter.RollAbilityCheck("Dexterity", "Stealth", perceptionOnTarget, RuleDefinitions.AdvantageType.None, new ActionModifier(), false, -1, out RuleDefinitions.RollOutcome outcome, true);
 
                             if (outcome == RuleDefinitions.RollOutcome.CriticalFailure || outcome == RuleDefinitions.RollOutcome.Failure)
                             {
-                                var conditionUnsurprised = UnityEngine.Object.Instantiate(DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionUnsurprised"));
+                                var conditionUnsurprised = DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionUnsurprised");
 
                                 surprisedCharacter.RulesetCharacter.AddConditionOfCategory("10Combat", RulesetCondition.CreateActiveCondition(surprisedCharacter.RulesetCharacter.Guid, conditionUnsurprised, RuleDefinitions.DurationType.Round, 0, RuleDefinitions.TurnOccurenceType.EndOfTurn, 0UL, string.Empty));
                                 isReallySurprised = false;

--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -10,15 +10,15 @@ namespace SolastaCommunityExpansion.Models
         internal static void Load()
         {
             var dbConditionDefinition = DatabaseRepository.GetDatabase<ConditionDefinition>();
-            var conditionUnsurprised = UnityEngine.Object.Instantiate(dbConditionDefinition.GetElement("ConditionSurprised"));
+            var conditionAware = UnityEngine.Object.Instantiate(dbConditionDefinition.GetElement("ConditionSurprised"));
 
-            conditionUnsurprised.name = "ConditionUnsurprised";
-            conditionUnsurprised.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(Settings.GUID), conditionUnsurprised.name).ToString());
-            conditionUnsurprised.GuiPresentation.SetTitle("Rules/&ConditionUnsurprisedTitle");
-            conditionUnsurprised.GuiPresentation.SetDescription("Rules/&ConditionUnsurprisedDescription");
-            conditionUnsurprised.Features.Clear();
+            conditionAware.name = "ConditionAware";
+            conditionAware.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(Settings.GUID), conditionAware.name).ToString());
+            conditionAware.GuiPresentation.SetTitle("Rules/&ConditionAwareTitle");
+            conditionAware.GuiPresentation.SetDescription("Rules/&ConditionAwareDescription");
+            conditionAware.Features.Clear();
 
-            dbConditionDefinition.Add(conditionUnsurprised);
+            dbConditionDefinition.Add(conditionAware);
         }
 
         internal static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
@@ -69,9 +69,9 @@ namespace SolastaCommunityExpansion.Models
 
                             if (outcome == RuleDefinitions.RollOutcome.CriticalFailure || outcome == RuleDefinitions.RollOutcome.Failure)
                             {
-                                var conditionUnsurprised = DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionUnsurprised");
+                                var conditionAware = DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionAware");
 
-                                surprisedCharacter.RulesetCharacter.AddConditionOfCategory("10Combat", RulesetCondition.CreateActiveCondition(surprisedCharacter.RulesetCharacter.Guid, conditionUnsurprised, RuleDefinitions.DurationType.Round, 0, RuleDefinitions.TurnOccurenceType.EndOfTurn, 0UL, string.Empty));
+                                surprisedCharacter.RulesetCharacter.AddConditionOfCategory("10Combat", RulesetCondition.CreateActiveCondition(surprisedCharacter.RulesetCharacter.Guid, conditionAware, RuleDefinitions.DurationType.Round, 0, RuleDefinitions.TurnOccurenceType.EndOfTurn, 0UL, string.Empty));
                                 isReallySurprised = false;
 
                                 break;

--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using SolastaModApi.Extensions;
+﻿using SolastaModApi.Extensions;
+using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
 
@@ -7,11 +7,10 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class SrdAndHouseRulesContext
     {
-        private const int SURPRISE_CHECK_DC_BASE = 10;
-
         internal static void Load()
         {
-            var conditionUnsurprised = UnityEngine.Object.Instantiate(DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionSurprised"));
+            var dbConditionDefinition = DatabaseRepository.GetDatabase<ConditionDefinition>();
+            var conditionUnsurprised = UnityEngine.Object.Instantiate(dbConditionDefinition.GetElement("ConditionSurprised"));
 
             conditionUnsurprised.name = "ConditionUnsurprised";
             conditionUnsurprised.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(Settings.GUID), conditionUnsurprised.name).ToString());
@@ -19,7 +18,7 @@ namespace SolastaCommunityExpansion.Models
             conditionUnsurprised.GuiPresentation.SetDescription("Rules/&ConditionUnsurprisedDescription");
             conditionUnsurprised.Features.Clear();
 
-            DatabaseRepository.GetDatabase<ConditionDefinition>().Add(conditionUnsurprised);
+            dbConditionDefinition.Add(conditionUnsurprised);
         }
 
         internal static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
@@ -55,7 +54,7 @@ namespace SolastaCommunityExpansion.Models
                     {
                         if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
                         {
-                            int perceptionOnTarget = SURPRISE_CHECK_DC_BASE;
+                            int perceptionOnTarget = 0;
                             
                             if (surprisedCharacter.RulesetCharacter is RulesetCharacterMonster monster)
                             {

--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -1,24 +1,34 @@
-﻿using SolastaModApi.Extensions;
+﻿using SolastaModApi;
 using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
 
 namespace SolastaCommunityExpansion.Models
 {
+    internal class AwareConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    {
+        internal const string ConditionAwareName = "ZSConditionAware";
+        private const string ConditionAwareGuid = "21163c80aa4b459892d8e066badc0b81";
+
+        protected AwareConditionBuilder(string name, string guid) : base(ConditionSurprised, name, guid)
+        {
+            Definition.Features.Clear();
+            Definition.GuiPresentation.Description = "Rules/&ConditionAwareDescription";
+            Definition.GuiPresentation.Title = "Rules/&ConditionAwareTitle";
+        }
+
+        private static ConditionDefinition CreateAndAddToDB(string name, string guid)
+            => new AwareConditionBuilder(name, guid).AddToDB();
+
+        internal static readonly ConditionDefinition AwareCondition =
+            CreateAndAddToDB(ConditionAwareName, ConditionAwareGuid);
+    }
+
     internal static class SrdAndHouseRulesContext
     {
         internal static void Load()
         {
-            var dbConditionDefinition = DatabaseRepository.GetDatabase<ConditionDefinition>();
-            var conditionAware = UnityEngine.Object.Instantiate(dbConditionDefinition.GetElement("ConditionSurprised"));
-
-            conditionAware.name = "ConditionAware";
-            conditionAware.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(Settings.GUID), conditionAware.name).ToString());
-            conditionAware.GuiPresentation.SetTitle("Rules/&ConditionAwareTitle");
-            conditionAware.GuiPresentation.SetDescription("Rules/&ConditionAwareDescription");
-            conditionAware.Features.Clear();
-
-            dbConditionDefinition.Add(conditionAware);
+            _ = AwareConditionBuilder.AwareCondition;
         }
 
         internal static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
@@ -103,7 +113,7 @@ namespace SolastaCommunityExpansion.Models
                 // adds a dummy Aware condition for a better Game Console description on what is happening
                 if (!reallySurprised)
                 {
-                    var conditionAwareDefinition = DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionAware");
+                    var conditionAwareDefinition = DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement(AwareConditionBuilder.ConditionAwareName);
                     var conditionAware = RulesetCondition.CreateActiveCondition(surprisedCharacter.RulesetCharacter.Guid, conditionAwareDefinition, RuleDefinitions.DurationType.Round, 0, RuleDefinitions.TurnOccurenceType.EndOfTurn, 0, string.Empty);
                     
                     surprisedCharacter.RulesetCharacter.AddConditionOfCategory("10Combat", conditionAware);

--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -1,11 +1,28 @@
-﻿using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
+﻿using System.Collections.Generic;
+using SolastaModApi.Extensions;
+using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
 
 namespace SolastaCommunityExpansion.Models
 {
     internal static class SrdAndHouseRulesContext
     {
-        public static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
+        private const int SURPRISE_CHECK_DC_BASE = 10;
+
+        internal static void Load()
+        {
+            var conditionUnsurprised = UnityEngine.Object.Instantiate(DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionSurprised"));
+
+            conditionUnsurprised.name = "ConditionUnsurprised";
+            conditionUnsurprised.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(Settings.GUID), conditionUnsurprised.name).ToString());
+            conditionUnsurprised.GuiPresentation.SetTitle("Rules/&ConditionUnsurprisedTitle");
+            conditionUnsurprised.GuiPresentation.SetDescription("Rules/&ConditionUnsurprisedDescription");
+            conditionUnsurprised.Features.Clear();
+
+            DatabaseRepository.GetDatabase<ConditionDefinition>().Add(conditionUnsurprised);
+        }
+
+        internal static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
         {
             // Use the shocked condition affinity which has the desired effect
             if (Main.Settings.EnableConditionBlindedShouldNotAllowOpportunityAttack)
@@ -21,6 +38,41 @@ namespace SolastaCommunityExpansion.Models
                 {
                     ConditionBlinded.Features.Remove(ActionAffinityConditionShocked);
                 }
+            }
+        }
+
+        internal static void StartContenders(bool surprised, List<GameLocationCharacter> surprisedParty, List<GameLocationCharacter> surprisingParty)
+        {
+            var gameLocationBattleService = ServiceRepository.GetService<IGameLocationBattleService>();
+
+            foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
+            {
+                var isReallySurprised = true;
+
+                if (surprised)
+                {
+                    foreach (GameLocationCharacter surprisingCharacter in surprisingParty)
+                    {
+                        if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
+                        {
+                            int perceptionOnTarget = surprisedCharacter.ComputePassivePerceptionOnTarget(surprisingCharacter, out bool _);
+
+                            surprisingCharacter.RollAbilityCheck("Dexterity", "Stealth", SURPRISE_CHECK_DC_BASE + perceptionOnTarget, RuleDefinitions.AdvantageType.None, new ActionModifier(), false, -1, out RuleDefinitions.RollOutcome outcome, true);
+
+                            if (outcome == RuleDefinitions.RollOutcome.CriticalFailure || outcome == RuleDefinitions.RollOutcome.Failure)
+                            {
+                                var conditionUnsurprised = UnityEngine.Object.Instantiate(DatabaseRepository.GetDatabase<ConditionDefinition>().GetElement("ConditionUnsurprised"));
+
+                                surprisedCharacter.RulesetCharacter.AddConditionOfCategory("10Combat", RulesetCondition.CreateActiveCondition(surprisedCharacter.RulesetCharacter.Guid, conditionUnsurprised, RuleDefinitions.DurationType.Round, 0, RuleDefinitions.TurnOccurenceType.EndOfTurn, 0UL, string.Empty));
+                                isReallySurprised = false;
+
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                surprisedCharacter.StartBattle(surprised && isReallySurprised);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -1,9 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
-using SolastaCommunityExpansion.Feats;
 using SolastaCommunityExpansion.Models;
-using SolastaCommunityExpansion.Subclasses.Rogue;
-using SolastaCommunityExpansion.Subclasses.Wizard;
 
 namespace SolastaCommunityExpansion.Patches
 {

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -12,7 +12,6 @@ namespace SolastaCommunityExpansion.Patches
             internal static void Postfix()
             {
                 Models.BugFixContext.Load();
-
                 Models.AdditionalNamesContext.Load();
                 Models.AsiAndFeatContext.Load();
                 Models.InitialChoicesContext.Load();
@@ -35,6 +34,7 @@ namespace SolastaCommunityExpansion.Patches
                 Models.CharacterExportContext.Load();
                 Models.InventoryManagementContext.Load();
                 Models.RemoveBugVisualModelsContext.Load();
+                Models.SrdAndHouseRulesContext.Load();
 
                 Main.Enabled = true;
             }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/GameLocationBattlePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/GameLocationBattlePatcher.cs
@@ -1,7 +1,7 @@
 ﻿using HarmonyLib;
 using System.Diagnostics.CodeAnalysis;
 
-namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
+namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 {
     [HarmonyPatch(typeof(GameLocationBattle), "StartContenders")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RuleDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RuleDefinitionsPatcher.cs
@@ -1,10 +1,10 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static RuleDefinitions;
 
-namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
+namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 {
     [HarmonyPatch(typeof(RuleDefinitions), "ComputeAdvantage")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
@@ -1,0 +1,63 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
+{
+    [HarmonyPatch(typeof(GameLocationBattle), "StartContenders")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameLocationBattle_StartContenders
+    {
+        internal static bool Prefix(GameLocationBattle __instance, bool partySurprised, bool enemySurprised)
+        {
+            if (Main.Settings.EnableSRDCombatSurpriseRules && (partySurprised || enemySurprised))
+            {
+                StartContenders(partySurprised, __instance.PlayerContenders, __instance.EnemyContenders);
+                StartContenders(enemySurprised, __instance.EnemyContenders, __instance.PlayerContenders);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        internal static void StartContenders(bool surprised, List<GameLocationCharacter> surprisedParty, List<GameLocationCharacter> surprisingParty)
+        {
+            var gameLocationBattleService = ServiceRepository.GetService<IGameLocationBattleService>();
+
+            if (surprised)
+            {
+                foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
+                {
+                    var isReallySurprised = true;
+
+                    foreach (GameLocationCharacter surprisingCharacter in surprisingParty)
+                    {
+                        if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
+                        {
+                            int perceptionOnTarget = surprisedCharacter.ComputePassivePerceptionOnTarget(surprisingCharacter, out bool _);
+
+                            surprisingCharacter.RollAbilityCheck("Dexterity", "Stealth", perceptionOnTarget, RuleDefinitions.AdvantageType.None, new ActionModifier(), false, -1, out RuleDefinitions.RollOutcome outcome, true);
+
+                            if (outcome == RuleDefinitions.RollOutcome.CriticalFailure || outcome == RuleDefinitions.RollOutcome.Failure)
+                            {
+                                isReallySurprised = false;
+
+                                break;
+                            }
+                        }
+                    }
+
+                    surprisedCharacter.StartBattle(isReallySurprised);
+                }
+            }
+            else
+            {
+                foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
+                {
+                    surprisedCharacter.StartBattle(surprised);
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
@@ -12,8 +11,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
         {
             if (Main.Settings.EnableSRDCombatSurpriseRules && (partySurprised || enemySurprised))
             {
-                StartContenders(partySurprised, __instance.PlayerContenders, __instance.EnemyContenders);
-                StartContenders(enemySurprised, __instance.EnemyContenders, __instance.PlayerContenders);
+                Models.SrdAndHouseRulesContext.StartContenders(partySurprised, __instance.PlayerContenders, __instance.EnemyContenders);
+                Models.SrdAndHouseRulesContext.StartContenders(enemySurprised, __instance.EnemyContenders, __instance.PlayerContenders);
 
                 return false;
             }
@@ -21,36 +20,6 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
             return true;
         }
 
-        internal static void StartContenders(bool surprised, List<GameLocationCharacter> surprisedParty, List<GameLocationCharacter> surprisingParty)
-        {
-            var gameLocationBattleService = ServiceRepository.GetService<IGameLocationBattleService>();
-
-            foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
-            {
-                var isReallySurprised = true;
-
-                if (surprised)
-                {
-                    foreach (GameLocationCharacter surprisingCharacter in surprisingParty)
-                    {
-                        if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
-                        {
-                            int perceptionOnTarget = surprisedCharacter.ComputePassivePerceptionOnTarget(surprisingCharacter, out bool _);
-
-                            surprisingCharacter.RollAbilityCheck("Dexterity", "Stealth", perceptionOnTarget, RuleDefinitions.AdvantageType.None, new ActionModifier(), false, -1, out RuleDefinitions.RollOutcome outcome, true);
-
-                            if (outcome == RuleDefinitions.RollOutcome.CriticalFailure || outcome == RuleDefinitions.RollOutcome.Failure)
-                            {
-                                isReallySurprised = false;
-
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                surprisedCharacter.StartBattle(surprised && isReallySurprised);
-            }
-        }
+       
     }
 }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRulesContext/GameLocationBattlePatcher.cs
@@ -25,12 +25,12 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
         {
             var gameLocationBattleService = ServiceRepository.GetService<IGameLocationBattleService>();
 
-            if (surprised)
+            foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
             {
-                foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
-                {
-                    var isReallySurprised = true;
+                var isReallySurprised = true;
 
+                if (surprised)
+                {
                     foreach (GameLocationCharacter surprisingCharacter in surprisingParty)
                     {
                         if (gameLocationBattleService.CanAttackerSeeCharacterFromPosition(surprisingCharacter.LocationPosition, surprisedCharacter.LocationPosition, surprisingCharacter, surprisedCharacter))
@@ -47,16 +47,9 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRulesContext
                             }
                         }
                     }
+                }
 
-                    surprisedCharacter.StartBattle(isReallySurprised);
-                }
-            }
-            else
-            {
-                foreach (GameLocationCharacter surprisedCharacter in surprisedParty)
-                {
-                    surprisedCharacter.StartBattle(surprised);
-                }
+                surprisedCharacter.StartBattle(surprised && isReallySurprised);
             }
         }
     }

--- a/SolastaCommunityExpansion/Repository.json
+++ b/SolastaCommunityExpansion/Repository.json
@@ -3,8 +3,8 @@
 	[
 		{
 			"Id": "SolastaCommunityExpansion",
-			"Version": "1.2.15.1",
-			"DownloadUrl": "https://github.com/ChrisPJohn/SolastaCommunityExpansion/releases/download/1.2.15.1/SolastaCommunityExpansion.zip"
+			"Version": "1.2.15.2",
+			"DownloadUrl": "https://github.com/ChrisPJohn/SolastaCommunityExpansion/releases/download/1.2.15.2/SolastaCommunityExpansion.zip"
 		}
 	]
 }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -145,6 +145,7 @@ namespace SolastaCommunityExpansion
         public bool NoAttunement { get; set; }
 
         public bool EnableSRDAdvantageRules { get; set; }
+        public bool EnableSRDCombatSurpriseRules { get; set; }
         public bool EnableConditionBlindedShouldNotAllowOpportunityAttack { get; set; }
         public bool AllowExtraKeyboardCharactersInNames { get; set; }
         public bool DruidNoMetalRestriction { get; set; }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -108,6 +108,7 @@ namespace SolastaCommunityExpansion
 
         public bool EnableSRDAdvantageRules { get; set; }
         public bool EnableSRDCombatSurpriseRules { get; set; }
+        public bool EnableSRDCombatSurpriseRulesManyRolls { get; set; }
         public bool EnableConditionBlindedShouldNotAllowOpportunityAttack { get; set; }
         public bool AllowExtraKeyboardCharactersInNames { get; set; }
         public bool DruidNoMetalRestriction { get; set; }

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -614,5 +614,5 @@ Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerDescription	Up to three e
 Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerTitle	Illuminating Burst
 Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeLine	Illuminating Strike deals extra damage to the target!
 Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeFormat Illuminating Strike!
-Rules/&ConditionUnsurprisedDescription	was surprised but succeed on a perception check.
-Rules/&ConditionUnsurprisedTitle	no longer surprised
+Rules/&ConditionAwareDescription	was surprised but is now aware after succeeding on a perception check.
+Rules/&ConditionAwareTitle	Aware

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -614,3 +614,5 @@ Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerDescription	Up to three e
 Subclass/&BarbarianPathOfTheLightIlluminatingBurstPowerTitle	Illuminating Burst
 Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeLine	Illuminating Strike deals extra damage to the target!
 Feedback/&AdditionalDamageBarbarianPathOfTheLightIlluminatingStrikeFormat Illuminating Strike!
+Rules/&ConditionUnsurprisedDescription	was surprised but succeed on a perception check.
+Rules/&ConditionUnsurprisedTitle	no longer surprised

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -13,10 +13,10 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("SRD:".yellow());
             UI.Label("");
 
-            toggle = Main.Settings.EnableSRDSurpriseChecks;
+            toggle = Main.Settings.EnableSRDCombatSurpriseRules;
             if (UI.Toggle("Uses official combat surprise rules", ref toggle, UI.AutoWidth()))
             {
-                Main.Settings.EnableSRDSurpriseChecks = toggle;
+                Main.Settings.EnableSRDCombatSurpriseRules = toggle;
             }
 
             toggle = Main.Settings.EnableSRDAdvantageRules;

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -13,17 +13,29 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("SRD:".yellow());
             UI.Label("");
 
-            toggle = Main.Settings.EnableSRDCombatSurpriseRules;
-            if (UI.Toggle("Uses official combat surprise rules", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.EnableSRDCombatSurpriseRules = toggle;
-            }
-
             toggle = Main.Settings.EnableSRDAdvantageRules;
             if (UI.Toggle("Uses official advantage / disadvantage rules", ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.EnableSRDAdvantageRules = toggle;
             }
+
+            toggle = Main.Settings.EnableSRDCombatSurpriseRules;
+            if (UI.Toggle("Uses official combat surprise rules", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableSRDCombatSurpriseRules = toggle;
+                Main.Settings.EnableSRDCombatSurpriseRulesManyRolls = toggle; // makes many rolls default
+            }
+
+            if (Main.Settings.EnableSRDCombatSurpriseRules)
+            {
+                toggle = Main.Settings.EnableSRDCombatSurpriseRulesManyRolls;
+                if (UI.Toggle("Rolls different " + "Stealth".orange() + " checks for each surprised / surprising character pairs", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableSRDCombatSurpriseRulesManyRolls = toggle;
+                }
+            }
+
+            UI.Label("");
 
             toggle = Main.Settings.EnableConditionBlindedShouldNotAllowOpportunityAttack;
             if (UI.Toggle("Blinded".orange() + " condition doesn't allow attack of opportunity", ref toggle, UI.AutoWidth()))

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -13,6 +13,12 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("SRD:".yellow());
             UI.Label("");
 
+            toggle = Main.Settings.EnableSRDSurpriseChecks;
+            if (UI.Toggle("Uses official combat surprise rules", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableSRDSurpriseChecks = toggle;
+            }
+
             toggle = Main.Settings.EnableSRDAdvantageRules;
             if (UI.Toggle("Uses official advantage / disadvantage rules", ref toggle, UI.AutoWidth()))
             {


### PR DESCRIPTION
. Implements surprise rules much closer to SRD:

for each surprised entity:
  for each surprising entity in field of vision:
    roll surprising entity stealth check against passive surprised entity perception check
if at least one roll fails surprised entity isn't surprised anymore