### PR TITLE
Gadget CheckIsEnabled bug fix

### DIFF
--- a/SolastaCommunityExpansion/Helpers/Extensions.cs
+++ b/SolastaCommunityExpansion/Helpers/Extensions.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace SolastaCommunityExpansion.Helpers
 {
-    internal static class Extensions
+    internal static class RulesetActorExtensions
     {
         /// <summary>
         /// Makes using RulesetActor.EnumerateFeaturesToBrowse simpler
@@ -22,19 +22,25 @@ namespace SolastaCommunityExpansion.Helpers
             actor.EnumerateFeaturesToBrowse<T>(features, featuresOrigin);
             return features.OfType<T>().ToList();
         }
+    }
+
+    internal static class GameGadgetExtensions
+    {
+        /// <summary>
+        /// Returns state of Invisible parameter, or false if not present
+        /// </summary>
+        public static bool IsInvisible(this GameGadget gadget)
+        {
+            return (bool)CheckConditionName.Invoke(gadget, new object[] { "Invisible", true, false });
+        }
 
         /// <summary>
-        /// CheckIsInvisible extension matching CheckIsEnabled() etc GameGadget methods
+        /// Replacement for buggy GameGadget.CheckIsEnabled().
         /// </summary>
-        /// <param name="gadget"></param>
-        /// <returns></returns>
-        public static bool CheckIsInvisible(this GameGadget gadget)
+        public static bool IsEnabled(this GameGadget gadget)
         {
-            var result = (bool)CheckConditionName.Invoke(gadget, new object[] { "Invisible", true, false });
-
-            Main.Log($"{gadget.UniqueNameId}, Invisible={result}");
-
-            return result;
+            return (bool)CheckConditionName.Invoke(gadget, new object[] { "Param_Enabled", true, false })
+                || (bool)CheckConditionName.Invoke(gadget, new object[] { "Enabled", true, false });
         }
 
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields

--- a/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameLocationScreenMapPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiScreenMap/GameLocationScreenMapPatcher.cs
@@ -29,9 +29,9 @@ namespace SolastaCommunityExpansion.Patches.GameUiScreenMap
             {
                 foreach (var gameGadget in gameSector.GameGadgets)
                 {
-                    Main.Log($"{gameGadget.UniqueNameId}, {gameGadget.Revealed}");
+                    Main.Log($"{gameGadget.UniqueNameId}, Revealed={gameGadget.Revealed}, Enabled={gameGadget.IsEnabled()}, Invisible={gameGadget.IsInvisible()}");
 
-                    if (gameGadget.Revealed && gameGadget.CheckIsEnabled())
+                    if (gameGadget.Revealed && gameGadget.IsEnabled())
                     {
                         MapGadgetItem.ItemType itemType = (MapGadgetItem.ItemType)int.MinValue;
 
@@ -43,7 +43,7 @@ namespace SolastaCommunityExpansion.Patches.GameUiScreenMap
                         {
                             itemType = (MapGadgetItem.ItemType)(-2);
                         }
-                        else if (gameGadget.UniqueNameId.StartsWith("Teleporter") && !gameGadget.CheckIsInvisible())
+                        else if (gameGadget.UniqueNameId.StartsWith("Teleporter") && !gameGadget.IsInvisible())
                         {
                             itemType = (MapGadgetItem.ItemType)(-3);
                         }


### PR DESCRIPTION
TA code appears buggy.  Maybe it's as designed but it doesn't work for us.

```
GameGadget
{ 
public bool CheckIsEnabled() => 
    this.CheckConditionName("Param_Enabled", true, false) 
    || this.CheckConditionName("Enabled", true, true);
}
```

which will always return true.

@ThyWoof please check your test dungeon still works.
