### PR TITLE
Adjust chain lightning

### DIFF
--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaModApi.Extensions;
 using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
@@ -7,6 +8,11 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class SrdAndHouseRulesContext
     {
+        internal static void Load()
+        {
+            AdjustChainLightningSpell();
+        }
+
         internal static void ApplyConditionBlindedShouldNotAllowOpportunityAttack()
         {
             // Use the shocked condition affinity which has the desired effect
@@ -105,6 +111,27 @@ namespace SolastaCommunityExpansion.Models
                 {
                     surprisedCharacter.StartBattle(false);
                 }
+            }
+        }
+
+        internal static void AdjustChainLightningSpell()
+        {
+            var spell = SolastaModApi.DatabaseHelper.SpellDefinitions.ChainLightning.EffectDescription;
+
+            if (Main.Settings.AdjustChainLightningSpell)
+            {
+                // This is half bug-fix, half houses rules since it's not completely SRD but better than implemented.
+                // Spell should arc from target (range 150ft) onto upto 3 extra selectable targets (range 30ft from first).
+                // Fix by allowing 4 selectable targets.
+                spell.TargetType = RuleDefinitions.TargetType.IndividualsUnique;
+                spell.SetTargetParameter(4);
+
+                // TODO: may need to tweak range parameters but it works as is.
+            }
+            else
+            {
+                spell.TargetType = RuleDefinitions.TargetType.ArcFromIndividual;
+                spell.SetTargetParameter(3);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -40,6 +40,7 @@ namespace SolastaCommunityExpansion.Patches
             DungeonMakerContext.Load();
             TelemaCampaignContext.Load();
             EncountersSpawnContext.Load();
+            SrdAndHouseRulesContext.Load();
 
             Main.Enabled = true;
         }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -202,5 +202,6 @@ namespace SolastaCommunityExpansion
 
         public bool ArcaneFighterEnchantWeaponRechargeShortRest { get; set; }
         public bool FixItemFiltering { get; set; } = true;
+        public bool AdjustChainLightningSpell { get; set; }
     }
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -61,6 +61,13 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 SrdAndHouseRulesContext.ApplyConditionBlindedShouldNotAllowOpportunityAttack();
             }
 
+            toggle = Main.Settings.AdjustChainLightningSpell;
+            if (UI.Toggle("Chain lightning spell: allow target selection", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.AdjustChainLightningSpell = toggle;
+                SrdAndHouseRulesContext.AdjustChainLightningSpell();
+            }
+
             UI.Label("");
             UI.Label("House:".yellow());
             UI.Label("");


### PR DESCRIPTION
Fixes #249 

This changes the Chain Lightning spell to allow targeting 4 creatures.  Not quite SRD but better than implemented where lightning arcs onto allies.
