### PR TITLE
Beta fix save by location

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUiSpellSelection/SubspellSelectionModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUiSpellSelection/SubspellSelectionModalPatcher.cs
@@ -52,10 +52,7 @@ namespace SolastaCommunityExpansion.Patches.GameUiSpellSelection
 
             if (subspells.Count > index)
             {
-                if (___spellCastEngaged != null)
-                {
-                    ___spellCastEngaged(___spellRepertoire, SpellDefinition_SubspellsList.FilteredSubspells[index], ___slotLevel);
-                }
+                ___spellCastEngaged?.Invoke(___spellRepertoire, SpellDefinition_SubspellsList.FilteredSubspells[index], ___slotLevel);
 
                 // If a device had the summon function, implement here
 

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
@@ -105,14 +105,7 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
                 .Where(opt => opt.LocationType == selectedCampaign.LocationType)
                 .FirstOrDefault(o => o.CampaignOrLocation == selectedCampaign.CampaignOrLocationName);
 
-            foreach (var o in guiDropdown.options.Cast<LocationOptionData>().Select((od, i) => new { od, i }))
-            {
-                Main.Log($"{o.od.LocationType}, {o.od.CampaignOrLocation}, {o.i}");
-            }
-
             guiDropdown.value = option?.Index ?? 0;
-
-            ValueChanged(guiDropdown);
 
             return false;
 


### PR DESCRIPTION
Small tidy in `SubspellSelectionModal_OnActivate`

Fix issue in Save By Location.  Calling unnecessary `ValueChanged(guiDropdown);` causes items to be added twice.

This issue also exists in Dev where items are added 3 times because we're using a postfix.  Suggest not fixing dev.