### PR TITLE
Fix lvl1 can cast spells feat prerequisite

### DIFF
--- a/SolastaCommunityExpansion/Patches/FirstLevelCasterFeats/GuiFeatDefinitionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/FirstLevelCasterFeats/GuiFeatDefinitionPatcher.cs
@@ -12,22 +12,33 @@ namespace SolastaCommunityExpansion.Patches.FirstLevelCasterFeats
     {
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            //Replace call to RulesetCharacterHero.SpellRepertores with list of FeatureCastSpell 
-            //which are registered before feat selection at lvl 1
             var codes = instructions.ToList();
             var callSpellRepertoiresIndex = codes.FindIndex(c => c.Calls(typeof(RulesetCharacter).GetMethod("get_SpellRepertoires")));
             codes[callSpellRepertoiresIndex] = new CodeInstruction(System.Reflection.Emit.OpCodes.Call, 
-                                                                   new Func<RulesetCharacterHero, List<FeatureDefinition>>(getFeaturesCastSpell).Method
+                                                                   new Func<RulesetCharacterHero, int>(canCastSpells).Method
                                                                    );
+            codes.RemoveAt(callSpellRepertoiresIndex + 1);
             return codes;
         }
 
 
-        static private List<FeatureDefinition> getFeaturesCastSpell(RulesetCharacterHero hero)
+        static private int canCastSpells(RulesetCharacterHero hero)
         {
-            var list = new List<FeatureDefinition>();
-            hero.EnumerateFeaturesToBrowse<FeatureDefinitionCastSpell>(list, null);
-            return list;
+            
+            if (Main.Settings.EnableFirstLevelCasterFeats)
+            {
+                //Replace call to RulesetCharacterHero.SpellRepertores.Count with Count list of FeatureCastSpell 
+                //which are registered before feat selection at lvl 1
+                var list = new List<FeatureDefinition>();
+                hero.EnumerateFeaturesToBrowse<FeatureDefinitionCastSpell>(list, null);
+                return list.Count;
+            }
+            else
+            {
+                return hero.SpellRepertoires.Count;
+            }
+               
+
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/FirstLevelCasterFeats/GuiFeatDefinitionPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/FirstLevelCasterFeats/GuiFeatDefinitionPatcher.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.FirstLevelCasterFeats
@@ -7,54 +10,24 @@ namespace SolastaCommunityExpansion.Patches.FirstLevelCasterFeats
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GuiFeatDefinition_IsFeatMacthingPrerequisites
     {
-        //internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-
-                            //{
-                            //    var code = new List<CodeInstruction>(instructions);
-                            //    code.Find(x => x.opcode == OpCodes.Ldc_I4_1).opcode = OpCodes.Ldc_I4_0;
-
-        //    return code;
-        //}
-
-        internal static void Postfix(FeatDefinition feat, RulesetCharacterHero hero, ref bool __result)
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            if (Main.Settings.EnableFirstLevelCasterFeats && !__result && feat.MustCastSpellsPrerequisite && hero.SpellRepertoires.Count == 0)
-            {
-                GetLastAssignedClassAndLevel(hero, out CharacterClassDefinition lastClassDefinition, out int _);
-
-                foreach (FeatureUnlockByLevel featureUnlock in lastClassDefinition.FeatureUnlocks)
-                {
-                    if (featureUnlock.FeatureDefinition is FeatureDefinitionCastSpell)
-                    {
-                        __result = true;
-                        return;
-                    }
-                }
-
-                if (hero.ClassesAndSubclasses.TryGetValue(lastClassDefinition, out CharacterSubclassDefinition subclassDefinition))
-                {
-                    foreach (FeatureUnlockByLevel featureUnlock in subclassDefinition.FeatureUnlocks)
-                    {
-                        if (featureUnlock.FeatureDefinition is FeatureDefinitionCastSpell)
-                        {
-                            __result = true;
-                            return;
-                        }
-                    }
-                }
-            }
+            //Replace call to RulesetCharacterHero.SpellRepertores with list of FeatureCastSpell 
+            //which are registered before feat selection at lvl 1
+            var codes = instructions.ToList();
+            var callSpellRepertoiresIndex = codes.FindIndex(c => c.Calls(typeof(RulesetCharacter).GetMethod("get_SpellRepertoires")));
+            codes[callSpellRepertoiresIndex] = new CodeInstruction(System.Reflection.Emit.OpCodes.Call, 
+                                                                   new Func<RulesetCharacterHero, List<FeatureDefinition>>(getFeaturesCastSpell).Method
+                                                                   );
+            return codes;
         }
 
-        private static void GetLastAssignedClassAndLevel(RulesetCharacterHero hero, out CharacterClassDefinition lastClassDefinition, out int level)
-        {
-            lastClassDefinition = null;
-            level = 0;
 
-            if (hero.ClassesHistory.Count > 0)
-            {
-                lastClassDefinition = hero.ClassesHistory[hero.ClassesHistory.Count - 1];
-                level = hero.ClassesAndLevels[lastClassDefinition];
-            }
+        static private List<FeatureDefinition> getFeaturesCastSpell(RulesetCharacterHero hero)
+        {
+            var list = new List<FeatureDefinition>();
+            hero.EnumerateFeaturesToBrowse<FeatureDefinitionCastSpell>(list, null);
+            return list;
         }
     }
 }


### PR DESCRIPTION
Makes FeatDefinition.MustCastSpellsPrerequisite check at lvl 1 more generic and also fixes color of the prerequisite if it is met (in the original version it was always red).