### PR TITLE
remove side effects from Settings setters

### DIFF
--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionPowerSharedPool.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionPowerSharedPool.cs
@@ -32,18 +32,14 @@ namespace SolastaCommunityExpansion.CustomFeatureDefinitions
     {
         public FeatureDefinitionPower PoolPower { get; set; }
 
-        // TODO: unassigned - remove or use
-        private readonly int poolChangeAmount;
-
         public FeatureDefinitionPower GetUsagePoolPower()
         {
             return PoolPower;
         }
 
-        // TODO: unused  - remove or use
         public int PoolChangeAmount()
         {
-            return poolChangeAmount;
+            return 0;
         }
     }
 

--- a/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
+++ b/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
@@ -6,8 +6,8 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class InitialChoicesContext
     {
-        internal static int previousAllRacesInitialFeats = -1;
-        internal static bool previousAlternateHuman = false;
+        internal static int PreviousAllRacesInitialFeats { get; set; } = -1;
+        internal static bool PreviousAlternateHuman { get; set; }
 
         internal static void Load()
         {
@@ -30,12 +30,12 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void RefreshAllRacesInitialFeats()
         {
-            if (previousAllRacesInitialFeats > -1)
+            if (PreviousAllRacesInitialFeats > -1)
             {
-                UnloadRacesLevel1Feats(previousAllRacesInitialFeats, previousAlternateHuman);
+                UnloadRacesLevel1Feats(PreviousAllRacesInitialFeats, PreviousAlternateHuman);
             }
-            previousAllRacesInitialFeats = Main.Settings.AllRacesInitialFeats;
-            previousAlternateHuman = Main.Settings.EnableAlternateHuman;
+            PreviousAllRacesInitialFeats = Main.Settings.AllRacesInitialFeats;
+            PreviousAlternateHuman = Main.Settings.EnableAlternateHuman;
             LoadRacesLevel1Feats(Main.Settings.AllRacesInitialFeats, Main.Settings.EnableAlternateHuman);
         }
 

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -1,5 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
+using SolastaCommunityExpansion.Feats;
+using SolastaCommunityExpansion.Models;
+using SolastaCommunityExpansion.Subclasses.Rogue;
+using SolastaCommunityExpansion.Subclasses.Wizard;
 
 namespace SolastaCommunityExpansion.Patches
 {
@@ -11,30 +15,36 @@ namespace SolastaCommunityExpansion.Patches
         {
             internal static void Postfix()
             {
-                Models.BugFixContext.Load();
+                BugFixContext.Load();
 
-                Models.AdditionalNamesContext.Load();
-                Models.AsiAndFeatContext.Load();
-                Models.InitialChoicesContext.Load();
-                Models.ItemCraftingContext.Load();
-                Models.GameUiContext.Load();
+                AdditionalNamesContext.Load();
+                AsiAndFeatContext.Load();
+                InitialChoicesContext.Load();
+                ItemCraftingContext.Load();
+                GameUiContext.Load();
                 // Fighting Styles should be loaded before feats in
                 // order to generate feats of new fighting styles.
-                Models.FightingStyleContext.Load();
-                Models.FeatsContext.Load();
-                Models.SubclassesContext.Load();
-                Models.FlexibleBackgroundsContext.Load();
-                Models.FlexibleRacesContext.Load();
-                Models.VisionContext.Load();
-                Models.PickPocketContext.Load();
-                Models.EpicArrayContext.Load();
-                Models.RespecContext.Load();
-                Models.RemoveIdentificationContext.Load();
-                Models.Level20Context.Load();
-                Models.DruidArmorContext.Load();
-                Models.CharacterExportContext.Load();
-                Models.InventoryManagementContext.Load();
-                Models.RemoveBugVisualModelsContext.Load();
+                FightingStyleContext.Load();
+                FeatsContext.Load();
+                SubclassesContext.Load();
+                FlexibleBackgroundsContext.Load();
+                FlexibleRacesContext.Load();
+                VisionContext.Load();
+                PickPocketContext.Load();
+                EpicArrayContext.Load();
+                RespecContext.Load();
+                RemoveIdentificationContext.Load();
+                Level20Context.Load();
+                DruidArmorContext.Load();
+                CharacterExportContext.Load();
+                InventoryManagementContext.Load();
+                RemoveBugVisualModelsContext.Load();
+
+                // Apply settings after everything loaded
+                ConArtist.UpdateSpellDCBoost();
+                MasterManipulator.UpdateSpellDCBoost();
+                AcehighFeats.UpdatePowerAttackModifier();
+                ItemCraftingContext.UpdateRecipeCost();
 
                 Main.Enabled = true;
             }

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -40,12 +40,6 @@ namespace SolastaCommunityExpansion.Patches
                 InventoryManagementContext.Load();
                 RemoveBugVisualModelsContext.Load();
 
-                // Apply settings after everything loaded
-                ConArtist.UpdateSpellDCBoost();
-                MasterManipulator.UpdateSpellDCBoost();
-                AcehighFeats.UpdatePowerAttackModifier();
-                ItemCraftingContext.UpdateRecipeCost();
-
                 Main.Enabled = true;
             }
         }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -1,7 +1,4 @@
-﻿using SolastaCommunityExpansion.Feats;
-using SolastaCommunityExpansion.Subclasses.Rogue;
-using SolastaCommunityExpansion.Subclasses.Wizard;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityModManagerNet;
 
 namespace SolastaCommunityExpansion
@@ -15,6 +12,8 @@ namespace SolastaCommunityExpansion
     {
         //
         // TODO: Reorganize the order of these settings in code per viewers on UI to simplify maintenance
+        // NOTE: xml deserialization expects properties to match the order of the xml, so reorganizing will 
+        // temporarily lose settings.
         //
 
         public const string GUID = "b1ffaca74824486ea74a68d45e6b1925";
@@ -57,15 +56,7 @@ namespace SolastaCommunityExpansion
         public List<string> ItemsInDM { get; private set; } = new List<string>();
         public List<string> RecipesInDM { get; private set; } = new List<string>();
 
-        private int recipeCost = 200;
-        public int RecipeCost
-        {
-            get => recipeCost; set
-            {
-                recipeCost = value;
-                Models.ItemCraftingContext.UpdateRecipeCost();
-            }
-        }
+        public int RecipeCost { get; set; } = 200;
 
         public List<string> FeatEnabled { get; private set; } = new List<string>();
         public List<string> SubclassEnabled { get; private set; } = new List<string>();
@@ -75,38 +66,9 @@ namespace SolastaCommunityExpansion
         public int SubclassSliderPosition { get; set; } = 1;
         public int FightingStyleSliderPosition { get; set; } = 1;
 
-        private int rogueConArtistSpellDCBoost { get; set; } = 3;
-
-        public int RogueConArtistSpellDCBoost
-        {
-            get => rogueConArtistSpellDCBoost; set
-            {
-                rogueConArtistSpellDCBoost = value;
-                ConArtist.UpdateSpellDCBoost();
-            }
-        }
-
-        private int masterManipulatorSpellDCBoost = 2;
-
-        public int MasterManipulatorSpellDCBoost
-        {
-            get => masterManipulatorSpellDCBoost; set
-            {
-                masterManipulatorSpellDCBoost = value;
-                MasterManipulator.UpdateSpellDCBoost();
-            }
-        }
-
-        private int featPowerAttackModifier = 3;
-
-        public int FeatPowerAttackModifier
-        {
-            get => featPowerAttackModifier; set
-            {
-                featPowerAttackModifier = value;
-                AcehighFeats.UpdatePowerAttackModifier();
-            }
-        }
+        public int RogueConArtistSpellDCBoost { get; set; } = 3;
+        public int MasterManipulatorSpellDCBoost { get; set; } = 2;
+        public int FeatPowerAttackModifier { get; set; } = 3;
 
         /* Commands to allow the player to hide certain parts of the HUD */
         public const InputCommands.Id CTRL_C = (InputCommands.Id)44440000;

--- a/SolastaCommunityExpansion/Viewers/Displays/FeatsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/FeatsDisplay.cs
@@ -1,4 +1,5 @@
 ﻿using ModKit;
+using SolastaCommunityExpansion.Feats;
 using SolastaCommunityExpansion.Models;
 using System.Linq;
 using static SolastaCommunityExpansion.Viewers.Displays.Shared;
@@ -24,6 +25,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (UI.Slider("Power Attack modifier ".white() + RequiresRestart, ref intValue, 1, 6, 3, ""))
             {
                 Main.Settings.FeatPowerAttackModifier = intValue;
+                AcehighFeats.UpdatePowerAttackModifier();
             }
 
             UI.Label("");

--- a/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
@@ -87,6 +87,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (UI.Slider("Recipes' Cost".white(), ref intValue, 1, 500, 200, "", UI.AutoWidth()))
             {
                 Main.Settings.RecipeCost = intValue;
+                ItemCraftingContext.UpdateRecipeCost();
             }
 
             UI.Label("");

--- a/SolastaCommunityExpansion/Viewers/Displays/SubClassesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/SubClassesDisplay.cs
@@ -1,5 +1,7 @@
 ﻿using ModKit;
 using SolastaCommunityExpansion.Models;
+using SolastaCommunityExpansion.Subclasses.Rogue;
+using SolastaCommunityExpansion.Subclasses.Wizard;
 using System.Linq;
 
 namespace SolastaCommunityExpansion.Viewers.Displays
@@ -23,7 +25,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (UI.Toggle("Enables unlimited ".white() + "Arcane Recovery".orange() + " on Wizard Spell Master\n".white() + "Must be enabled when the ability has available uses (or before character creation)".italic().yellow(), ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.SpellMasterUnlimitedArcaneRecovery = toggle;
-                Subclasses.Wizard.SpellMaster.UpdateRecoveryLimited();
+                SpellMaster.UpdateRecoveryLimited();
             }
 
             UI.Label("");
@@ -32,13 +34,16 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (UI.Slider("", ref intValue, 0, 5, 3, "", UI.AutoWidth()))
             {
                 Main.Settings.RogueConArtistSpellDCBoost = intValue;
+                ConArtist.UpdateSpellDCBoost();
             }
+
             UI.Label("");
             UI.Label("Overrides Wizard Master Manipulator ".white() + "Arcane Manipulation".orange() + " Spell DC".white());
             intValue = Main.Settings.MasterManipulatorSpellDCBoost;
             if (UI.Slider("", ref intValue, 0, 5, 2, "", UI.AutoWidth()))
             {
                 Main.Settings.MasterManipulatorSpellDCBoost = intValue;
+                MasterManipulator.UpdateSpellDCBoost();
             }
 
             UI.Label("");


### PR DESCRIPTION
Applying settings during the xml deserialization was throwing exception after recent change to make some static properties lazy loading.
Now applying at the end of GameManager_BindPostDatabase_Patch.