### PR TITLE
keeps char. panel open w/ hero selected after level up / char creation

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUiLevelUp/CharacterEditionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiLevelUp/CharacterEditionScreenPatcher.cs
@@ -1,0 +1,24 @@
+﻿using HarmonyLib;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(CharacterEditionScreen), "OnFinishCb")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterEditionScreen_OnFinishCb
+    {
+        internal static string HeroName { get; set; }
+
+        internal static void Prefix()
+        {
+            if (Gui.Game == null && Main.Settings.KeepCharactersPanelOpenAndHeroSelectedOnLevelUp)
+            {
+                HeroName = ServiceRepository.GetService<ICharacterBuildingService>().HeroCharacter.Name;
+            }
+            else
+            {
+                HeroName = null;
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUiLevelUp/CharactersPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiLevelUp/CharactersPanelPatcher.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(CharactersPanel), "OnBeginShow")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharactersPanel_OnBeginShow
+    {
+        internal static void Postfix(CharactersPanel __instance)
+        {
+            if (CharacterEditionScreen_OnFinishCb.HeroName != null)
+            {
+                var mainMenuScreen = __instance.OriginScreen as MainMenuScreen;
+                var charactersPanel = AccessTools.Field(mainMenuScreen.GetType(), "charactersPanel").GetValue(mainMenuScreen) as CharactersPanel;
+                var characterPlates = AccessTools.Field(charactersPanel.GetType(), "characterPlates").GetValue(charactersPanel) as List<CharacterPlateToggle>;
+                var characterPlate = characterPlates.Find(x => x.GuiCharacter.Name == CharacterEditionScreen_OnFinishCb.HeroName);
+
+                CharacterEditionScreen_OnFinishCb.HeroName = null;
+
+                charactersPanel.OnSelectPlate(characterPlate);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUiLevelUp/GuiPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiLevelUp/GuiPanelPatcher.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SolastaCommunityExpansion.Patches
+{
+    [HarmonyPatch(typeof(GuiPanel), "Show")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GuiPanel_Show
+    {
+        internal static void Postfix(GuiPanel __instance)
+        {
+            if (__instance is MainMenuScreen mainMenuScreen && CharacterEditionScreen_OnFinishCb.HeroName != null)
+            {
+                var charactersPanel = AccessTools.Field(mainMenuScreen.GetType(), "charactersPanel").GetValue(mainMenuScreen) as CharactersPanel;
+
+                charactersPanel.Show();
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -39,6 +39,7 @@ namespace SolastaCommunityExpansion
         public bool MultiLineSpellPanel { get; set; } = true;
         public bool MultiLinePowerPanel { get; set; } = true;
         public bool KeepSpellsOpenSwitchingEquipment { get; set; } = true;
+        public bool KeepCharactersPanelOpenAndHeroSelectedOnLevelUp { get; set; } = true;
         public bool BugFixExpandColorTables { get; set; } = true;
         public bool AllowDynamicPowers { get; set; } = true;
 


### PR DESCRIPTION
. quality of life patch to keep the char panel open on main screen after char. creation / level up.
. the first patch is protected by an invisible toggle on first state
. the 2 other patches are protected by a property set on first patch