### PR TITLE
Remove duplicated translations

### DIFF
--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -31,6 +31,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
         internal Thug()
         {
             var featureName = AdditionalDamageRogueSneakAttack.Name + "Remove";
+
             var guiPresentation = new GuiPresentationBuilder(
                 "Subclass/&KSRogueSubclassThugDescription",
                 "Subclass/&KSRogueSubclassThugTitle")

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -671,8 +671,6 @@ Subclass/&HealingPoolLifeTransmuterBonusTitle Additional Transmute Force
 Subclass/&HealingPoolLifeTransmuterListDescription 2 times per day enact your will on reality with special abilities.
 Subclass/&HealingPoolLifeTransmuterListTitle Transmute Force
 Subclass/&KSRogueSubclassThugDescription Thugs are sharp-minded combattants who seek the thrill of the fight and will make their enemies bite the dust by any means necessary. They benefit from an advanced martial training and learn to make use of their wit and brawn alike to triumph in battle.
-Subclass/&KSRogueSubclassThugDescription Thugs are sharp-minded combattants who seek the thrill of the fight and will make their enemies bite the dust by any means necessary. They benefit from an advanced martial training and learn to make use of their wit and brawn alike to triumph in battle.
-Subclass/&KSRogueSubclassThugTitle	Thug
 Subclass/&KSRogueSubclassThugTitle	Thug
 Subclass/&MagicAffinityFighterSpellShieldDescription Advantage on concentration checks as well as the ability to perform somatic components of spells while holding items.
 Subclass/&MagicAffinityFighterSpellShieldTitle Combat Casting


### PR DESCRIPTION
Duplicated translations cause an internal exception in BaseDefinition:FormatTitle ().

