### PR TITLE
Stop dungeon rotation when editing text box

### DIFF
--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class UserLocationEditorScreen_HandleInput
     {
-        public static void Postfix(UserLocationEditorScreen __instance, InputCommands.Id command)
+        public static void Postfix(UserLocationEditorScreen __instance, SelectedGadgetPanel ___selectedGadgetPanel, InputCommands.Id command)
         {
             if (!Main.Settings.EnableDungeonMakerRotationHotkeys || __instance == null)
             {
@@ -29,11 +29,17 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker
             switch (command)
             {
                 case InputCommands.Id.RotateCCW:
-                    Rotate(-90f);
+                    if (!(___selectedGadgetPanel?.IsTextFieldFocused() ?? false))
+                    {
+                        Rotate(-90f);
+                    }
                     break;
 
                 case InputCommands.Id.RotateCW:
-                    Rotate(90f);
+                    if (!(___selectedGadgetPanel?.IsTextFieldFocused() ?? false))
+                    {
+                        Rotate(90f);
+                    }
                     break;
             }
 

--- a/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
@@ -216,7 +216,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                                 }
 
                                 SpellsContext.SwitchSpellList(spellDefinition, spellListDefinition);
-                            };
+                            }
                         }
 
                         current++;


### PR DESCRIPTION
If you type 'q' or 'e' in a text box the dungeon rotates