### PR TITLE
Beta fix cancel edit on right mouse click

### DIFF
--- a/SolastaCommunityExpansion/Patches/DungeonMaker/CursorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/CursorPatcher.cs
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker
         /// </summary>
         internal static void Postfix(Cursor __instance)
         {
-            if (Main.Settings.EnableCancelEditOnRightMouseClick && __instance is CursorLocationEditor)
+            if (Main.Settings.EnableCancelEditOnRightMouseClick && __instance is CursorLocationEditor && !(__instance is CursorLocationEditorDefault))
             {
                 // This is a field on CursorEditor not Cursor so can't be passed in by the patch
                 var userLocationEditorScreen = __instance.GetField<UserLocationEditorScreen>("userLocationEditorScreen");


### PR DESCRIPTION
When using the default (non-drag) cursor the screen was closed.