### PR TITLE
adds support to only reveal gadgets on map after they are discovered

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameGadgetPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameGadgetPatcher.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using TA;
+using static SolastaModApi.DatabaseHelper.GadgetBlueprints;
+
+namespace SolastaCommunityExpansion.Patches.GameUiScreenMap
+{
+    // hides certain element from the map on custom dungeons unless already discovered
+    [HarmonyPatch(typeof(GameGadget), "ComputeIsRevealed")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GameGadget_ComputeIsRevealed
+    {
+        //
+        // TODO: @ImpPhil, tweak this array per your needs on the map feature
+        //
+        private static readonly GadgetBlueprint[] gadgetBlueprintsToRevealAfterDiscovery = new GadgetBlueprint[]
+        {
+            Exit,
+            Node,
+            TeleporterIndividual,
+            TeleporterParty
+        };
+
+        internal static bool Prefix(GameGadget __instance, ref bool __result)
+        {
+            if (!Main.Settings.EnableAdditionalIconsOnLevelMap || Gui.GameLocation.UserLocation == null)
+            {
+                return true;
+            }
+
+            if (!__instance.Revealed)
+            {
+                BoxInt referenceBoundingBox;
+                var gadgetBlueprint = Gui.GameLocation.UserLocation.GadgetsByName[__instance.UniqueNameId].GadgetBlueprint;
+
+                if (Array.IndexOf(gadgetBlueprintsToRevealAfterDiscovery, gadgetBlueprint) != -1)
+                {
+                    var x = (int)__instance.FeedbackPosition.x;
+                    var y = (int)__instance.FeedbackPosition.z;
+                    var position = new int3(x, 0, y);
+
+                    referenceBoundingBox = new BoxInt(position, position);
+                }
+                else
+                {
+                    referenceBoundingBox = __instance.ReferenceBoundingBox;
+                }
+
+                if (referenceBoundingBox.IsValid)
+                {
+                    var gridAccessor = GridAccessor.Default;
+
+                    foreach (var position in referenceBoundingBox.EnumerateAllPositionsWithin())
+                    {
+                        if (gridAccessor.Visited(position))
+                        {
+                            AccessTools.Field(__instance.GetType(), "revealed").SetValue(__instance, true);
+
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    AccessTools.Field(__instance.GetType(), "revealed").SetValue(__instance, true);
+                }
+            }
+
+            __result = __instance.Revealed;
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameLocationScreenMapPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameLocationScreenMapPatcher.cs
@@ -38,10 +38,17 @@ namespace SolastaCommunityExpansion.Patches.GameUiScreenMap
                         {
                             itemType = (MapGadgetItem.ItemType)(-1);
                         }
-                        else if (gameGadget.UniqueNameId.IndexOf("exit", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        else if (gameGadget.UniqueNameId.StartsWith("Exit"))
                         {
-                            // exits are revealed by default, so all are shown
                             itemType = (MapGadgetItem.ItemType)(-2);
+                        }
+                        else if (gameGadget.UniqueNameId.StartsWith("Teleporter"))
+                        {
+                            itemType = (MapGadgetItem.ItemType)(-3);
+                        }
+                        else if (gameGadget.UniqueNameId.StartsWith("Node"))
+                        {
+                            itemType = (MapGadgetItem.ItemType)(-4);
                         }
                         else if (gameGadget.CheckIsLocked())
                         {

--- a/SolastaCommunityExpansion/Patches/GameUiScreenMap/MapGadgetItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiScreenMap/MapGadgetItemPatcher.cs
@@ -42,6 +42,16 @@ namespace SolastaCommunityExpansion.Patches.GameUiScreenMap
                     ___iconImage.sprite = CreateSprite(Properties.Resources.Entry, 24);
                     ___guiTooltip.Content = "Exit";
                     break;
+                case -3:
+                    ___backgroundImage.sprite = ___backgroundSprites[2];
+                    ___iconImage.sprite = CreateSprite(Properties.Resources.Entry, 24); // TODO: @ImpPhil, change to teleporter icon
+                    ___guiTooltip.Content = "Teleporter";
+                    break;
+                case -4:
+                    ___backgroundImage.sprite = ___backgroundSprites[2];
+                    ___iconImage.sprite = CreateSprite(Properties.Resources.Entry, 24); // TODO: @ImpPhil, change to teleportation destination icon
+                    ___guiTooltip.Content = "Teleportation Destination";
+                    break;
                 default:
                     return true;
             }


### PR DESCRIPTION
@PhilPJL , we cannot mess up too much with the ReferenceBox object in the gadget. Took this approach as this is the only place where we care some gadgets to respond with a valid ReferenceBox. You should now decide what to tweak in array `gadgetBlueprintsToRevealAfterDiscovery `.