### PR TITLE
remove virtual exits from logic

### DIFF
--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -15,8 +15,6 @@ namespace SolastaCommunityExpansion.Models
             ExitMultiple,
             TeleporterIndividual,
             TeleporterParty,
-            VirtualExit,
-            VirtualExitMultiple,
         };
 
         public const InputCommands.Id CTRL_C = (InputCommands.Id)44440000;


### PR DESCRIPTION
virtual exits only have standard highlight but no gizmos. removed from collection.