### PR TITLE
Fix potential bug removing feature unlocks

### DIFF
--- a/SolastaCommunityExpansion/Models/FlexibleRacesContext.cs
+++ b/SolastaCommunityExpansion/Models/FlexibleRacesContext.cs
@@ -52,13 +52,7 @@ namespace SolastaCommunityExpansion.Models
 
         private static void RemoveMatchingFeature(List<FeatureUnlockByLevel> unlocks, FeatureDefinition toRemove)
         {
-            for (int i = 0; i < unlocks.Count; i++)
-            {
-                if (unlocks[i].FeatureDefinition.GUID == toRemove.GUID)
-                {
-                    unlocks.RemoveAt(i);
-                }
-            }
+            unlocks.RemoveAll(u => u.FeatureDefinition.GUID == toRemove.GUID);
         }
 
         internal static void SwitchFlexibleRaces()


### PR DESCRIPTION
This code will potentially miss removing items if there are multiple instances of the same FeatureUnlock in the list
```
            for (int i = 0; i < unlocks.Count; i++)
            {
                if (unlocks[i].FeatureDefinition.GUID == toRemove.GUID)
                {
                    unlocks.RemoveAt(i);
                }
            }
```