### PR TITLE
Custom Dungeons

### DIFF
--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -31,12 +31,13 @@ namespace SolastaCommunityExpansion.Models
             if (gameCampaign != null && gameCampaign.CampaignDefinitionName == "UserCampaign")
             {
                 var adventureLog = gameCampaign.AdventureLog;
-                var adventureLogDefinition = AccessTools.Field(adventureLog.GetType(), "adventureLogDefinition").GetValue(adventureLog) as AdventureLogDefinition;
-                var loreEntry = new GameAdventureEntryDungeonMaker(adventureLogDefinition, title, text, speakerName, assetReferenceSprite);
                 var hashCode = text.GetHashCode();
 
-                if (!captionHashes.Contains(hashCode))
+                if (adventureLog != null && !captionHashes.Contains(hashCode))
                 {
+                    var adventureLogDefinition = AccessTools.Field(adventureLog.GetType(), "adventureLogDefinition").GetValue(adventureLog) as AdventureLogDefinition;
+                    var loreEntry = new GameAdventureEntryDungeonMaker(adventureLogDefinition, title, text, speakerName, assetReferenceSprite);
+
                     captionHashes.Add(hashCode);
                     adventureLog.AddAdventureEntry(loreEntry);
                 }
@@ -58,13 +59,10 @@ namespace SolastaCommunityExpansion.Models
 
             public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, string header, string text, string actorName, AssetReferenceSprite sprite) : base(adventureLogDefinition)
             {
-                var isNpc = actorName != "";
-
-                conversationInfos.Add(new GameAdventureConversationInfo(actorName, text, isNpc));
-                textBreakers.Add(new TextBreaker());
-
                 assetGuid = assetReferenceSprite == null ? string.Empty : assetReferenceSprite.AssetGUID;
                 assetReferenceSprite = sprite;
+                conversationInfos.Add(new GameAdventureConversationInfo(actorName, text, actorName != ""));
+                textBreakers.Add(new TextBreaker());
                 title = header;
             }
 

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -19,7 +19,7 @@ namespace SolastaCommunityExpansion.Models
                 var builder = new StringBuilder();
                 var fragments = itemDefinition.DocumentDescription.ContentFragments.Select(x => x.Text).ToList();
 
-                builder.Append(fragments);
+                fragments.ForEach(x => builder.Append(x));
                 LogEntry(itemDefinition.FormatTitle(), builder.ToString(), string.Empty, assetReferenceSprite);
             }
         }
@@ -72,14 +72,9 @@ namespace SolastaCommunityExpansion.Models
             {
                 get
                 {
-                    //
-                    // TODO: revisit addressables
-                    //
-                    return false;
+                    var illustrationReference = IllustrationReference;
 
-                    //var illustrationReference = IllustrationReference;
-
-                    //return illustrationReference != null && illustrationReference.RuntimeKeyIsValid();
+                    return illustrationReference != null && illustrationReference.RuntimeKeyIsValid();
                 }
             }
 

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -1,0 +1,91 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SolastaCommunityExpansion.Models
+{
+    internal static class AdventureLogContext
+    {
+        internal static void LogEntry(ItemDefinition itemDefinition)
+        {
+            var isUserText = itemDefinition.Name.StartsWith("Custom") && itemDefinition.IsDocument;
+
+            if (isUserText)
+            {
+                var fragments = itemDefinition.DocumentDescription.ContentFragments.Select(x => x.Text).ToList();
+
+                LogEntry(fragments);
+            }
+        }
+
+        internal static void LogEntry(List<string> captions, GameLocationCharacter speaker = null)
+        {
+            var gameCampaign = Gui.GameCampaign;
+
+            if (gameCampaign != null && gameCampaign.CampaignDefinitionName == "UserCampaign")
+            {
+                var speakerName = speaker != null ? speaker.Name : string.Empty;
+                var adventureLog = gameCampaign.AdventureLog;
+                var adventureLogDefinition = AccessTools.Field(adventureLog.GetType(), "adventureLogDefinition").GetValue(adventureLog) as AdventureLogDefinition;
+                var loreEntry = new GameAdventureEntryDungeonMaker(adventureLogDefinition, captions, speakerName);
+
+                adventureLog.AddEntry(loreEntry);
+            }
+        }
+
+        internal class GameAdventureEntryDungeonMaker : GameAdventureEntry
+        {
+            private List<GameAdventureConversationInfo> conversationInfos = new List<GameAdventureConversationInfo>();
+            private readonly List<TextBreaker> textBreakers = new List<TextBreaker>();
+
+            public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, List<string> captions, string actorName = "", string itemDefinitionGuid = "") : base(adventureLogDefinition)
+            {
+                foreach (var caption in captions)
+                {
+                    this.conversationInfos.Add(new GameAdventureConversationInfo(actorName, caption, actorName != ""));
+                    this.textBreakers.Add(new TextBreaker());
+                }
+            }
+
+            public List<TextBreaker> TextBreakers => this.textBreakers;
+
+            public override void ComputeHeight(float areaWidth, ITextComputer textCompute)
+            {
+                base.ComputeHeight(areaWidth, textCompute);
+                this.Height = this.AdventureLogDefinition.ConversationHeaderHeight;
+
+                for (var i = 0; i < textBreakers.Count; ++i)
+                {
+                    var textBreaker = textBreakers[i];
+
+                    if (this.conversationInfos[i].ActorName != "")
+                    {
+                        this.Parameters.Clear();
+                        this.AddParameter(AdventureStyleDuplet.ParameterType.NpcName, this.conversationInfos[i].ActorName + ":");
+                        this.BreakdownFragments(textBreaker, "{0}" + Gui.Localize(this.conversationInfos[i].ActorLine), this.AdventureLogDefinition.BaseStyle);
+                    }
+                    else
+                    {
+                        this.BreakdownFragments(textBreaker, Gui.Localize(this.conversationInfos[i].ActorLine), this.AdventureLogDefinition.BaseStyle);
+                    }
+
+                    textBreaker.ComputeFragmentExtents(textCompute, this.AdventureLogDefinition.ConversationLineHeight);
+                    this.Height += textBreaker.DispatchFragments(areaWidth, this.AdventureLogDefinition.ConversationIndentWidth, this.AdventureLogDefinition.ConversationLineHeight, this.AdventureLogDefinition.ConversationLineHeight, this.AdventureLogDefinition.ConversationWordSpacing, true, this.Height - this.AdventureLogDefinition.ConversationHeaderHeight);
+                    this.Height += this.AdventureLogDefinition.ConversationParagraphSpacing;
+                    this.Height += this.AdventureLogDefinition.ConversationTrailingHeight;
+                }
+            }
+
+            public override void SerializeElements(IElementsSerializer serializer, IVersionProvider versionProvider)
+            {
+                base.SerializeElements(serializer, versionProvider);
+                this.conversationInfos = serializer.SerializeElement<GameAdventureConversationInfo>("ConversationInfos", this.conversationInfos);
+
+                for (int i = 0; i < this.conversationInfos.Count; ++i)
+                {
+                    this.textBreakers.Add(new TextBreaker());
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -35,6 +35,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal class GameAdventureEntryDungeonMaker : GameAdventureEntry
         {
+            private string assetGuid;
             private AssetReferenceSprite assetReferenceSprite;
             private List<GameAdventureConversationInfo> conversationInfos = new List<GameAdventureConversationInfo>();
             private readonly List<TextBreaker> textBreakers = new List<TextBreaker>();
@@ -47,6 +48,7 @@ namespace SolastaCommunityExpansion.Models
 
             public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, string title, List<string> captions, string actorName, AssetReferenceSprite assetReferenceSprite) : base(adventureLogDefinition)
             {
+                this.assetGuid = assetReferenceSprite.AssetGUID;
                 this.assetReferenceSprite = assetReferenceSprite;
                 this.title = title;
 
@@ -103,8 +105,9 @@ namespace SolastaCommunityExpansion.Models
             public override void SerializeAttributes(IAttributesSerializer serializer, IVersionProvider versionProvider)
             {
                 base.SerializeAttributes(serializer, versionProvider);
-                this.assetReferenceSprite = serializer.SerializeAttribute<AssetReferenceSprite>("AssetReferenceSprite", this.assetReferenceSprite);
+                this.assetGuid = serializer.SerializeAttribute<string>("AssetGuid", this.assetGuid);
                 this.title = serializer.SerializeAttribute<string>("SectionTitle", this.title);
+                this.assetReferenceSprite = new AssetReferenceSprite(this.assetGuid);
             }
 
             public override void SerializeElements(IElementsSerializer serializer, IVersionProvider versionProvider)

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -48,7 +48,7 @@ namespace SolastaCommunityExpansion.Models
 
             public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, string title, List<string> captions, string actorName, AssetReferenceSprite assetReferenceSprite) : base(adventureLogDefinition)
             {
-                this.assetGuid = assetReferenceSprite.AssetGUID;
+                this.assetGuid = assetReferenceSprite == null ? string.Empty : assetReferenceSprite.AssetGUID;
                 this.assetReferenceSprite = assetReferenceSprite;
                 this.title = title;
 
@@ -107,7 +107,11 @@ namespace SolastaCommunityExpansion.Models
                 base.SerializeAttributes(serializer, versionProvider);
                 this.assetGuid = serializer.SerializeAttribute<string>("AssetGuid", this.assetGuid);
                 this.title = serializer.SerializeAttribute<string>("SectionTitle", this.title);
-                this.assetReferenceSprite = new AssetReferenceSprite(this.assetGuid);
+
+                if (this.assetGuid != string.Empty)
+                {
+                    this.assetReferenceSprite = new AssetReferenceSprite(this.assetGuid);
+                }
             }
 
             public override void SerializeElements(IElementsSerializer serializer, IVersionProvider versionProvider)

--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -1,4 +1,8 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TMPro;
+using UnityEngine;
 
 namespace SolastaCommunityExpansion.Models
 {
@@ -10,6 +14,30 @@ namespace SolastaCommunityExpansion.Models
             ServiceRepository.GetService<IInputService>().RegisterCommand(Settings.CTRL_L, (int)KeyCode.L, (int)KeyCode.LeftControl, -1, -1, -1, -1);
             ServiceRepository.GetService<IInputService>().RegisterCommand(Settings.CTRL_M, (int)KeyCode.M, (int)KeyCode.LeftControl, -1, -1, -1, -1);
             ServiceRepository.GetService<IInputService>().RegisterCommand(Settings.CTRL_P, (int)KeyCode.P, (int)KeyCode.LeftControl, -1, -1, -1, -1);
+        }
+
+        internal static class RemoveInvalidFilenameChars
+        {
+            private static readonly HashSet<char> InvalidFilenameChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+
+            public static bool Invoke(TMP_InputField textField)
+            {
+                if (textField != null)
+                {
+                    // Solasta original code disallows invalid filename chars and an additional list of illegal chars.
+                    // We're disallowing invalid filename chars only.
+                    // We're trimming whitespace from start only as per original method.
+                    // This allows the users to create a name with spaces inside, but also allows trailing space.
+                    textField.text = new string(
+                        textField.text
+                            .Where(n => !InvalidFilenameChars.Contains(n))
+                            .ToArray()).TrimStart();
+
+                    return false;
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
@@ -11,7 +11,9 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogDocuments)
             {
-                Models.AdventureLogContext.LogEntry(guiEquipmentItem.ItemDefinition, guiEquipmentItem.ItemDefinition.GuiPresentation.SpriteReference);
+                var itemDefinition = guiEquipmentItem.ItemDefinition;
+
+                Models.AdventureLogContext.LogEntry(itemDefinition, itemDefinition.GuiPresentation.SpriteReference);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogDocuments)
             {
-                Models.AdventureLogContext.LogEntry(guiEquipmentItem.ItemDefinition);
+                Models.AdventureLogContext.LogEntry(guiEquipmentItem.ItemDefinition, guiEquipmentItem.ItemDefinition.GuiPresentation.SpriteReference);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(DocumentModal), "Show")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class DocumentModal_Show
+    {
+        internal static void Prefix(GuiEquipmentItem guiEquipmentItem)
+        {
+            if (Main.Settings.EnableAdventureLogDocuments)
+            {
+                Models.AdventureLogContext.LogEntry(guiEquipmentItem.ItemDefinition);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/DocumentModalPatcher.cs
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Patches
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class DocumentModal_Show
     {
-        internal static void Prefix(GuiEquipmentItem guiEquipmentItem)
+        internal static void Postfix(GuiEquipmentItem guiEquipmentItem)
         {
             if (Main.Settings.EnableAdventureLogDocuments)
             {

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogBanterLines)
             {
-                Models.AdventureLogContext.LogEntry("Conversation", new List<string> { line }, speaker.Name);
+                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { line }, speaker.Name, (speaker.RulesetCharacter as RulesetCharacterMonster).MonsterDefinition.GuiPresentation.SpriteReference);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogBanterLines)
             {
-                Models.AdventureLogContext.LogEntry(new List<string> { line }, speaker: speaker);
+                Models.AdventureLogContext.LogEntry("Conversation", new List<string> { line }, speaker.Name);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(GameLocationBanterManager), "ForceBanterLine")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameLocationBanterManager_ForceBanterLine
+    {
+        internal static void Postfix(string line, GameLocationCharacter speaker)
+        {
+            if (Main.Settings.EnableAdventureLogBanterLines)
+            {
+                Models.AdventureLogContext.LogEntry(new List<string> { line }, speaker: speaker);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -24,7 +24,7 @@ namespace SolastaCommunityExpansion.Patches
                     assetReferenceSprite = rulesetCharacterMonster.MonsterDefinition.GuiPresentation.SpriteReference;
                 }
 
-                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { line }, speaker.Name, assetReferenceSprite);
+                Models.AdventureLogContext.LogEntry(string.Empty, line, rulesetCharacterMonster.Name, assetReferenceSprite);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Patches
 {
@@ -10,9 +11,20 @@ namespace SolastaCommunityExpansion.Patches
     {
         internal static void Postfix(string line, GameLocationCharacter speaker)
         {
-            if (Main.Settings.EnableAdventureLogBanterLines)
+            if (Main.Settings.EnableAdventureLogBanterLines && speaker.RulesetCharacter is RulesetCharacterMonster rulesetCharacterMonster && rulesetCharacterMonster != null)
             {
-                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { line }, speaker.Name, (speaker.RulesetCharacter as RulesetCharacterMonster).MonsterDefinition.GuiPresentation.SpriteReference);
+                AssetReferenceSprite assetReferenceSprite = null;
+
+                if (rulesetCharacterMonster.HumanoidMonsterPresentationDefinition != null)
+                {
+                    assetReferenceSprite = rulesetCharacterMonster.HumanoidMonsterPresentationDefinition.GuiPresentation.SpriteReference;
+                }             
+                else if (rulesetCharacterMonster.MonsterDefinition != null)
+                {
+                    assetReferenceSprite = rulesetCharacterMonster.MonsterDefinition.GuiPresentation.SpriteReference;
+                }
+
+                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { line }, speaker.Name, assetReferenceSprite);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using UnityEngine.AddressableAssets;
 

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogTextFeedback)
             {
-                Models.AdventureLogContext.LogEntry(new List<string> { caption });
+                Models.AdventureLogContext.LogEntry("Text Feedback", new List<string> { caption });
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(GameLocationLabelScreen), "ShowTextFeedback")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameLocationLabelScreen_ShowTextFeedback
+    {
+        internal static void Postfix(string caption)
+        {
+            if (Main.Settings.EnableAdventureLogTextFeedback)
+            {
+                Models.AdventureLogContext.LogEntry(new List<string> { caption });
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogTextFeedback)
             {
-                Models.AdventureLogContext.LogEntry("Feedback", new List<string> { caption });
+                Models.AdventureLogContext.LogEntry("Feedback", caption);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogTextFeedback)
             {
-                Models.AdventureLogContext.LogEntry("Text Feedback", new List<string> { caption });
+                Models.AdventureLogContext.LogEntry("Feedback", new List<string> { caption });
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry("Popup Feedback", new List<string> { text });
+                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { text });
             }
         }
     }
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry("Popup Feedback", new List<string> { text });
+                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { text });
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { text });
+                Models.AdventureLogContext.LogEntry(string.Empty, text);
             }
         }
     }
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry(string.Empty, new List<string> { text });
+                Models.AdventureLogContext.LogEntry(string.Empty, text);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -1,0 +1,32 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(GamePartyStatusScreen), "ShowBottomPopup")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GamePartyStatusScreen_ShowBottomPopup
+    {
+        internal static void Postfix(string text)
+        {
+            if (Main.Settings.EnableAdventureLogPopups)
+            {
+                Models.AdventureLogContext.LogEntry(new List<string> { text });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GamePartyStatusScreen), "ShowHeaderPopup")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GamePartyStatusScreen_ShowHeaderPopup
+    {
+        internal static void Postfix(string text)
+        {
+            if (Main.Settings.EnableAdventureLogPopups)
+            {
+                Models.AdventureLogContext.LogEntry(new List<string> { text });
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry(new List<string> { text });
+                Models.AdventureLogContext.LogEntry("Popup Feedback", new List<string> { text });
             }
         }
     }
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogPopups)
             {
-                Models.AdventureLogContext.LogEntry(new List<string> { text });
+                Models.AdventureLogContext.LogEntry("Popup Feedback", new List<string> { text });
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
@@ -10,6 +10,8 @@ namespace SolastaCommunityExpansion.Patches
     internal static class GuiAdventureLine_Bind
     {
         internal static void Postfix(
+            RectTransform ___sectionHeaderGroup,
+            GuiLabel ___sectionHeaderTitle,
             RectTransform ___conversationGroup, 
             GuiLabel ___conversationTitle,
             RectTransform ___conversationFragmentsContainer,
@@ -19,6 +21,8 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (entry is Models.AdventureLogContext.GameAdventureEntryDungeonMaker gameAdventureEntryLore)
             {
+                ___sectionHeaderGroup.gameObject.SetActive(true);
+                ___sectionHeaderTitle.Text = gameAdventureEntryLore.Title;
                 ___conversationGroup.gameObject.SetActive(true);
                 ___conversationTitle.transform.parent.gameObject.SetActive(false);
                 ___totalFragments.Clear();

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
@@ -1,0 +1,57 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(GuiAdventureLine), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GuiAdventureLine_Bind
+    {
+        internal static void Postfix(
+            RectTransform ___conversationGroup, 
+            GuiLabel ___conversationTitle,
+            RectTransform ___conversationFragmentsContainer,
+            GameObject ___fragmentPrefab,
+            List<TextBreaker.FragmentInfo> ___totalFragments,
+            GameRecordEntry entry)
+        {
+            if (entry is Models.AdventureLogContext.GameAdventureEntryDungeonMaker gameAdventureEntryLore)
+            {
+                ___conversationGroup.gameObject.SetActive(true);
+                ___conversationTitle.transform.parent.gameObject.SetActive(false);
+                ___totalFragments.Clear();
+
+                foreach (TextBreaker textBreaker in gameAdventureEntryLore.TextBreakers)
+                {
+                    ___totalFragments.AddRange(textBreaker.Fragments);
+                }
+
+                while (___conversationFragmentsContainer.childCount < ___totalFragments.Count)
+                {
+                    Gui.GetPrefabFromPool(___fragmentPrefab, ___conversationFragmentsContainer);
+                }
+
+                for (int i = 0; i < ___totalFragments.Count; ++i)
+                {
+                    var child = ___conversationFragmentsContainer.GetChild(i);
+
+                    child.gameObject.SetActive(true);
+                    child.GetComponent<GuiTextFragment>().Bind(___totalFragments[i]);
+                }
+
+                for (int i = ___totalFragments.Count; i < ___conversationFragmentsContainer.childCount; ++i)
+                {
+                    var child = ___conversationFragmentsContainer.GetChild(i);
+
+                    if (child.gameObject.activeSelf)
+                    {
+                        child.GetComponent<GuiTextFragment>().Unbind();
+                        child.gameObject.SetActive(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/GuiAdventureLinePatcher.cs
@@ -21,10 +21,11 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (entry is Models.AdventureLogContext.GameAdventureEntryDungeonMaker gameAdventureEntryLore)
             {
-                ___sectionHeaderGroup.gameObject.SetActive(true);
+                ___sectionHeaderGroup.gameObject.SetActive(gameAdventureEntryLore.Title != string.Empty);
                 ___sectionHeaderTitle.Text = gameAdventureEntryLore.Title;
-                ___conversationGroup.gameObject.SetActive(true);
+
                 ___conversationTitle.transform.parent.gameObject.SetActive(false);
+                ___conversationGroup.gameObject.SetActive(true);
                 ___totalFragments.Clear();
 
                 foreach (TextBreaker textBreaker in gameAdventureEntryLore.TextBreakers)

--- a/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
@@ -15,7 +15,7 @@ namespace SolastaCommunityExpansion.Patches
             {
                 var builder = new StringBuilder();
 
-                builder.Append(captions);
+                captions.ForEach(x => builder.Append(x));
                 Models.AdventureLogContext.LogEntry("Lore", builder.ToString());
             }
         }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogLore)
             {
-                Models.AdventureLogContext.LogEntry(captions);
+                Models.AdventureLogContext.LogEntry("Lore", captions);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(PosterScreen), "Show")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class PosterScreen_Show
+    {
+        internal static void Postfix(List<string> captions)
+        {
+            if (Main.Settings.EnableAdventureLogLore)
+            {
+                Models.AdventureLogContext.LogEntry(captions);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/AdventureLog/PosterScreenPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace SolastaCommunityExpansion.Patches
 {
@@ -12,7 +13,10 @@ namespace SolastaCommunityExpansion.Patches
         {
             if (Main.Settings.EnableAdventureLogLore)
             {
-                Models.AdventureLogContext.LogEntry("Lore", captions);
+                var builder = new StringBuilder();
+
+                builder.Append(captions);
+                Models.AdventureLogContext.LogEntry("Lore", builder.ToString());
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/CampaignRequirements/NewAdventurePanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CampaignRequirements/NewAdventurePanelPatcher.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // this patch changes the min/max requirements on campaigns
+    [HarmonyPatch(typeof(NewAdventurePanel), "SelectCampaign")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class NewAdventurePanelSelectCampaign
+    {
+        internal static void Prefix(UserCampaign userCampaign)
+        {
+            if (userCampaign != null && Main.Settings.EnableDungeonLevelBypass)
+            {
+                userCampaign.StartLevelMin = Settings.DUNGEON_MIN_LEVEL;
+                userCampaign.StartLevelMax = Settings.DUNGEON_MAX_LEVEL;
+            }
+        }
+    }
+
+    // this patch changes the min/max requirements on locations
+    [HarmonyPatch(typeof(NewAdventurePanel), "SelectUserLocation")]
+    internal static class NewAdventurePanelSelectUserLocation
+    {
+        internal static void Prefix(UserLocation userLocation)
+        {
+            if (userLocation != null && Main.Settings.EnableDungeonLevelBypass)
+            {
+                userLocation.StartLevelMin = Settings.DUNGEON_MIN_LEVEL;
+                userLocation.StartLevelMax = Settings.DUNGEON_MAX_LEVEL;
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/UserCampaignEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/UserCampaignEditorScreenPatcher.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using TMPro;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // allows extra characters on campaign names
+    [HarmonyPatch(typeof(UserCampaignEditorScreen), "RemoveUselessSpaces")]
+    internal static class UserCampaignEditorScreenRemoveUselessSpaces
+    {
+        public static bool Prefix(TMP_InputField textField)
+        {
+            if (!Main.Settings.AllowExtraKeyboardCharactersInNames)
+            {
+                return true;
+            }
+
+            return Models.GameUiContext.RemoveInvalidFilenameChars.Invoke(textField);
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/UserLocationSettingsModalPatcher.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using TMPro;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // allows extra characters on location names
+    [HarmonyPatch(typeof(UserLocationSettingsModal), "RemoveUselessSpaces")]
+    internal static class UserLocationSettingsModalRemoveUselessSpaces
+    {
+        public static bool Prefix(TMP_InputField textField)
+        {
+            if (!Main.Settings.AllowExtraKeyboardCharactersInNames)
+            {
+                return true;
+            }
+
+            return Models.GameUiContext.RemoveInvalidFilenameChars.Invoke(textField);
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/FunctorParametersDescriptionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/FunctorParametersDescriptionPatcher.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // this patch ensures all party members teleport to new locations
+    [HarmonyPatch(typeof(FunctorParametersDescription), "PlayerPlacementMarkers", MethodType.Getter)]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class FunctorParametersDescription_PlayerPlacementMarkers
+    {
+        internal static void Postfix(ref Transform[] __result)
+        {
+            var partyCount = Gui.GameCampaign.Party.CharactersList.Count;
+
+            if (partyCount > 4)
+            {
+                var result = new Transform[partyCount];
+
+                for (var idx = 0; idx < partyCount; idx++)
+                {
+                    result[idx] = __result[idx % Settings.GAME_PARTY_SIZE];
+                }
+
+                __result = result;
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/GameLocationCharacterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/GameLocationCharacterManagerPatcher.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using TA;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // use this patch to recalculate the additional party members positions
+    [HarmonyPatch(typeof(GameLocationCharacterManager), "UnlockCharactersForLoading")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameLocationCharacterManager_UnlockCharactersForLoading
+    {
+        internal static void Prefix(GameLocationCharacterManager __instance)
+        {
+            var partyCharacters = __instance.PartyCharacters;
+
+            for (int idx = Settings.GAME_PARTY_SIZE; idx < partyCharacters.Count; idx++)
+            {
+                var position = partyCharacters[idx % Settings.GAME_PARTY_SIZE].LocationPosition;
+
+                partyCharacters[idx].LocationPosition = new int3(position.x, position.y, position.z);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/GameLocationPositioningManagerPatch.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/GameLocationPositioningManagerPatch.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SolastaDungeonMakerPro.Patches.PartySize
+{
+    // avoids a trace message when party greater than 4
+    [HarmonyPatch(typeof(GameLocationPositioningManager), "CharacterMoved", new Type[] { typeof(GameLocationCharacter), typeof(TA.int3), typeof(TA.int3), typeof(RulesetActor.SizeParameters), typeof(RulesetActor.SizeParameters) })]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameLocationPositioningManager_CharacterMoved
+    {
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var logErrorMethod = typeof(Trace).GetMethod("LogError", BindingFlags.Public | BindingFlags.Static, Type.DefaultBinder, new Type[1] { typeof(string) }, null);
+            int found = 0;
+
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (instruction.Calls(logErrorMethod) && ++found == 1)
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                }
+                else
+                {
+                    yield return instruction;
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/NewAdventurePanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/NewAdventurePanelPatcher.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaModApi;
+using SolastaModApi.Extensions;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // this patch tweaks the UI to allow less/more heroes to be selected on a campaign
+    [HarmonyPatch(typeof(NewAdventurePanel), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class NewAdventurePanel_OnBeginShow
+    {
+        internal static void Prefix(RectTransform ___characterSessionPlatesTable)
+        {
+            // overrides campaign party size
+            DatabaseHelper.CampaignDefinitions.UserCampaign.SetPartySize<CampaignDefinition>(Main.Settings.UserDungeonsPartySize);
+
+            // adds new character plates if required
+            for (int i = Settings.GAME_PARTY_SIZE; i < Main.Settings.UserDungeonsPartySize; i++)
+            {
+                var firstChild = ___characterSessionPlatesTable.GetChild(0);
+
+                Object.Instantiate(firstChild, firstChild.parent);
+            }
+
+            // scales down the plates table if required
+            if (Main.Settings.UserDungeonsPartySize > Settings.GAME_PARTY_SIZE)
+            {
+                var scale = (float)System.Math.Pow(Settings.ADVENTURE_PANEL_DEFAULT_SCALE, Main.Settings.UserDungeonsPartySize - Settings.GAME_PARTY_SIZE);
+
+                ___characterSessionPlatesTable.localScale = new Vector3(scale, scale, scale);
+            }
+            else
+            {
+                ___characterSessionPlatesTable.localScale = new Vector3(1, 1, 1);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/PartyControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/PartyControlPanelPatcher.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // this patch scales down the party control panel whenever the party size is bigger than 4
+    [HarmonyPatch(typeof(PartyControlPanel), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class PartyControlPanel_OnBeginShow
+    {
+        internal static void Prefix(RectTransform ___partyPlatesTable, RectTransform ___guestPlatesTable)
+        {
+            var partyCount = Gui.GameCampaign.Party.CharactersList.Count;
+
+            if (partyCount > Settings.GAME_PARTY_SIZE)
+            {
+                float scale = (float)Math.Pow(Settings.PARTY_CONTROL_PANEL_DEFAULT_SCALE, partyCount - Settings.GAME_PARTY_SIZE);
+
+                ___partyPlatesTable.localScale = new Vector3(scale, scale, scale);
+                ___guestPlatesTable.localScale = new Vector3(scale, scale, scale);
+            }
+            else
+            {
+                ___partyPlatesTable.localScale = new Vector3(1, 1, 1);
+                ___guestPlatesTable.localScale = new Vector3(1, 1, 1);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/RestSubPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/RestSubPanelPatcher.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    // this patch scales down the rest sub panel whenever the party size is bigger than 4
+    [HarmonyPatch(typeof(RestSubPanel), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class RestSubPanel_OnBeginShow
+    {
+        internal static void Prefix(RectTransform ___characterPlatesTable, RectTransform ___restModulesTable)
+        {
+            var partyCount = Gui.GameCampaign.Party.CharactersList.Count;
+
+            if (partyCount > Settings.GAME_PARTY_SIZE)
+            {
+                float scale = (float)Math.Pow(Settings.REST_PANEL_DEFAULT_SCALE, partyCount - Settings.GAME_PARTY_SIZE);
+
+                ___restModulesTable.localScale = new Vector3(scale, scale, scale);
+                ___characterPlatesTable.localScale = new Vector3(scale, scale, scale);
+            }
+            else
+            {
+                ___restModulesTable.localScale = new Vector3(1, 1, 1);
+                ___characterPlatesTable.localScale = new Vector3(1, 1, 1);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/RevivePartyControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/RevivePartyControlPanelPatcher.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches.PartySize
+{
+    // this patch scales down the revive party control panel whenever the party size is bigger than 4
+    [HarmonyPatch(typeof(RevivePartyControlPanel), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class RevivePartyControlPanel_OnBeginShow
+    {
+        internal static void Prefix(RectTransform ___partyPlatesTable)
+        {
+            var partyCount = Gui.GameCampaign.Party.CharactersList.Count;
+
+            if (partyCount > Settings.GAME_PARTY_SIZE)
+            {
+                float scale = (float)Math.Pow(Settings.REVIVE_PARTY_CONTROL_PANEL_DEFAULT_SCALE, partyCount - Settings.GAME_PARTY_SIZE);
+
+                ___partyPlatesTable.localScale = new Vector3(scale, 1, scale);
+            }
+            else
+            {
+                ___partyPlatesTable.localScale = new Vector3(1, 1, 1);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/PartySize/VictoryModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/VictoryModalPatcher.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches.PartySize
+{
+    // this patch scales down the victory modal whenever the party size is bigger than 4
+    [HarmonyPatch(typeof(VictoryModal), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class VictoryModal_OnBeginShow
+    {
+        internal static void Prefix(RectTransform ___heroStatsGroup)
+        {
+            var partyCount = Gui.GameCampaign.Party.CharactersList.Count;
+
+            if (partyCount > Settings.GAME_PARTY_SIZE)
+            {
+                float scale = (float)Math.Pow(Settings.VICTORY_MODAL_DEFAULT_SCALE, partyCount - Settings.GAME_PARTY_SIZE);
+
+                ___heroStatsGroup.localScale = new Vector3(scale, 1, scale);
+            }
+            else
+            {
+                ___heroStatsGroup.localScale = new Vector3(1, 1, 1);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -158,5 +158,28 @@ namespace SolastaCommunityExpansion
 
         public bool DontFollowCharacterInBattle { get; set; }
         public int DontFollowMargin { get; set; } = 5;
+
+        public bool EnableAdventureLogBanterLines { get; set; }
+        public bool EnableAdventureLogDocuments { get; set; }
+        public bool EnableAdventureLogLore { get; set; }
+        public bool EnableAdventureLogTextFeedback { get; set; }
+        public bool EnableAdventureLogPopups { get; set; }
+
+        public const int DUNGEON_MIN_LEVEL = 1;
+        public const int DUNGEON_MAX_LEVEL = 20;
+
+        public const int GAME_PARTY_SIZE = 4;
+
+        public const int MIN_PARTY_SIZE = 1;
+        public const int MAX_PARTY_SIZE = 6;
+
+        public const float ADVENTURE_PANEL_DEFAULT_SCALE = 0.75f;
+        public const float REST_PANEL_DEFAULT_SCALE = 0.8f;
+        public const float PARTY_CONTROL_PANEL_DEFAULT_SCALE = 0.95f;
+        public const float VICTORY_MODAL_DEFAULT_SCALE = 0.85f;
+        public const float REVIVE_PARTY_CONTROL_PANEL_DEFAULT_SCALE = 0.85f;
+
+        public bool EnableDungeonLevelBypass { get; set; }
+        public int UserDungeonsPartySize { get; set; } = GAME_PARTY_SIZE;
     }
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
@@ -57,6 +57,13 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 InitialChoicesContext.RefreshAllRacesInitialFeats();
             }
 
+            toggle = Main.Settings.EnableFlexibleBackgrounds;
+            if (UI.Toggle("Enables flexible backgrounds " + "[select skill and tool proficiencies from backgrounds]".italic().yellow(), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableFlexibleBackgrounds = toggle;
+                FlexibleBackgroundsContext.Switch(toggle);
+            }
+
             toggle = Main.Settings.EnableFlexibleRaces;
             if (UI.Toggle("Enables flexible races " + "[assign ability score points instead of the racial defaults]".italic().yellow() + "\ni.e.: High Elf has 3 points to assign instead of +2 Dex / +1 Int".italic(), ref toggle, UI.AutoWidth()))
             {
@@ -64,13 +71,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 FlexibleRacesContext.Switch(toggle);
             }
             UI.Label("");
-
-            toggle = Main.Settings.EnableFlexibleBackgrounds;
-            if (UI.Toggle("Enables flexible backgrounds " + "[select skill and tool proficiencies from backgrounds]".italic().yellow(), ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.EnableFlexibleBackgrounds = toggle;
-                FlexibleBackgroundsContext.Switch(toggle);
-            }
 
             UI.Label("");
 
@@ -101,6 +101,20 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             {
                 Main.Settings.AllRacesInitialFeats = intValue;
                 InitialChoicesContext.RefreshAllRacesInitialFeats();
+            }
+
+            UI.Label("");
+
+            toggle = Main.Settings.AllowExtraKeyboardCharactersInNames;
+            if (UI.Toggle("Allows extra keyboard characters in names", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.AllowExtraKeyboardCharactersInNames = toggle;
+            }
+
+            toggle = Main.Settings.OfferAdditionalNames;
+            if (UI.Toggle("Offers additional lore friendly names on character creation " + RequiresRestart, ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.OfferAdditionalNames = toggle;
             }
 
             UI.Label("");
@@ -151,6 +165,8 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                     Main.Settings.EnableFaceUnlockGlowingBodyDecorations = toggle;
                 }
             }
+
+            UI.Label("");
         }
     }
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
@@ -8,7 +8,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
         internal static readonly Dictionary<string, string> CreditsTable = new Dictionary<string, string>
         {
             { "ChrisJohnDigital".orange().bold(), "head developer, feats, items, subclasses, progression, etc." },
-            { "Zappastuff", "mod UI work, integration, community organization, level 20, respec" },
+            { "Zappastuff", "mod UI work, integration, adventure log, sorting, level 20, respec, party size, QoL" },
             { "ImpPhil", "monster's health, pause UI, stocks prices, no attunement, xp scaling, character export" },
             { "DubhHerder", "Crafty Feats Migration" },
             { "View619", "Darkvision, Superior Dark Vision" },

--- a/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
@@ -75,6 +75,8 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (DisplayAdventureLog)
             {
                 UI.Label("");
+                UI.Label(". The settings below only work in custom campaigns or locations");
+                UI.Label("");
 
                 toggle = Main.Settings.EnableAdventureLogBanterLines;
                 if (UI.Toggle("Records NPCs banter lines", ref toggle, UI.AutoWidth()))

--- a/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
@@ -7,7 +7,15 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class GameUiDisplay
     {
+        private static bool DisplayAdventureLog { get; set; }
+
         private static bool DisplayBattle { get; set; }
+
+        private static bool DisplayItem { get; set; }
+
+        private static bool DisplayMonster { get; set; }
+
+        private static bool DisplaySpell { get; set; }
 
         internal static void DisplayGameUi()
         {
@@ -17,56 +25,11 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 
             UI.Label("");
 
-            toggle = Main.Settings.AllowExtraKeyboardCharactersInNames;
-            if (UI.Toggle("Allows extra keyboard characters in names", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.AllowExtraKeyboardCharactersInNames = toggle;
-            }
-
             toggle = Main.Settings.EnableCharacterExport;
             if (UI.Toggle("Enables character export from inventory screen " + "[ctrl-(E)xport]".italic().yellow(), ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.EnableCharacterExport = toggle;
             }
-
-            toggle = Main.Settings.OfferAdditionalNames;
-            if (UI.Toggle("Offers additional lore friendly names on character creation " + RequiresRestart, ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.OfferAdditionalNames = toggle;
-            }
-
-            UI.Label("");
-
-            toggle = Main.Settings.HideMonsterHitPoints;
-            if (UI.Toggle("Displays Monsters's health in steps of 25% / 50% / 75% / 100% instead of exact hit points", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.HideMonsterHitPoints = toggle;
-            }
-
-            UI.Label("");
-
-            toggle = Main.Settings.EnableInvisibleCrownOfTheMagister;
-            if (UI.Toggle("Hides Crown of the Magister on game UI", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.EnableInvisibleCrownOfTheMagister = toggle;
-                ItemOptionsContext.SwitchCrownOfTheMagister();
-            }
-
-            toggle = Main.Settings.RemoveBugVisualModels;
-            if (UI.Toggle("Replaces bug-like models with alternative visuals in the game " + "[must be switched on before maps are loaded] ".italic().yellow() + RequiresRestart , ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.RemoveBugVisualModels = toggle;
-            }
-
-            UI.Label("");
-
-            toggle = Main.Settings.EnableHudToggleElementsHotkeys;
-            if (UI.Toggle("Enables hotkeys to toggle HUD components visibility " + "[ctrl-(C)ontrol Panel / ctrl-(L)og / ctrl-(M)ap / ctrl-(P)arty]".italic().yellow(), ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.EnableHudToggleElementsHotkeys = toggle;
-            }
-
-            UI.Label("");
 
             toggle = Main.Settings.EnableInventoryFilterAndSort;
             if (UI.Toggle("Enables inventory filtering and sorting " + RequiresRestart, ref toggle, UI.AutoWidth()))
@@ -75,9 +38,17 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             }
 
             toggle = Main.Settings.EnableSaveByLocation;
-            if (UI.Toggle("Enables save by locations / campaigns", ref toggle, UI.AutoWidth()))
+            if (UI.Toggle("Enables save by campaigns / locations", ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.EnableSaveByLocation = toggle;
+            }
+
+            UI.Label("");
+
+            toggle = Main.Settings.EnableHudToggleElementsHotkeys;
+            if (UI.Toggle("Enables hotkeys to toggle HUD components visibility " + "[ctrl-(C)ontrol Panel / ctrl-(L)og / ctrl-(M)ap / ctrl-(P)arty]".italic().yellow(), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableHudToggleElementsHotkeys = toggle;
             }
 
             toggle = Main.Settings.InvertAltBehaviorOnTooltips;
@@ -92,6 +63,52 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 Main.Settings.RecipeTooltipShowsRecipe = toggle;
             }
 
+            #region AdventureLog
+            UI.Label("");
+
+            toggle = DisplayAdventureLog;
+            if (UI.DisclosureToggle("Adventure Log settings: ".yellow(), ref toggle, 200))
+            {
+                DisplayAdventureLog = toggle;
+            }
+
+            if (DisplayAdventureLog)
+            {
+                UI.Label("");
+
+                toggle = Main.Settings.EnableAdventureLogBanterLines;
+                if (UI.Toggle("Records NPCs banter lines", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableAdventureLogBanterLines = toggle;
+                }
+
+                toggle = Main.Settings.EnableAdventureLogDocuments;
+                if (UI.Toggle("Records read documents and notes", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableAdventureLogDocuments = toggle;
+                }
+
+                toggle = Main.Settings.EnableAdventureLogLore;
+                if (UI.Toggle("Records full screen lore", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableAdventureLogLore = toggle;
+                }
+
+                toggle = Main.Settings.EnableAdventureLogTextFeedback;
+                if (UI.Toggle("Records text feedback", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableAdventureLogTextFeedback = toggle;
+                }
+
+                toggle = Main.Settings.EnableAdventureLogPopups;
+                if (UI.Toggle("Records bottom and header popups", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableAdventureLogPopups = toggle;
+                }
+            }
+            #endregion
+
+            #region Battle
             UI.Label("");
 
             toggle = DisplayBattle;
@@ -138,34 +155,99 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                     Main.Settings.CustomTimeScale = floatValue;
                 }
             }
+            #endregion
 
+            #region Item
             UI.Label("");
 
-            using (UI.HorizontalScope())
+            toggle = DisplayItem;
+            if (UI.DisclosureToggle("Item settings: ".yellow(), ref toggle, 200))
             {
-                UI.Label("Empress Garb".orange() + " appearance ".white(), UI.Width(325));
+                DisplayItem = toggle;
+            }
 
-                intValue = Array.IndexOf(ItemOptionsContext.EmpressGarbSkins, Main.Settings.EmpressGarbSkin);
-                if (UI.SelectionGrid(ref intValue, ItemOptionsContext.EmpressGarbSkins, ItemOptionsContext.EmpressGarbSkins.Length, UI.Width(600)))
+            if (DisplayItem)
+            {
+                UI.Label("");
+
+                toggle = Main.Settings.EnableInvisibleCrownOfTheMagister;
+                if (UI.Toggle("Hides Crown of the Magister on game UI", ref toggle, UI.AutoWidth()))
                 {
-                    Main.Settings.EmpressGarbSkin = ItemOptionsContext.EmpressGarbSkins[intValue];
-                    ItemOptionsContext.SwitchEmpressGarb();
+                    Main.Settings.EnableInvisibleCrownOfTheMagister = toggle;
+                    ItemOptionsContext.SwitchCrownOfTheMagister();
+                }
+
+                UI.Label("");
+
+                using (UI.HorizontalScope())
+                {
+                    UI.Label("Empress Garb".orange() + " appearance ".white(), UI.Width(325));
+
+                    intValue = Array.IndexOf(ItemOptionsContext.EmpressGarbSkins, Main.Settings.EmpressGarbSkin);
+                    if (UI.SelectionGrid(ref intValue, ItemOptionsContext.EmpressGarbSkins, ItemOptionsContext.EmpressGarbSkins.Length, UI.Width(600)))
+                    {
+                        Main.Settings.EmpressGarbSkin = ItemOptionsContext.EmpressGarbSkins[intValue];
+                        ItemOptionsContext.SwitchEmpressGarb();
+                    }
                 }
             }
+            #endregion
 
+            #region Monster
             UI.Label("");
 
-            intValue = Main.Settings.MaxSpellLevelsPerLine;
-            if (UI.Slider("Max levels per line on Spell Panel".white(), ref intValue, 3, 7, 5, "", UI.AutoWidth()))
+            toggle = DisplayMonster;
+            if (UI.DisclosureToggle("Monster settings: ".yellow(), ref toggle, 200))
             {
-                Main.Settings.MaxSpellLevelsPerLine = intValue;
+                DisplayMonster = toggle;
             }
 
-            floatValue = Main.Settings.SpellPanelGapBetweenLines;
-            if (UI.Slider("Gap between spell lines on Spell Panel".white(), ref floatValue, 0f, 200f, 50f, 0, "", UI.AutoWidth()))
+            if (DisplayMonster)
             {
-                Main.Settings.SpellPanelGapBetweenLines = floatValue;
+                UI.Label("");
+
+                toggle = Main.Settings.HideMonsterHitPoints;
+                if (UI.Toggle("Displays Monsters's health in steps of 25% / 50% / 75% / 100% instead of exact hit points", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.HideMonsterHitPoints = toggle;
+                }
+
+                toggle = Main.Settings.RemoveBugVisualModels;
+                if (UI.Toggle("Replaces bug-like models with alternative visuals in the game " + "[must be switched on before maps are loaded] ".italic().yellow() + RequiresRestart, ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.RemoveBugVisualModels = toggle;
+                }
             }
+            #endregion
+
+            #region Spell
+            UI.Label("");
+
+            toggle = DisplaySpell;
+            if (UI.DisclosureToggle("Spell settings: ".yellow(), ref toggle, 200))
+            {
+                DisplaySpell = toggle;
+            }
+
+            if (DisplaySpell)
+            {
+                UI.Label("");
+
+                intValue = Main.Settings.MaxSpellLevelsPerLine;
+                if (UI.Slider("Max levels per line on Spell Panel".white(), ref intValue, 3, 7, 5, "", UI.AutoWidth()))
+                {
+                    Main.Settings.MaxSpellLevelsPerLine = intValue;
+                }
+
+                floatValue = Main.Settings.SpellPanelGapBetweenLines;
+                if (UI.Slider("Gap between spell lines on Spell Panel".white(), ref floatValue, 0f, 200f, 50f, 0, "", UI.AutoWidth()))
+                {
+                    Main.Settings.SpellPanelGapBetweenLines = floatValue;
+                }
+            }
+            #endregion
+
+            UI.Label("");
         }
     }
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -55,16 +55,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("House:".yellow());
             UI.Label("");
 
-            toggle = Main.Settings.PickPocketEnabled;
-            if (UI.Toggle("Adds pickpocketable loot [suggested if " + "Pickpocket".orange() + " feat is enabled]", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.PickPocketEnabled = toggle;
-                if (toggle)
-                {
-                    PickPocketContext.Load();
-                }
-            }
-
             toggle = Main.Settings.EnableUniversalSylvanArmor;
             if (UI.Toggle("Allows any class to wear sylvan armor", ref toggle, UI.AutoWidth()))
             {
@@ -79,12 +69,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 DruidArmorContext.Switch(toggle);
             }
 
-            toggle = Main.Settings.DisableAutoEquip;
-            if (UI.Toggle("Disables auto-equip of items in inventory", ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.DisableAutoEquip = toggle;
-            }
-
             toggle = Main.Settings.EnableMagicStaffFoci;
             if (UI.Toggle("Makes all magic staves arcane foci " + "[except for Staff of Healing which is Universal]".italic().yellow(), ref toggle, UI.AutoWidth()))
             {
@@ -92,11 +76,31 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 ItemOptionsContext.SwitchMagicStaffFoci();
             }
 
+            UI.Label("");
+
+            toggle = Main.Settings.PickPocketEnabled;
+            if (UI.Toggle("Adds pickpocketable loot [suggested if " + "Pickpocket".orange() + " feat is enabled]", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.PickPocketEnabled = toggle;
+                if (toggle)
+                {
+                    PickPocketContext.Load();
+                }
+            }
+
+            toggle = Main.Settings.DisableAutoEquip;
+            if (UI.Toggle("Disables auto-equip of items in inventory", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.DisableAutoEquip = toggle;
+            }
+
             toggle = Main.Settings.ExactMerchantCostScaling;
             if (UI.Toggle("Scales merchant prices correctly / exactly", ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.ExactMerchantCostScaling = toggle;
             }
+
+            UI.Label("");
         }
     }
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/ToolsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ToolsDisplay.cs
@@ -10,9 +10,32 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 
         internal static void DisplayTools()
         {
+            bool toggle;
+            int intValue;
+
+            UI.Label("");
+            UI.Label("Custom dungeons:".yellow());
             UI.Label("");
 
-            bool toggle = Main.Settings.EnableCheatMenuDuringGameplay;
+            toggle = Main.Settings.EnableDungeonLevelBypass;
+            if (UI.Toggle("Overrides required min / max level", ref toggle))
+            {
+                Main.Settings.EnableDungeonLevelBypass = toggle;
+            }
+
+            UI.Label("");
+
+            intValue = Main.Settings.UserDungeonsPartySize;
+            if (UI.Slider("Overrides party size".white(), ref intValue, Settings.MIN_PARTY_SIZE, Settings.MAX_PARTY_SIZE, Settings.GAME_PARTY_SIZE, "", UI.AutoWidth()))
+            {
+                Main.Settings.UserDungeonsPartySize = intValue;
+            }
+
+            UI.Label("");
+            UI.Label("Debug:".yellow());
+            UI.Label("");
+
+            toggle = Main.Settings.EnableCheatMenuDuringGameplay;
             if (UI.Toggle("Enables the cheats menu", ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.EnableCheatMenuDuringGameplay = toggle;
@@ -39,6 +62,8 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             }
 
             UI.Label("");
+            UI.Label("Experience:".yellow());
+            UI.Label("");
 
             toggle = Main.Settings.NoExperienceOnLevelUp;
             if (UI.Toggle("No experience is required to level up", ref toggle, UI.AutoWidth()))
@@ -46,15 +71,17 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 Main.Settings.NoExperienceOnLevelUp = toggle;
             }
 
+            UI.Label("");
 
-            int intValue = Main.Settings.ExperienceModifier;
+            intValue = Main.Settings.ExperienceModifier;
             if (UI.Slider("Multiplies the experience gained by ".white() + "[%]".red(), ref intValue, 50, 200, 100, "", UI.Width(100)))
             {
                 Main.Settings.ExperienceModifier = intValue;
             }
 
             UI.Label("");
-            UI.Label("Faction Relations:");
+            UI.Label("Faction Relations:".yellow());
+            UI.Label("");
 
             bool flip = true;
             var gameService = ServiceRepository.GetService<IGameService>();
@@ -99,9 +126,10 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             }
             else
             {
-                UI.Label("");
                 UI.Label("Load an official campaign game to modify faction relations...".red());
             }
+
+            UI.Label("");
         }
     }
 }


### PR DESCRIPTION
- adds support for adventure log entries on custom dungeons
- reorganizes the UI a bit
- migrates from DMPRO:

1. custom party size from 1 to 6 on custom dungeons only
2. no min/max level constraints when selecting custom dungeons' heroes