### PR TITLE
Rollback

### DIFF
--- a/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DynamicPowers/RulesetCharacterHeroPatcher.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaCommunityExpansion.Helpers;
 using SolastaCommunityExpansion.Patches.PowerSharedPool;
 using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
@@ -31,10 +30,14 @@ namespace SolastaCommunityExpansion.Patches.DynamicPowers
             // to max available uses.
             List<RulesetUsablePower> curPowers = new List<RulesetUsablePower>();
             bool newPower = false;
-            foreach (var featureDefinitionPower in hero
-                .EnumerateFeaturesToBrowse<FeatureDefinitionPower>()
-                .Where(f => f is IConditionalPower p && !p.IsActive(hero)))
+            hero.EnumerateFeaturesToBrowse<FeatureDefinitionPower>(hero.FeaturesToBrowse, null);
+            foreach (FeatureDefinitionPower featureDefinitionPower in hero.FeaturesToBrowse.Cast<FeatureDefinitionPower>())
             {
+                if (featureDefinitionPower is IConditionalPower &&
+                    !(featureDefinitionPower as IConditionalPower).IsActive(hero))
+                {
+                    continue;
+                }
                 RulesetUsablePower rulesetUsablePower = hero.UsablePowers.FirstOrDefault(up => up.PowerDefinition == featureDefinitionPower);
                 if (rulesetUsablePower != null)
                 {
@@ -47,6 +50,7 @@ namespace SolastaCommunityExpansion.Patches.DynamicPowers
                     RulesetUsablePower power = BuildUsablePower(hero, featureDefinitionPower);
                     // If this new power is part of a shared pool, get it properly initialized for usage.
                     if (featureDefinitionPower is IPowerSharedPool)
+
                     {
                         hero.UpdateUsageForPowerPool(power, 0);
                     }

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterPatcher.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaCommunityExpansion.Helpers;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -106,8 +106,12 @@ namespace SolastaCommunityExpansion.Patches.Level20
 
         private static int? MinimumStrengthAbilityCheckTotal(RulesetCharacter character, string proficiencyName)
         {
-            return character
-                .EnumerateFeaturesToBrowse<IMinimumAbilityCheckTotal>()
+            var featuresToBrowse = new List<FeatureDefinition>();
+
+            character.EnumerateFeaturesToBrowse<IMinimumAbilityCheckTotal>(featuresToBrowse);
+
+            return featuresToBrowse
+                .OfType<IMinimumAbilityCheckTotal>()
                 .Select(feature => feature.MinimumStrengthAbilityCheckTotal(character, proficiencyName))
                 .Max();
         }


### PR DESCRIPTION
rolling back both changes that use Helpers Enumerate. Confirmed this broke Powers offering on UI. Haven't had a chance to test the Level 20 one but safer to rollback.