### PR TITLE
Work around attunement issue and fix attunement bug in export.

### DIFF
--- a/SolastaCommunityExpansion/Models/CharacterExportContext.cs
+++ b/SolastaCommunityExpansion/Models/CharacterExportContext.cs
@@ -140,6 +140,15 @@ namespace SolastaCommunityExpansion.Models
 
                 customItems.ForEach(x => inventoryItems.Remove(x));
 
+                // change attunement to the new character name
+                foreach (var item in attunedItems)
+                {
+                    if (!string.IsNullOrWhiteSpace(item.Item.AttunedToCharacter))
+                    {
+                        item.Item.AttunedToCharacter = newFirstName;
+                    } 
+                }
+
                 heroCharacter.SetCurrentHitPoints(heroCharacter.GetAttribute("HitPoints").CurrentValue);
                 heroCharacter.Unregister();
                 heroCharacter.ResetForOutgame();

--- a/SolastaCommunityExpansion/Patches/Attunement/AttunementModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Attunement/AttunementModalPatcher.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.Attunement
+{
+    [HarmonyPatch(typeof(AttunementModal), "DoAttuneItemAndSwap")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class AttunementModal_DoAttuneItemAndSwap
+    {
+        public static bool Prefix(AttunementModal __instance, ref RulesetItem ___itemToAttune, ref RulesetItem ___itemToFadeIn)
+        {
+            if (!Main.Settings.BugFixAttunementUnknownCharacter)
+            {
+                return true;
+            }
+
+            // This is a work around for data corruption introduced by the CE character export feature.
+            // Plus TA code shouldn't throw null-ref.
+
+            var method = AccessTools.Method(typeof(AttunementModal), "FindAttunedCharacterOfItem");
+            var attunedCharacterOfItem = (GuiCharacter)method.Invoke(__instance, new object[] { ___itemToAttune });
+            Trace.AssertNotNull(attunedCharacterOfItem);
+            attunedCharacterOfItem?.RulesetCharacterHero.UnattuneItem(___itemToAttune);
+
+            ServiceRepository.GetService<IGameService>();
+            ServiceRepository.GetService<IInventoryCommandService>().AttuneItem(__instance.AttuningCharacter.RulesetCharacterHero, ___itemToAttune, true);
+            ___itemToFadeIn = ___itemToAttune;
+            ___itemToAttune = null;
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -47,6 +47,7 @@ namespace SolastaCommunityExpansion
         public bool AllowDynamicPowers { get; set; } = true;
         public bool AllowExtraKeyboardCharactersInCampaignNames { get; set; } = true;
         public bool AllowExtraKeyboardCharactersInLocationNames { get; set; } = true;
+        public bool BugFixAttunementUnknownCharacter { get; set; } = true;
         public bool BugFixBestiarySorting { get; set; } = true;
         public bool BugFixButtonActivatorTriggerIssue { get; set; } = true;
         public bool BugFixCharacterPanelSorting { get; set; } = true;


### PR DESCRIPTION
Closes #414 

Fixes character export to set the correct, new character name on attuned items.
Fixes null-ref issue with AttunementModal.DoAttuneItemAndSwap to allow already exported characters to have their attunement fixed.

Created against dev since this bug will affect anyone who has already used character export.