### PR TITLE
Save by location changes

### DIFF
--- a/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
+++ b/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
@@ -31,6 +31,24 @@
         {
             public string Campaign { get; set; }
             public string Location { get; set; }
+
+            public string GetFolderName()
+            {
+                string folder = string.Empty;
+
+                if((Campaign == USER_CAMPAIGN || string.IsNullOrWhiteSpace(Campaign)) && !string.IsNullOrWhiteSpace(Location))
+                {
+                    folder = $@"CE\Location\{Location.Trim()}"; 
+                }
+                else if (Campaign != MAIN_CAMPAIGN && !string.IsNullOrWhiteSpace(Campaign))
+                {
+                    folder = $@"CE\Campaign\{Campaign.Trim()}";
+                }
+
+                Main.Log($"Campaign='{Campaign}', Location='{Location}', Folder='{folder}'");
+
+                return folder;
+            }
         }
     }
 }

--- a/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
+++ b/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
@@ -44,7 +44,7 @@ namespace SolastaCommunityExpansion.Models
         {
             MainCampaign,
             UserLocation,
-            UserCampaign
+            CustomCampaign
         }
 
         internal class SelectedCampaignService : ISelectedCampaignService
@@ -69,7 +69,7 @@ namespace SolastaCommunityExpansion.Models
                 {
                     // User campaign
                     SaveGameDirectory = Path.Combine(CampaignSaveGameDirectory, camp);
-                    LocationType = LocationType.UserCampaign;
+                    LocationType = LocationType.CustomCampaign;
                     CampaignOrLocationName = campaign;
                 }
                 else
@@ -94,7 +94,7 @@ namespace SolastaCommunityExpansion.Models
 
                         return Directory.Exists(saveFolder) && Directory.EnumerateFiles(saveFolder, "*.sav").Any();
                     }
-                case LocationType.UserCampaign:
+                case LocationType.CustomCampaign:
                     {
                         var saveFolder = Path.Combine(CampaignSaveGameDirectory, folder);
 

--- a/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
+++ b/SolastaCommunityExpansion/Models/SaveByLocationContext.cs
@@ -1,9 +1,14 @@
-﻿namespace SolastaCommunityExpansion.Models
+﻿using System.IO;
+using System.Linq;
+
+namespace SolastaCommunityExpansion.Models
 {
     internal static class SaveByLocationContext
     {
         internal const string MAIN_CAMPAIGN = "CrownOfTheMagister";
         internal const string USER_CAMPAIGN = "UserCampaign";
+
+        internal static readonly string BaseSaveFolder = Path.Combine(TacticalAdventuresApplication.GameDirectory, "Saves");
 
         internal static class ServiceRepositoryEx
         {
@@ -36,9 +41,9 @@
             {
                 string folder = string.Empty;
 
-                if((Campaign == USER_CAMPAIGN || string.IsNullOrWhiteSpace(Campaign)) && !string.IsNullOrWhiteSpace(Location))
+                if ((Campaign == USER_CAMPAIGN || string.IsNullOrWhiteSpace(Campaign)) && !string.IsNullOrWhiteSpace(Location))
                 {
-                    folder = $@"CE\Location\{Location.Trim()}"; 
+                    folder = $@"CE\Location\{Location.Trim()}";
                 }
                 else if (Campaign != MAIN_CAMPAIGN && !string.IsNullOrWhiteSpace(Campaign))
                 {
@@ -49,6 +54,35 @@
 
                 return folder;
             }
+        }
+
+        public static bool HasSaves(bool? isLocation, string folder)
+        {
+            switch (isLocation)
+            {
+                case true:
+                    {
+                        var saveFolder = Path.Combine(BaseSaveFolder, $@"CE\Location\{folder}");
+
+                        var hasSaves = Directory.Exists(saveFolder) && Directory.EnumerateFiles(saveFolder, "*.sav").Any();
+
+                        Main.Log($"Scanning {saveFolder}, hasSaves={hasSaves}");
+
+                        return hasSaves;
+                    }
+                case false:
+                    {
+                        var saveFolder = Path.Combine(BaseSaveFolder, $@"CE\Campaign\{folder}");
+
+                        var hasSaves = Directory.Exists(saveFolder) && Directory.EnumerateFiles(saveFolder, "*.sav").Any();
+
+                        Main.Log($"Scanning {saveFolder}, hasSaves={hasSaves}");
+
+                        return hasSaves;
+                    }
+            }
+
+            return true;
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/GameLocationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/GameLocationManagerPatcher.cs
@@ -22,13 +22,14 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
 
             if (sessionService != null && sessionService.Session != null)
             {
+                // Record which campaign/location the latest load game belongs to
+
                 var session = sessionService.Session;
                 var selectedCampaignService = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>();
 
                 Main.Log($"Campaign-ss: Campaign={session.CampaignDefinitionName}, Location: {session.UserLocationName}");
 
-                selectedCampaignService.Campaign = userCampaignName;
-                selectedCampaignService.Location = userLocationName;
+                selectedCampaignService.SetCampaignLocation(userCampaignName, userLocationName);
             }
 
             __instance.StartCoroutine(ServiceRepository.GetService<IGameSerializationService>()?.EnumerateSavesGames());

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/GameLocationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/GameLocationManagerPatcher.cs
@@ -8,12 +8,15 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameLocationManager_LoadLocationAsync
     {
-        public static void Prefix(GameLocationManager __instance, string userLocationName)
+        public static void Prefix(GameLocationManager __instance,
+            string locationDefinitionName, string userLocationName, string userCampaignName)
         {
             if (!Main.Settings.EnableSaveByLocation)
             {
                 return;
             }
+
+            Main.Log($"LoadLocationAsync-Params: ld={locationDefinitionName}, ul={userLocationName}, uc={userCampaignName}");
 
             var sessionService = ServiceRepository.GetService<ISessionService>();
 
@@ -22,8 +25,10 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
                 var session = sessionService.Session;
                 var selectedCampaignService = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>();
 
-                selectedCampaignService.Campaign = session.CampaignDefinitionName;
-                selectedCampaignService.Location = string.IsNullOrEmpty(session.UserCampaignName) ? session.UserLocationName : session.UserCampaignName;
+                Main.Log($"Campaign-ss: Campaign={session.CampaignDefinitionName}, Location: {session.UserLocationName}");
+
+                selectedCampaignService.Campaign = userCampaignName;
+                selectedCampaignService.Location = userLocationName;
             }
 
             __instance.StartCoroutine(ServiceRepository.GetService<IGameSerializationService>()?.EnumerateSavesGames());

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
@@ -15,6 +15,8 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
                 return true;
             }
 
+            // Enable/disable the 'load' button in the load save panel
+
             __result = !___saving && !___loading && ___loadDisabledTokens.Count <= 0;
 
             return false;

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using ModKit;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -6,6 +7,7 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 using static SolastaCommunityExpansion.Models.SaveByLocationContext;
+using static TMPro.TMP_Dropdown;
 
 namespace SolastaCommunityExpansion
 {
@@ -29,66 +31,49 @@ namespace SolastaCommunityExpansion
                 return;
             }
 
-            GuiDropdown guiDropdown;
-
-            // create a drop down singleton
-            if (Dropdown == null)
-            {
-                var dropdownPrefab = Resources.Load<GameObject>("GUI/Prefabs/Component/Dropdown");
-
-                Dropdown = Object.Instantiate(dropdownPrefab);
-                Dropdown.name = "LoadMenuDropDown";
-
-                guiDropdown = Dropdown.GetComponent<GuiDropdown>();
-                guiDropdown.onValueChanged.AddListener(delegate { ValueChanged(guiDropdown); });
-
-                var buttonBar = canvas.GetComponentsInChildren<RectTransform>().SingleOrDefault(c => c.gameObject.name == "ButtonsBar")?.gameObject;
-
-                if (buttonBar != null)
-                {
-                    var horizontalLayoutGroup = buttonBar.GetComponent<HorizontalLayoutGroup>();
-
-                    if (horizontalLayoutGroup != null)
-                    {
-                        Dropdown.transform.SetParent(horizontalLayoutGroup.transform, false);
-                    }
-                }
-            }
-            else
-            {
-                Dropdown.SetActive(true);
-                guiDropdown = Dropdown.GetComponent<GuiDropdown>();
-            }
-
-            var removedContent = new List<string>();
+            var guiDropdown = CreateOrActivateDropdown();
 
             // get all user locations
             var userLocationPoolService = ServiceRepository.GetService<IUserLocationPoolService>();
-            userLocationPoolService.EnumeratePool(out var _, removedContent);
+            userLocationPoolService.EnumeratePool(out var _, new List<string>());
             var allLocations = userLocationPoolService.AllLocations;
 
             // get all user campaigns
             var userCampaignPoolService = ServiceRepository.GetService<IUserCampaignPoolService>();
-            userCampaignPoolService.EnumeratePool(out var _, removedContent);
+            userCampaignPoolService.EnumeratePool(out var _, new List<string>());
             var allCampaigns = userCampaignPoolService.AllCampaigns;
 
             // populate the dropdown
             guiDropdown.ClearOptions();
 
-            var userContentList = allLocations
-                .Select(l => l.Title)
-                .Union(allCampaigns.Select(l => l.Title))
-                .OrderBy(l => l)
+            var userContentList =
+                allCampaigns
+                        .Select(l => new { IsLocation = (bool?)false, l.Title })
+                        .OrderBy(l => l.Title)
+                .Concat(
+                    allLocations
+                    .Select(l => new { IsLocation = (bool?)true, l.Title })
+                    .OrderBy(l => l.Title)
+                )
                 .ToList();
 
-            // TODO: give a visual indication (colour/icon) of campaign vs location
-            guiDropdown.AddOptions(Enumerable.Repeat("Main campaign", 1)
+            guiDropdown.AddOptions(
+                Enumerable.Repeat(new { IsLocation = (bool?)null, Title = "Main campaign" }, 1)
                 .Union(userContentList)
-                .Select(l => new TMPro.TMP_Dropdown.OptionData
+                .Select(opt => new CEOptionData
                 {
-                    text = l
-                }).ToList());
+                    text = GetTitle(opt.IsLocation, opt.Title),
+                    CampaignOrLocation = opt.Title,
+                    image = GetImage(opt.IsLocation, opt.Title),
+                    IsLocation = opt.IsLocation,
+                    HasSaves = HasSaves(opt.IsLocation, opt.Title),
+                    // TODO: get latest save date
+                })
+                .Where(opt => opt.HasSaves)
+                .OfType<OptionData>()
+                .ToList());
 
+            // TODO: is this working?
             // Get the current campaign location and select it in the dropdown
             var currentLocation = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>().Location;
             var option = guiDropdown.options
@@ -99,14 +84,47 @@ namespace SolastaCommunityExpansion
 
             ValueChanged(guiDropdown);
 
+            Sprite GetImage(bool? isLocation, string title)
+            {
+                // TODO: get suitable sprites - anyone?
+                return null;
+            }
+
+            string GetTitle(bool? isLocation, string title)
+            {
+                switch (isLocation)
+                {
+                    case null:
+                        return title;
+                    case false:
+                        return title.yellow();
+                    default:
+                        return title.orange();
+                }
+            }
+
             void ValueChanged(GuiDropdown dropdown)
             {
                 // update selected campaign
                 var selectedCampaignService = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>();
-                var title = dropdown.value == 0 ? string.Empty : dropdown.options.Skip(dropdown.value).FirstOrDefault()?.text;
 
-                selectedCampaignService.Campaign = dropdown.value == 0 ? MAIN_CAMPAIGN : USER_CAMPAIGN;
-                selectedCampaignService.Location = title;
+                var selected = dropdown.options.Skip(dropdown.value).FirstOrDefault() as CEOptionData;
+
+                switch (selected.IsLocation)
+                {
+                    case null: // default campaign
+                        selectedCampaignService.Campaign = MAIN_CAMPAIGN;
+                        selectedCampaignService.Location = "";
+                        break;
+                    case true: // location (campaign=USER_CAMPAIGN + location)
+                        selectedCampaignService.Campaign = USER_CAMPAIGN;
+                        selectedCampaignService.Location = selected.CampaignOrLocation;
+                        break;
+                    case false: // campaign
+                        selectedCampaignService.Campaign = selected.CampaignOrLocation;
+                        selectedCampaignService.Location = "";
+                        break;
+                }
 
                 // reload the save list
                 var method = AccessTools.Method(typeof(LoadPanel), "EnumerateSaveLines");
@@ -116,6 +134,49 @@ namespace SolastaCommunityExpansion
                 method = AccessTools.Method(typeof(LoadPanel), "Reset");
                 method.Invoke(__instance, null);
             }
+
+            GuiDropdown CreateOrActivateDropdown()
+            {
+                GuiDropdown dd;
+
+                // create a drop down singleton
+                if (Dropdown == null)
+                {
+                    var dropdownPrefab = Resources.Load<GameObject>("GUI/Prefabs/Component/Dropdown");
+
+                    Dropdown = Object.Instantiate(dropdownPrefab);
+                    Dropdown.name = "LoadMenuDropDown";
+
+                    dd = Dropdown.GetComponent<GuiDropdown>();
+                    dd.onValueChanged.AddListener(delegate { ValueChanged(dd); });
+
+                    var buttonBar = canvas.GetComponentsInChildren<RectTransform>().SingleOrDefault(c => c.gameObject.name == "ButtonsBar")?.gameObject;
+
+                    if (buttonBar != null)
+                    {
+                        var horizontalLayoutGroup = buttonBar.GetComponent<HorizontalLayoutGroup>();
+
+                        if (horizontalLayoutGroup != null)
+                        {
+                            Dropdown.transform.SetParent(horizontalLayoutGroup.transform, false);
+                        }
+                    }
+                }
+                else
+                {
+                    Dropdown.SetActive(true);
+                    dd = Dropdown.GetComponent<GuiDropdown>();
+                }
+
+                return dd;
+            }
         }
+    }
+
+    internal class CEOptionData : OptionData
+    {
+        public string CampaignOrLocation { get; set; }
+        public bool? IsLocation { get; set; }
+        public bool HasSaves { get; set; }
     }
 }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
@@ -48,7 +48,7 @@ namespace SolastaCommunityExpansion
                 {
                     var horizontalLayoutGroup = buttonBar.GetComponent<HorizontalLayoutGroup>();
 
-                    if(horizontalLayoutGroup != null)
+                    if (horizontalLayoutGroup != null)
                     {
                         Dropdown.transform.SetParent(horizontalLayoutGroup.transform, false);
                     }
@@ -75,10 +75,19 @@ namespace SolastaCommunityExpansion
             // populate the dropdown
             guiDropdown.ClearOptions();
 
-            var userContentList = allLocations.Select(l => l.Title).Union(allCampaigns.Select(l => l.Title)).ToList();
+            var userContentList = allLocations
+                .Select(l => l.Title)
+                .Union(allCampaigns.Select(l => l.Title))
+                .OrderBy(l => l)
+                .ToList();
 
-            userContentList.Sort();
-            guiDropdown.AddOptions(Enumerable.Repeat("Main campaign", 1).Union(userContentList).Select(l => new TMPro.TMP_Dropdown.OptionData { text = l }).ToList());
+            // TODO: give a visual indication (colour/icon) of campaign vs location
+            guiDropdown.AddOptions(Enumerable.Repeat("Main campaign", 1)
+                .Union(userContentList)
+                .Select(l => new TMPro.TMP_Dropdown.OptionData
+                {
+                    text = l
+                }).ToList());
 
             // Get the current campaign location and select it in the dropdown
             var currentLocation = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>().Location;

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
@@ -18,6 +18,8 @@ namespace SolastaCommunityExpansion
                 return;
             }
 
+            // TODO: select the most recent location/campaign
+
             var root = TacticalAdventuresApplication.SaveGameDirectory;
 
             var mostRecent = Directory.EnumerateDirectories(root)

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
@@ -18,26 +18,36 @@ namespace SolastaCommunityExpansion
                 return;
             }
 
-            // find the most recently touched save file and select the correct location/campaign for that save
+            // Ensure folders exist
+            Directory.CreateDirectory(LocationSaveGameDirectory);
+            Directory.CreateDirectory(CampaignSaveGameDirectory);
 
-
-/*
-            var root = TacticalAdventuresApplication.SaveGameDirectory;
-
-            var mostRecent = Directory.EnumerateDirectories(root)
+            // Find the most recently touched save file and select the correct location/campaign for that save
+            var mostRecent = Directory.EnumerateDirectories(LocationSaveGameDirectory)
                 .Select(d => new
                 {
                     Path = d,
-                    LastWriteTime = Directory.EnumerateFiles(d).Max(f => (DateTime?)File.GetLastWriteTimeUtc(f))
+                    LastWriteTime = Directory.EnumerateFiles(d, "*.sav").Max(f => (DateTime?)File.GetLastWriteTimeUtc(f)),
+                    LocationType = LocationType.UserLocation
                 })
+                .Concat(
+                    Directory.EnumerateDirectories(CampaignSaveGameDirectory)
+                        .Select(d => new
+                        {
+                            Path = d,
+                            LastWriteTime = Directory.EnumerateFiles(d, "*.sav").Max(f => (DateTime?)File.GetLastWriteTimeUtc(f)),
+                            LocationType = LocationType.CustomCampaign
+                        })
+                )
                 .Concat(
                     Enumerable.Repeat(
                         new
                         {
-                            Path = root,
-                            LastWriteTime = Directory.EnumerateFiles(root).Max(f => (DateTime?)File.GetLastWriteTimeUtc(f))
-                        }, 
-                        1)
+                            Path = DefaultSaveGameDirectory,
+                            LastWriteTime = Directory.EnumerateFiles(DefaultSaveGameDirectory, "*.sav").Max(f => (DateTime?)File.GetLastWriteTimeUtc(f)),
+                            LocationType = LocationType.MainCampaign
+                        }
+                    , 1)
                 )
                 .Where(d => d.LastWriteTime.HasValue)
                 .OrderByDescending(d => d.LastWriteTime)
@@ -45,12 +55,23 @@ namespace SolastaCommunityExpansion
 
             var selectedCampaignService = ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>();
 
-            if (mostRecent != null && mostRecent.Path != root && selectedCampaignService != null)
+            if (selectedCampaignService != null && mostRecent != null)
             {
-                selectedCampaignService.Location = Path.GetFileName(mostRecent.Path);
-                selectedCampaignService.Campaign = USER_CAMPAIGN;
+                Main.Log($"Most recent folder={mostRecent.Path}");
+
+                switch(mostRecent.LocationType)
+                {
+                    default:
+                        selectedCampaignService.SetCampaignLocation(MAIN_CAMPAIGN, string.Empty);
+                        break;
+                    case LocationType.UserLocation:
+                        selectedCampaignService.SetCampaignLocation(USER_CAMPAIGN, Path.GetFileName(mostRecent.Path));
+                        break;
+                    case LocationType.CustomCampaign:
+                        selectedCampaignService.SetCampaignLocation(Path.GetFileName(mostRecent.Path), string.Empty);
+                        break;
+                }
             }
-*/
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
@@ -18,8 +18,10 @@ namespace SolastaCommunityExpansion
                 return;
             }
 
-            // TODO: select the most recent location/campaign
+            // find the most recently touched save file and select the correct location/campaign for that save
 
+
+/*
             var root = TacticalAdventuresApplication.SaveGameDirectory;
 
             var mostRecent = Directory.EnumerateDirectories(root)
@@ -48,6 +50,7 @@ namespace SolastaCommunityExpansion
                 selectedCampaignService.Location = Path.GetFileName(mostRecent.Path);
                 selectedCampaignService.Campaign = USER_CAMPAIGN;
             }
+*/
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
@@ -16,12 +16,14 @@ namespace SolastaCommunityExpansion
                 return true;
             }
 
+            // Modify the value returned by TacticalAdventuresApplication.SaveGameDirectory so that saves
+            // end up where we want them (by location/campaign).
+
             var selectedCampaignService = ServiceRepository.GetService<SelectedCampaignService>();
 
-            var saves = Path.Combine(TacticalAdventuresApplication.GameDirectory, "Saves");
-            __result = Path.Combine(saves, selectedCampaignService?.GetFolderName() ?? string.Empty);
+            __result = selectedCampaignService?.SaveGameDirectory ?? DefaultSaveGameDirectory;
 
-            Main.Log($"GetSaveFolder={saves}, {__result}");
+            Main.Log($"SaveFolder changed from {DefaultSaveGameDirectory} to {__result}");
 
             return false;
         }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
@@ -18,14 +18,10 @@ namespace SolastaCommunityExpansion
 
             var selectedCampaignService = ServiceRepository.GetService<SelectedCampaignService>();
 
-            if (selectedCampaignService == null || string.IsNullOrEmpty(selectedCampaignService.Location) || selectedCampaignService.Campaign == MAIN_CAMPAIGN)
-            {
-                __result = Path.Combine(TacticalAdventuresApplication.GameDirectory, "Saves");
-            }
-            else
-            {
-                __result = Path.Combine(Path.Combine(TacticalAdventuresApplication.GameDirectory, "Saves"), selectedCampaignService.Location);
-            }
+            var saves = Path.Combine(TacticalAdventuresApplication.GameDirectory, "Saves");
+            __result = Path.Combine(saves, selectedCampaignService?.GetFolderName() ?? string.Empty);
+
+            Main.Log($"GetSaveFolder={saves}, {__result}");
 
             return false;
         }

--- a/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
         {
             { "ChrisJohnDigital".orange().bold(), "head developer, feats, items, subclasses, progression, etc." },
             { "Zappastuff", "mod UI work, integration, community organization, level 20, respec" },
-            { "ImpPhil", "monster's health, pause UI, stocks prices, no attunement, xp scaling, character export" },
+            { "ImpPhil", "monster's health, pause UI, stocks prices, no attunement, xp scaling, character export, save by location" },
             { "DubhHerder", "Crafty Feats Migration" },
             { "View619", "Darkvision, Superior Dark Vision" },
             { "SilverGriffon", "PickPocket, lore friendly names, crafty feats, face unlocks" },


### PR DESCRIPTION
Changed save by location to
1) save locations in their own folder (used to save in the first folder of a linked set)
2) save locations and campaigns in the following folder structure

Solasta\Saves\Ce\Location\<loc names>
Solasta\Saves\Ce\Campaign\<campaign names>
Solasta\Saves ... main campaign saves

Drop down is now colour coded to distinguish campaigns from locations.  Could use some suitable icons.
![image](https://user-images.githubusercontent.com/271656/145715861-76172b01-0a28-4beb-952e-ce52ff1b23ba.png)

