### PR TITLE
fix fast combat to work as originally intended

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUiBattle/GameTimeSetTimeScalePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiBattle/GameTimeSetTimeScalePatcher.cs
@@ -10,14 +10,14 @@ namespace SolastaCommunityExpansion.Patches.GameUiBattle
     {
         internal static bool Prefix(ref float ___timeScale, ref bool ___fasterTimeMode)
         {
-            if (!Main.Settings.PermanentlySpeedBattleUp)
+            var isBattleInProgress = ServiceRepository.GetService<IGameLocationBattleService>()?.IsBattleInProgress;
+
+            if (isBattleInProgress == false)
             {
                 return true;
             }
 
-            var isBattleInProgress = ServiceRepository.GetService<IGameLocationBattleService>()?.IsBattleInProgress;
-
-            if (isBattleInProgress == true)
+            if (Main.Settings.PermanentlySpeedBattleUp)
             {
                 Time.timeScale = ___timeScale * Main.Settings.BattleCustomTimeScale;
             }


### PR DESCRIPTION
Fixed code per original mod description:

Set a custom timescale for the Speed Up Battle setting (hold Space during battle).
Ability to make the speed up setting permanent with a toggle in the mod menu.

in CE we changed the default from 1.5x to 1.0x so patch is indeed protected by this setting.