### PR TITLE
Refactor NegativeFeature so that it can be used outside of Thug

### DIFF
--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/NegativeFeature.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/NegativeFeature.cs
@@ -1,0 +1,26 @@
+﻿using SolastaModApi;
+using SolastaModApi.Extensions;
+
+namespace SolastaCommunityExpansion.CustomFeatureDefinitions
+{
+    class NegativeFeature
+    {
+    }
+
+    public class NegativeFeatureDefinition : FeatureDefinition
+    {
+        public string Tag;
+        public FeatureDefinition FeatureToRemove;
+    }
+
+    public sealed class NegativeFeatureBuilder : BaseDefinitionBuilder<NegativeFeatureDefinition>
+    {
+        public NegativeFeatureBuilder(string name, string guid, string tag, FeatureDefinition featureToRemove)
+            : base(name, guid)
+        {
+            Definition.Tag = tag;
+            Definition.FeatureToRemove = featureToRemove;
+            Definition.GuiPresentation.SetHidden(true);
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/NegativeFeature/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/NegativeFeature/CharacterBuildingManagerPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -14,9 +15,9 @@ namespace SolastaCommunityExpansion.Patches.NegativeFeature
         internal static void Prefix(CharacterBuildingManager __instance)
         {
             var activeFeatures = __instance.HeroCharacter.ActiveFeatures;
-            var negativeFeatures = activeFeatures.SelectMany(x => x.Value.FindAll(y => y is Subclasses.Rogue.Thug.NegativeFeatureDefinition));
+            var negativeFeatures = activeFeatures.SelectMany(x => x.Value.FindAll(y => y is NegativeFeatureDefinition));
 
-            foreach (Subclasses.Rogue.Thug.NegativeFeatureDefinition negativeFeature in negativeFeatures)
+            foreach (NegativeFeatureDefinition negativeFeature in negativeFeatures)
             {
                 if (activeFeatures.TryGetValue(negativeFeature.Tag, out var featureDefinitions))
                 {

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -1,4 +1,5 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.CustomFeatureDefinitions;
+using SolastaModApi;
 using SolastaModApi.Extensions;
 using System;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionAdditionalDamages;
@@ -37,35 +38,14 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
 
             Subclass = new CharacterSubclassDefinitionBuilder(RogueSubclassThugName, RogueSubclassThugNameGuid)
                 .SetGuiPresentation(guiPresentation)
-                .AddFeatureAtLevel(NegativeFeatureBuilder.AdditionalDamageRogueSneakAttackRemove, 3)
+                .AddFeatureAtLevel(new NegativeFeatureBuilder(AdditionalDamageRogueSneakAttack.Name + "Remove",
+                     GuidHelper.Create(Thug.SubclassNamespace, AdditionalDamageRogueSneakAttack.Name + "Remove").ToString(),
+                     "03ClassRogue1", AdditionalDamageRogueSneakAttack).AddToDB(), 3)
                 .AddFeatureAtLevel(RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder.ExploitVulnerabilities, 3)
                 .AddFeatureAtLevel(RogueSubclassThugProficienciesBuilder.ThugProficiencies, 3)
                 .AddFeatureAtLevel(RogueSubclassThugBrutalMethodsBuilder.ThugBrutalMethods, 9)
                 .AddFeatureAtLevel(RogueSubclassThugOvercomeCompetitionBuilder.ThugOvercomeCompetition, 13)
                 .AddToDB();
-        }
-
-        internal class NegativeFeatureDefinition : FeatureDefinition
-        {
-            public string Tag;
-            public FeatureDefinition FeatureToRemove;
-        }
-
-        private sealed class NegativeFeatureBuilder : BaseDefinitionBuilder<NegativeFeatureDefinition>
-        {
-            private NegativeFeatureBuilder(string tag, FeatureDefinition featureToRemove)
-                : base(featureToRemove.Name + "Remove", GuidHelper.Create(Thug.SubclassNamespace, featureToRemove.Name + "Remove").ToString())
-            {
-                Definition.Tag = tag;
-                Definition.FeatureToRemove = featureToRemove;
-                Definition.GuiPresentation.SetHidden(true);
-            }
-
-            private static NegativeFeatureDefinition CreateAndAddToDB(string tag, FeatureDefinition featureToRemove)
-                => new NegativeFeatureBuilder(tag, featureToRemove).AddToDB();
-
-            internal static readonly NegativeFeatureDefinition AdditionalDamageRogueSneakAttackRemove =
-                CreateAndAddToDB("03ClassRogue1", AdditionalDamageRogueSneakAttack);
         }
 
         private sealed class RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>


### PR DESCRIPTION
I'm not a fan of requiring the tag of the feature that's getting removed. That just feels like it's likely to break. The alternative of just searching every active feature though doesn't seem great either.