### PR TITLE
General cleanup using Roslynator.

### DIFF
--- a/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
@@ -269,7 +269,6 @@ namespace SolastaCommunityExpansion.Builders
                 case CasterProgression.THIRD_CASTER:
                     for (; level < 21; level++)
                     {
-
                         Definition.KnownSpells.Add(startingAmount +
                             // +2 here because third casters effectively "round up" for spells known
                             BonusSpellsKnownByCasterLevel[(level + 2) / 3] +
@@ -382,7 +381,7 @@ namespace SolastaCommunityExpansion.Builders
                         FeatureDefinitionCastSpell.SlotsByLevelDuplet slotsForLevel = new FeatureDefinitionCastSpell.SlotsByLevelDuplet
                         {
                             Level = level,
-                            Slots = SlotsByCasterLevel[(level - startingLevel) / 2 + 1]
+                            Slots = SlotsByCasterLevel[((level - startingLevel) / 2) + 1]
                         };
                         Definition.SlotsPerLevels.Add(slotsForLevel);
                     }
@@ -393,7 +392,7 @@ namespace SolastaCommunityExpansion.Builders
                         FeatureDefinitionCastSpell.SlotsByLevelDuplet slotsForLevel = new FeatureDefinitionCastSpell.SlotsByLevelDuplet
                         {
                             Level = level,
-                            Slots = SlotsByCasterLevel[(level - startingLevel + 2) / 3 + 1]
+                            Slots = SlotsByCasterLevel[((level - startingLevel + 2) / 3) + 1]
                         };
                         Definition.SlotsPerLevels.Add(slotsForLevel);
                     }

--- a/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
@@ -8,8 +8,6 @@ using static CharacterClassDefinition;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    /// <summary>
-    /// </summary>
     public class CharacterClassDefinitionBuilder : BaseDefinitionBuilder<CharacterClassDefinition>
     {
         public CharacterClassDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
@@ -3,8 +3,6 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    /// <summary>
-    /// </summary>
     public class CharacterSubclassDefinitionBuilder : BaseDefinitionBuilder<CharacterSubclassDefinition>
     {
         public CharacterSubclassDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/EffectDescriptionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/EffectDescriptionBuilder.cs
@@ -87,7 +87,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public EffectDescriptionBuilder NoVisibilityRequiredToTarget()
         {
-
             effect.SetRequiresVisibilityForPosition(false);
             return this;
         }

--- a/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
@@ -30,7 +30,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatDefinitionBuilder(FeatDefinition original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatDefinitionBuilder SetFeatures(params FeatureDefinition[] features)

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionAdditionalActionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionAdditionalActionBuilder.cs
@@ -24,12 +24,10 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAdditionalActionBuilder(FeatureDefinitionAdditionalAction original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatureDefinitionAdditionalActionBuilder(string name, string guid) : base(name, guid)
         {
-
         }
 
         public FeatureDefinitionAdditionalActionBuilder SetGuiPresentation(GuiPresentation guiPresentation)

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
@@ -23,7 +23,7 @@ namespace SolastaCommunityExpansion.Builders
         public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid, List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists,
             GuiPresentation guiPresentation) : base(name, guid)
         {
-            Definition.SetField("autoPreparedSpellsGroups", 
+            Definition.SetField("autoPreparedSpellsGroups",
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>(autospelllists));
 
             Definition.SetGuiPresentation(guiPresentation);
@@ -31,12 +31,10 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid) : base(name, guid)
         {
-
         }
 
         public FeatureDefinitionAutoPreparedSpellsBuilder(FeatureDefinitionAutoPreparedSpells original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatureDefinitionAutoPreparedSpellsBuilder SetPreparedSpellGroups(params FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup[] autospelllists)
@@ -46,7 +44,7 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAutoPreparedSpellsBuilder SetPreparedSpellGroups(IEnumerable<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists)
         {
-            Definition.SetField("autoPreparedSpellsGroups", 
+            Definition.SetField("autoPreparedSpellsGroups",
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>(autospelllists));
 
             return this;

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionPointPoolBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionPointPoolBuilder.cs
@@ -15,7 +15,7 @@ namespace SolastaCommunityExpansion.Builders
             Definition.SetPoolAmount(poolAmount);
         }
 
-        public FeatureDefinitionPointPoolBuilder(string name, Guid baseGuid, 
+        public FeatureDefinitionPointPoolBuilder(string name, Guid baseGuid,
             HeroDefinitions.PointsPoolType poolType, int poolAmount, string keyPrefix = null) : base(name, baseGuid, keyPrefix)
         {
             Definition.SetPoolType(poolType);

--- a/SolastaCommunityExpansion/Builders/MonsterBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/MonsterBuilder.cs
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion.Builders
 {
     public class MonsterBuilder : BaseDefinitionBuilder<MonsterDefinition>
     {
-        public MonsterBuilder(string name, string guid, string title, string description, MonsterDefinition baseMonster) 
+        public MonsterBuilder(string name, string guid, string title, string description, MonsterDefinition baseMonster)
             : base(baseMonster, name, guid, title, description)
         {
         }
@@ -290,7 +290,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public MonsterBuilder ClearSkillScores()
         {
-
             Definition.SkillScores.Clear();
             return this;
         }
@@ -308,7 +307,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public MonsterBuilder ClearAttackIterations()
         {
-
             Definition.AttackIterations.Clear();
             return this;
         }

--- a/SolastaCommunityExpansion/Builders/SpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/SpellBuilder.cs
@@ -123,6 +123,5 @@ namespace SolastaCommunityExpansion.Builders
             Definition.SetGuiPresentation(gui);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
@@ -6,7 +6,7 @@ using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class AlchemistBuilder
+    public static class AlchemistBuilder
     {
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer)
         {
@@ -46,21 +46,21 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&MagicAffinityAlchemistSpellRecoveryDescription",
                 "Subclass/&MagicAffinityAlchemistSpellRecoveryTitle");
             spellRecoveryGui.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerWizardArcaneRecovery.GuiPresentation.SpriteReference);
-            FeatureDefinitionPower bonusRecovery = FeatureHelpers.BuildSpellFormPower(2 /* usePerRecharge */, RuleDefinitions.UsesDetermination.Fixed, RuleDefinitions.ActivationTime.Rest,
-                1 /* cost */, RuleDefinitions.RechargeRate.LongRest, "PowerAlchemistSpellBonusRecovery", spellRecoveryGui.Build());
+            FeatureDefinitionPower bonusRecovery = FeatureHelpers.BuildSpellFormPower(2 /* usePerRecharge */, UsesDetermination.Fixed, ActivationTime.Rest,
+                1 /* cost */, RechargeRate.LongRest, "PowerAlchemistSpellBonusRecovery", spellRecoveryGui.Build());
             alchemist.AddFeatureAtLevel(bonusRecovery, 3);
 
-            FeatureHelpers.BuildRestActivity(RestDefinitions.RestStage.AfterRest, RuleDefinitions.RestType.ShortRest,
+            FeatureHelpers.BuildRestActivity(RestDefinitions.RestStage.AfterRest, RestType.ShortRest,
                 RestActivityDefinition.ActivityCondition.CanUsePower, "UsePower", bonusRecovery.Name, "AlcemicalPreparationRestAction", spellRecoveryGui.Build());
 
             // Healing 2d4+int
             EffectDescriptionBuilder healEffect = new EffectDescriptionBuilder();
             healEffect.AddEffectForm(new EffectFormBuilder()
-                .SetHealingForm(RuleDefinitions.HealingComputation.Dice, 0, RuleDefinitions.DieType.D4, 2, false, RuleDefinitions.HealingCap.MaximumHitPoints)
-                .SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus)
+                .SetHealingForm(HealingComputation.Dice, 0, DieType.D4, 2, false, HealingCap.MaximumHitPoints)
+                .SetBonusMode(AddBonusMode.AbilityBonus)
                 .Build());
-            healEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            healEffect.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            healEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            healEffect.SetDurationData(DurationType.Hour, 1, TurnOccurenceType.EndOfTurn);
             healEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.CureWounds.EffectDescription.EffectParticleParameters);
             GuiPresentationBuilder healingElixirGui = new GuiPresentationBuilder(
                 "Feat/&ArtificerAlchemistHealElixirDescription",
@@ -69,9 +69,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             SpellDefinition healElixirSpell = new SpellBuilder("AlchemistHealElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistHealElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(healEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(healingElixirGui.Build())
                 .AddToDB();
 
@@ -83,7 +83,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ConditionDefinition swiftness = FeatureHelpers.BuildCondition(new List<FeatureDefinition>()
             {
                 FeatureHelpers.BuildMovementAffinity(true, 2, 1, "AlchemistSwiftnessMovementAffinity", swiftnessGui.Build())
-            }, RuleDefinitions.DurationType.Hour, 1, false, "AlchemistSwiftnessElixirCondition", swiftnessGui.Build());
+            }, DurationType.Hour, 1, false, "AlchemistSwiftnessElixirCondition", swiftnessGui.Build());
             FeatureDefinitionPower cancelSwiftness = new CancelConditionPowerBuilder("CancelElixirSwiftness", "86888f66-c8b2-49db-910a-bde389dd69df",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirSwiftnessDescription", "Subclass/&CancelCancelElixirSwiftnessTitle")
                 .SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionExpeditiousRetreat.GuiPresentation.SpriteReference).Build(),
@@ -93,16 +93,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectFormBuilder swiftnessForm = new EffectFormBuilder();
             swiftnessForm.SetConditionForm(swiftness, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>());
             swiftnessEffect.AddEffectForm(swiftnessForm.Build());
-            swiftnessEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, RuleDefinitions.DieType.D1, 0).Build());
-            swiftnessEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            swiftnessEffect.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            swiftnessEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D1, 0).Build());
+            swiftnessEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            swiftnessEffect.SetDurationData(DurationType.Hour, 1, TurnOccurenceType.EndOfTurn);
             swiftnessEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Longstrider.EffectDescription.EffectParticleParameters);
             SpellDefinition swiftnessElixirSpell = new SpellBuilder("AlchemistSwiftnessElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistSwiftnessElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(swiftnessEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(swiftnessGui.Build())
                 .AddToDB();
 
@@ -115,7 +115,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             {
                 FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
                 "AlchemistResilienceMovementAffinity", resilienceGui.Build())
-            }, RuleDefinitions.DurationType.Minute, 10, false, "AlchemistResilienceElixirCondition", resilienceGui.Build());
+            }, DurationType.Minute, 10, false, "AlchemistResilienceElixirCondition", resilienceGui.Build());
             FeatureDefinitionPower cancelResilience = new CancelConditionPowerBuilder("CancelElixirResilience", "4de693d2-f193-4434-8741-57335d7cefdc",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirResilienceDescription", "Subclass/&CancelCancelElixirResilienceTitle")
                 .SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference).Build(),
@@ -123,15 +123,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             resilience.Features.Add(cancelResilience);
             EffectDescriptionBuilder resilienceEffect = new EffectDescriptionBuilder();
             resilienceEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(resilience, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            resilienceEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            resilienceEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 10, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            resilienceEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            resilienceEffect.SetDurationData(DurationType.Minute, 10, TurnOccurenceType.EndOfTurn);
             resilienceEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Blur.EffectDescription.EffectParticleParameters);
             SpellDefinition resilienceElixirSpell = new SpellBuilder("AlchemistResilienceElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistResilienceElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(resilienceEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(resilienceGui.Build())
                 .AddToDB();
 
@@ -143,16 +143,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             EffectDescriptionBuilder boldnessEffect = new EffectDescriptionBuilder();
             boldnessEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.ConditionBlessed, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            boldnessEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            boldnessEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            boldnessEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            boldnessEffect.SetDurationData(DurationType.Minute, 1, TurnOccurenceType.EndOfTurn);
             boldnessEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Bless.EffectDescription.EffectParticleParameters);
 
             SpellDefinition boldnessElixirSpell = new SpellBuilder("AlchemistBoldnessElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistBoldnessElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(boldnessEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(boldnessElixirGui.Build())
                 .AddToDB();
 
@@ -164,7 +164,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ConditionDefinition fly = FeatureHelpers.BuildCondition(new List<FeatureDefinition>()
             {
                 DatabaseHelper.FeatureDefinitionMoveModes.MoveModeFly2,
-            }, RuleDefinitions.DurationType.Minute, 10, false, "AlchemistFlyElixirCondition", flyElixirGui.Build());
+            }, DurationType.Minute, 10, false, "AlchemistFlyElixirCondition", flyElixirGui.Build());
 
             FeatureDefinitionPower cancelFly = new CancelConditionPowerBuilder("CancelElixirFly", "64385214-7b0f-4372-a12f-8346b2b33884",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirFlyDescription", "Subclass/&CancelCancelElixirFlyTitle")
@@ -174,15 +174,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             EffectDescriptionBuilder flyEffect = new EffectDescriptionBuilder();
             flyEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(fly, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            flyEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            flyEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 10, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            flyEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            flyEffect.SetDurationData(DurationType.Minute, 10, TurnOccurenceType.EndOfTurn);
             flyEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Fly.EffectDescription.EffectParticleParameters);
             SpellDefinition flyElixirSpell = new SpellBuilder("AlchemistFlyElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistFlyElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(flyEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(flyElixirGui.Build())
                 .AddToDB();
 
@@ -203,7 +203,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder alchemicalSavantGui = new GuiPresentationBuilder(
                 "Feat/&ArtificerAlchemistAlchemicalSavantDescription",
                 "Feat/&ArtificerAlchemistAlchemicalSavantTitle");
-            FeatureDefinitionHealingModifier improvedHealing = FeatureHelpers.BuildHealingModifier(1, RuleDefinitions.DieType.D4, RuleDefinitions.LevelSourceType.CharacterLevel,
+            FeatureDefinitionHealingModifier improvedHealing = FeatureHelpers.BuildHealingModifier(1, DieType.D4, LevelSourceType.CharacterLevel,
                 "ArtificerAlchemistAlchemicalSavantHealing", alchemicalSavantGui.Build());
             alchemist.AddFeatureAtLevel(improvedHealing, 5);
 
@@ -223,8 +223,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistRestorativeElixirsTitle");
             restorativeElixirs.SetSpriteReference(DatabaseHelper.SpellDefinitions.LesserRestoration.GuiPresentation.SpriteReference);
             FeatureDefinitionPower restorativeElixisrPower = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistRestorativeElixirs", GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistRestorativeElixirs").ToString(),
-                0, RuleDefinitions.UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                0, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 DatabaseHelper.SpellDefinitions.LesserRestoration.EffectDescription,
                 restorativeElixirs.Build()).AddToDB();
@@ -234,17 +234,17 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistEmboldeningShotsDescription",
                 "Feat/&PowerAlchemistEmboldeningShotsTitle");
             EffectDescriptionBuilder emboldeningShotsEffect = new EffectDescriptionBuilder();
-            emboldeningShotsEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D6, 4).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            emboldeningShotsEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 6, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            emboldeningShotsEffect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            emboldeningShotsEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D6, 4).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            emboldeningShotsEffect.SetTargetingData(Side.Ally, RangeType.Distance, 6, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            emboldeningShotsEffect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             emboldeningShotsEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             SpellDefinition emboldeningShots = new SpellBuilder("CantripAlchemistEmboldeningShots", GuidHelper.Create(TinkererClass.GuidNamespace, "CantripAlchemistEmboldeningShots").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSpellLevel(0)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(emboldeningShotsEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(emboldeningShotsGui.Build())
                 .AddToDB();
 
@@ -259,21 +259,20 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistGreaterRestorativeElixirsTitle");
             restorativeElixirs.SetSpriteReference(DatabaseHelper.SpellDefinitions.GreaterRestoration.GuiPresentation.SpriteReference);
             FeatureDefinitionPower greaterRestorativeElixirs = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistGreaterRestorativeElixirs", GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistGreaterRestorativeElixirs").ToString(),
-                1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                1, UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 DatabaseHelper.SpellDefinitions.GreaterRestoration.EffectDescription,
                 greaterRestorativeElixirsGui.Build()).AddToDB();
             alchemist.AddFeatureAtLevel(greaterRestorativeElixirs, 15);
-
 
             GuiPresentationBuilder healElixirsGui = new GuiPresentationBuilder(
                 "Feat/&PowerAlchemistHealElixirsDescription",
                 "Feat/&PowerAlchemistHealElixirsTitle");
             EffectDescriptionBuilder healSpellEffect = new EffectDescriptionBuilder();
             healSpellEffect.AddEffectForm(new EffectFormBuilder()
-                .SetHealingForm(RuleDefinitions.HealingComputation.Dice, 0, RuleDefinitions.DieType.D1, 70, false, RuleDefinitions.HealingCap.MaximumHitPoints)
-                .SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus)
+                .SetHealingForm(HealingComputation.Dice, 0, DieType.D1, 70, false, HealingCap.MaximumHitPoints)
+                .SetBonusMode(AddBonusMode.AbilityBonus)
                 .Build());
             healSpellEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.ConditionParalyzed, ConditionForm.ConditionOperation.RemoveDetrimentalAll,
                 false, false, new List<ConditionDefinition>() {
@@ -287,14 +286,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                     DatabaseHelper.ConditionDefinitions.ConditionContagionSeizure,
                     DatabaseHelper.ConditionDefinitions.ConditionContagionSlimyDoom,
                 }).Build());
-            healSpellEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 12, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            healSpellEffect.SetDurationData(RuleDefinitions.DurationType.Instantaneous, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            healSpellEffect.SetTargetingData(Side.Ally, RangeType.Distance, 12, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            healSpellEffect.SetDurationData(DurationType.Instantaneous, 1, TurnOccurenceType.EndOfTurn);
             healSpellEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             FeatureDefinitionPower greatHealElixirs = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistHealElixirs",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistHealElixirs").ToString(),
-                1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                1, UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 healSpellEffect.Build(),
                 healElixirsGui.Build()).AddToDB();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
@@ -6,8 +6,9 @@ using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class ArtilleristBuilder
+    public static class ArtilleristBuilder
     {
+        // NOTE: unused parameter 'spellCasting'
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer, FeatureDefinitionCastSpell spellCasting)
         {
             // Make Artillerist subclass
@@ -18,25 +19,25 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             meleePresentation.SetSpriteReference(DatabaseHelper.CharacterSubclassDefinitions.TraditionShockArcanist.GuiPresentation.SpriteReference);
             artillerist.SetGuiPresentation(meleePresentation.Build());
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells1 = FeatureHelpers.BuildAutoPreparedSpellGroup(3,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells1 = BuildAutoPreparedSpellGroup(3,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.Shield, DatabaseHelper.SpellDefinitions.Thunderwave });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells2 = FeatureHelpers.BuildAutoPreparedSpellGroup(5,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells2 = BuildAutoPreparedSpellGroup(5,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.ScorchingRay, DatabaseHelper.SpellDefinitions.Shatter });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells3 = FeatureHelpers.BuildAutoPreparedSpellGroup(9,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells3 = BuildAutoPreparedSpellGroup(9,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.Fireball, DatabaseHelper.SpellDefinitions.WindWall });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells4 = FeatureHelpers.BuildAutoPreparedSpellGroup(13,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells4 = BuildAutoPreparedSpellGroup(13,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.IceStorm, DatabaseHelper.SpellDefinitions.WallOfFire });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells5 = FeatureHelpers.BuildAutoPreparedSpellGroup(17,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells5 = BuildAutoPreparedSpellGroup(17,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.ConeOfCold, DatabaseHelper.SpellDefinitions.WallOfForce });
 
             GuiPresentationBuilder artilleristSpellsPresentation = new GuiPresentationBuilder(
                 "Feat/&ArtilleristSubclassSpellsDescription",
                 "Feat/&ArtilleristSubclassSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleristPrepSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleristPrepSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     artilleristSpells1, artilleristSpells2, artilleristSpells3, artilleristSpells4, artilleristSpells5 },
                 artificer, "ArtificerArtilleristAutoPrepSpells", artilleristSpellsPresentation.Build());
@@ -52,9 +53,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fireEffect = new EffectDescriptionBuilder();
             fireEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 2, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fireEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fireEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fireEffect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fireEffect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fireEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -62,7 +63,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 1, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence, ActivationTime.BonusAction, 0, RechargeRate.AtWill, false, false, AttributeDefinitions.Intelligence, fireEffect.Build(),
                 flameGui.Build()).AddToDB();
             //    artillerist.AddFeatureAtLevel(flameAttack, 3);
-
 
             GuiPresentationBuilder forceGui = new GuiPresentationBuilder(
                 "Feat/&ArtilleristForceCannonDescription",
@@ -73,7 +73,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             forceEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 2, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             forceEffect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            forceEffect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            forceEffect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
             forceEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -89,9 +89,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             protectorGui.SetSpriteReference(DatabaseHelper.SpellDefinitions.FalseLife.GuiPresentation.SpriteReference);
 
             EffectDescriptionBuilder protectorEffect = new EffectDescriptionBuilder();
-            protectorEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 1).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            protectorEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 2, RuleDefinitions.TargetType.Sphere, 2, 2, ActionDefinitions.ItemSelectionType.None);
-            protectorEffect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            protectorEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 1).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            protectorEffect.SetTargetingData(Side.Ally, RangeType.Self, 2, TargetType.Sphere, 2, 2, ActionDefinitions.ItemSelectionType.None);
+            protectorEffect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             protectorEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -105,7 +105,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder ArtilleryConstructLevel03AutopreparedSpellsPresentation = new GuiPresentationBuilder(
                  "Feat/&ArtilleryConstructLevel03AutopreparedSpellsDescription",
                  "Feat/&ArtilleryConstructLevel03AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel03AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel03AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,
@@ -122,8 +122,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&ArtificerArtilleristArcaneFirearmTitle");
             FeatureDefinitionAdditionalDamage arcaneFirearm = new FeatureDefinitionAdditionalDamageBuilder("ArtificerArtilleristArcaneFirearm",
                  GuidHelper.Create(TinkererClass.GuidNamespace, "ArtificerArtilleristArcaneFirearm").ToString(), "ArcaneFirearm",
-                RuleDefinitions.FeatureLimitedUsage.OncePerTurn, RuleDefinitions.AdditionalDamageValueDetermination.Die, RuleDefinitions.AdditionalDamageTriggerCondition.EvocationSpellDamage, RuleDefinitions.AdditionalDamageRequiredProperty.None,
-                false /* attack only */, RuleDefinitions.DieType.D8, 1 /* dice number */, RuleDefinitions.AdditionalDamageType.SameAsBaseDamage, "", RuleDefinitions.AdditionalDamageAdvancement.None,
+                FeatureLimitedUsage.OncePerTurn, AdditionalDamageValueDetermination.Die, AdditionalDamageTriggerCondition.EvocationSpellDamage, AdditionalDamageRequiredProperty.None,
+                false /* attack only */, DieType.D8, 1 /* dice number */, AdditionalDamageType.SameAsBaseDamage, "", AdditionalDamageAdvancement.None,
                 new List<DiceByRank>(), false, AttributeDefinitions.Wisdom, 0, EffectSavingThrowType.None, new List<ConditionOperationDescription>(),
                 arcaneFirearmGui.Build()).AddToDB();
             artillerist.AddFeatureAtLevel(arcaneFirearm, 5);
@@ -136,17 +136,17 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             detonationEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage)
                 .Build());
-            detonationEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            detonationEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            detonationEffect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Distance, 12, RuleDefinitions.TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
+            detonationEffect.SetTargetingData(Side.All, RangeType.Distance, 12, TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
             detonationEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             SpellDefinition detonation = new SpellBuilder("ArtilleristCannonDetonation", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristCannonDetonation").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.Action)
+                .SetCastingTime(ActivationTime.Action)
                 .SetEffectDescription(detonationEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(detonationGui.Build())
                 .AddToDB();
 
@@ -154,12 +154,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder artilleristDetonationPreparedPresentation = new GuiPresentationBuilder(
                 "Feat/&ArtificerArtillerstDetonationSpellPreparedDescription",
                 "Feat/&ArtificerArtillerstDetonationSpellPreparedTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleristDetonationSpell = FeatureHelpers.BuildAutoPreparedSpells(
+
+#pragma warning disable S1481 // Unused local variables should be removed
+            // TODO: use - assume WIP
+            FeatureDefinitionAutoPreparedSpells artilleristDetonationSpell = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
-                    FeatureHelpers.BuildAutoPreparedSpellGroup(9, new List<SpellDefinition>() { detonation })
+                    BuildAutoPreparedSpellGroup(9, new List<SpellDefinition>() { detonation })
                 },
                 artificer, "ArtificerArtillerstDetonationSpellPrepared", artilleristDetonationPreparedPresentation.Build());
             //    artillerist.AddFeatureAtLevel(ArtilleristDetonationSpell, 9);
+#pragma warning restore S1481 // Unused local variables should be removed
 
             // cannons with boosted damage
             GuiPresentationBuilder flame9Gui = new GuiPresentationBuilder(
@@ -170,9 +174,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fire9Effect = new EffectDescriptionBuilder();
             fire9Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fire9Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fire9Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fire9Effect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fire9Effect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fire9Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -191,7 +195,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             force9Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             force9Effect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            force9Effect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            force9Effect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
             force9Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -205,12 +209,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder ArtilleryConstructLevel09AutopreparedSpellsPresentation = new GuiPresentationBuilder(
                  "Feat/&ArtilleryConstructLevel09AutopreparedSpellsDescription",
                  "Feat/&ArtilleryConstructLevel09AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel09AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel09AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,
                         SpellsList=new List<SpellDefinition>
-                            {SummonArtillerySpellConstruct_9Builder.SummonArtillerySpellConstruct_9}} },
+                            {SummonArtillerySpellConstruct9Builder.SummonArtillerySpellConstruct_9}} },
                 artificer,
                 "ArtilleryConstructLevel09AutopreparedSpells",
                 ArtilleryConstructLevel09AutopreparedSpellsPresentation.Build());
@@ -225,16 +229,18 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fire15Effect = new EffectDescriptionBuilder();
             fire15Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 6, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fire15Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fire15Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fire15Effect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fire15Effect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fire15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
-            FeatureDefinitionPower flame15Attack = new FeatureHelpers.FeatureDefinitionPowerBuilder("ArtilleristFlame15CannonAttack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristFlame15CannonAttack").ToString(),
+#pragma warning disable S1481 // Unused local variables should be removed
+            FeatureDefinitionPower flame15Attack = new FeatureDefinitionPowerBuilder("ArtilleristFlame15CannonAttack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristFlame15CannonAttack").ToString(),
                 1, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence, ActivationTime.BonusAction, 0, RechargeRate.AtWill, false, false, AttributeDefinitions.Intelligence, fire15Effect.Build(),
                 flame15Gui.Build(), flame9Attack).AddToDB();
             //    artillerist.AddFeatureAtLevel(flame15Attack, 15);
+#pragma warning restore S1481 // Unused local variables should be removed
 
             // Force
             GuiPresentationBuilder force15Gui = new GuiPresentationBuilder(
@@ -246,14 +252,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             force15Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             force15Effect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            force15Effect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 2, 2, ActionDefinitions.ItemSelectionType.None);
+            force15Effect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 2, 2, ActionDefinitions.ItemSelectionType.None);
             force15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
-            FeatureDefinitionPower force15Attack = new FeatureHelpers.FeatureDefinitionPowerBuilder("ArtilleristForceCannon15Attack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristForceCannon15Attack").ToString(),
+#pragma warning disable S1481 // Unused local variables should be removed
+            FeatureDefinitionPower force15Attack = new FeatureDefinitionPowerBuilder("ArtilleristForceCannon15Attack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristForceCannon15Attack").ToString(),
                 1, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence, ActivationTime.BonusAction, 0, RechargeRate.AtWill, true, true, AttributeDefinitions.Intelligence, force15Effect.Build(),
                 force15Gui.Build(), force9Attack).AddToDB();
             //    artillerist.AddFeatureAtLevel(force15Attack, 15);
+#pragma warning restore S1481 // Unused local variables should be removed
             // Protector
             GuiPresentationBuilder protector15Gui = new GuiPresentationBuilder(
                 "Feat/&ArtilleristProtectorCannon15Description",
@@ -261,28 +269,30 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             protectorGui.SetSpriteReference(DatabaseHelper.SpellDefinitions.FalseLife.GuiPresentation.SpriteReference);
 
             EffectDescriptionBuilder protector15Effect = new EffectDescriptionBuilder();
-            protector15Effect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 2).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            protector15Effect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 2, RuleDefinitions.TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
-            protector15Effect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            protector15Effect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 2).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            protector15Effect.SetTargetingData(Side.Ally, RangeType.Self, 2, TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
+            protector15Effect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             protector15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
-            FeatureDefinitionPower protector15Activation = new FeatureHelpers.FeatureDefinitionPowerBuilder("ArtilleristProtector15CannonAttack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristProtector15CannonAttack").ToString(),
+#pragma warning disable S1481 // Unused local variables should be removed
+            FeatureDefinitionPower protector15Activation = new FeatureDefinitionPowerBuilder("ArtilleristProtector15CannonAttack", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristProtector15CannonAttack").ToString(),
                 1, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence, ActivationTime.BonusAction, 0, RechargeRate.AtWill, false, false, AttributeDefinitions.Intelligence, protector15Effect.Build(),
                 protector15Gui.Build(), protectorActivation).AddToDB();
             //    artillerist.AddFeatureAtLevel(protector15Activation, 15);
+#pragma warning restore S1481 // Unused local variables should be removed
 
             artillerist.AddFeatureAtLevel(ArtilleryConstructlevel15FeatureSetBuilder.ArtilleryConstructlevel15FeatureSet, 15);
 
             GuiPresentationBuilder ArtilleryConstructLevel15AutopreparedSpellsPresentation = new GuiPresentationBuilder(
     "Feat/&ArtilleryConstructLevel15AutopreparedSpellsDescription",
     "Feat/&ArtilleryConstructLevel15AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel15AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel15AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,
                         SpellsList=new List<SpellDefinition>
-                            {SummonArtillerySpellConstruct_15Builder.SummonArtillerySpellConstruct_15}} },
+                            {SummonArtillerySpellConstruct15Builder.SummonArtillerySpellConstruct_15}} },
                 artificer,
                 "ArtilleryConstructLevel15AutopreparedSpells",
                 ArtilleryConstructLevel15AutopreparedSpellsPresentation.Build());

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
@@ -16,7 +16,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected FlameArtilleryBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDragonBreath_Fire, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&FlameArtilleryTitle";
             Definition.GuiPresentation.Description = "Feat/&FlameArtilleryDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
@@ -24,8 +23,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
 
-
-            DamageForm FlameArtillery = new DamageForm
+            DamageForm flameArtillery = new DamageForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 2,
@@ -36,11 +34,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // AlterationForm alterationForm = new AlterationForm();
             //alterationForm.SetAlterationType (AlterationForm.Type.LightUp);
 
-
             EffectForm effect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (FlameArtillery)
+                DamageForm = flameArtillery
             };
             effect.SetCreatedByCharacter(true);
             effect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.HalfDamage;
@@ -49,7 +46,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effect.SetLevelMultiplier(1);
             effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
@@ -66,7 +62,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.EffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
             Definition.EffectDescription.SetRangeType(RuleDefinitions.RangeType.Distance);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -74,29 +69,23 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower FlameArtillery = CreateAndAddToDB(FlameArtilleryName, FlameArtilleryGuid);
-
-
+        public static readonly FeatureDefinitionPower FlameArtillery = CreateAndAddToDB(FlameArtilleryName, FlameArtilleryGuid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		FlameArtillery_2Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtillery_2Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class FlameArtillery2Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
         private const string FlameArtillery_2Name = "FlameArtillery_2";
         private const string FlameArtillery_2Guid = "2ba003a5-718a-4eea-a0f8-33fa79884cb1";
 
-        protected FlameArtillery_2Builder(string name, string guid) : base(FlameArtilleryBuilder.FlameArtillery, name, guid)
+        protected FlameArtillery2Builder(string name, string guid) : base(FlameArtilleryBuilder.FlameArtillery, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&FlameArtillery_2Title";
             Definition.GuiPresentation.Description = "Feat/&FlameArtillery_2Description";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
-
 
             Definition.EffectDescription.EffectForms[0].DamageForm.DiceNumber = 3;
             Definition.SetOverriddenPower(FlameArtilleryBuilder.FlameArtillery);
@@ -104,12 +93,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
         {
-            return new FlameArtillery_2Builder(name, guid).AddToDB();
+            return new FlameArtillery2Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower FlameArtillery_2 = CreateAndAddToDB(FlameArtillery_2Name, FlameArtillery_2Guid);
-
-
+        public static readonly FeatureDefinitionPower FlameArtillery_2 = CreateAndAddToDB(FlameArtillery_2Name, FlameArtillery_2Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -123,7 +110,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected FlameArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // can use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -147,10 +133,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
-
-
-
-
 
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
@@ -179,12 +161,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Add(FlameArtilleryBuilder.FlameArtillery);
 
-
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -192,64 +169,53 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
-
-
+        public static readonly MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
     }
 
-    internal class FlameArtilleryConstruct_9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class FlameArtilleryConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string FlameArtilleryConstruct_9Name = "FlameArtilleryConstruct_9";
         private const string FlameArtilleryConstruct_9Guid = "3445274f-9668-4606-8a91-4c6a420a7c30";
 
-        protected FlameArtilleryConstruct_9Builder(string name, string guid) : base(FlameArtilleryConstructBuilder.FlameArtilleryConstruct, name, guid)
+        protected FlameArtilleryConstruct9Builder(string name, string guid) : base(FlameArtilleryConstructBuilder.FlameArtilleryConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&FlameArtilleryConstructTitle_3";
 
-            Definition.Features.Add(FlameArtillery_2Builder.FlameArtillery_2);
+            Definition.Features.Add(FlameArtillery2Builder.FlameArtillery_2);
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new FlameArtilleryConstruct_9Builder(name, guid).AddToDB();
+            return new FlameArtilleryConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct_9 = CreateAndAddToDB(FlameArtilleryConstruct_9Name, FlameArtilleryConstruct_9Guid);
-
-
+        public static readonly MonsterDefinition FlameArtilleryConstruct_9 = CreateAndAddToDB(FlameArtilleryConstruct_9Name, FlameArtilleryConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		FlameArtilleryConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtilleryConstruct_15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class FlameArtilleryConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string FlameArtilleryConstruct_15Name = "FlameArtilleryConstruct_15";
         private const string FlameArtilleryConstruct_15Guid = "8c4ff931-4a17-4de4-8571-6c94e8327e8e";
 
-        protected FlameArtilleryConstruct_15Builder(string name, string guid) : base(FlameArtilleryConstruct_9Builder.FlameArtilleryConstruct_9, name, guid)
+        protected FlameArtilleryConstruct15Builder(string name, string guid) : base(FlameArtilleryConstruct9Builder.FlameArtilleryConstruct_9, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&FlameArtilleryConstructTitle_5";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new FlameArtilleryConstruct_15Builder(name, guid).AddToDB();
+            return new FlameArtilleryConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct_15 = CreateAndAddToDB(FlameArtilleryConstruct_15Name, FlameArtilleryConstruct_15Guid);
-
-
+        public static readonly MonsterDefinition FlameArtilleryConstruct_15 = CreateAndAddToDB(FlameArtilleryConstruct_15Name, FlameArtilleryConstruct_15Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstructBuilder		*******************************************************************
@@ -262,7 +228,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonFlameArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtilleryModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtilleryModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
@@ -272,12 +237,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.FlameArtillery_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -285,71 +245,55 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonFlameArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct = CreateAndAddToDB(SummonFlameArtilleryConstructName, SummonFlameArtilleryConstructGuid);
-
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct = CreateAndAddToDB(SummonFlameArtilleryConstructName, SummonFlameArtilleryConstructGuid);
     }
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonFlameArtillerySpellConstruct_9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonFlameArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonFlameArtilleryConstruct_9Name = "SummonFlameArtilleryConstruct_9";
         private const string SummonFlameArtilleryConstruct_9Guid = "4aaaf381-c54c-4285-9045-6a4d69aa37c9";
 
-        protected SummonFlameArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
+        protected SummonFlameArtillerySpellConstruct9Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtillery_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtillery_09ModePowerDescription";
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct_9Builder.FlameArtilleryConstruct_9.Name);
-
-
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct9Builder.FlameArtilleryConstruct_9.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonFlameArtillerySpellConstruct_9Builder(name, guid).AddToDB();
+            return new SummonFlameArtillerySpellConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct_9 = CreateAndAddToDB(SummonFlameArtilleryConstruct_9Name, SummonFlameArtilleryConstruct_9Guid);
-
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct_9 = CreateAndAddToDB(SummonFlameArtilleryConstruct_9Name, SummonFlameArtilleryConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonFlameArtillerySpellConstruct_15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonFlameArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonFlameArtilleryConstruct_15Name = "SummonFlameArtilleryConstruct_15";
         private const string SummonFlameArtilleryConstruct_15Guid = "68aba04a-07c5-4b83-bda7-db08cec2dec8";
 
-        protected SummonFlameArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
+        protected SummonFlameArtillerySpellConstruct15Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtillery_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtillery_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct_15Builder.FlameArtilleryConstruct_15.Name);
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct15Builder.FlameArtilleryConstruct_15.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonFlameArtillerySpellConstruct_15Builder(name, guid).AddToDB();
+            return new SummonFlameArtillerySpellConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct_15 = CreateAndAddToDB(SummonFlameArtilleryConstruct_15Name, SummonFlameArtilleryConstruct_15Guid);
-
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct_15 = CreateAndAddToDB(SummonFlameArtilleryConstruct_15Name, SummonFlameArtilleryConstruct_15Guid);
     }
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
@@ -7,6 +7,110 @@ using System.Collections.Generic;
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     //*****************************************************************************************************************************************
+    //***********************************		ForceArtilleryBuilder		*******************************************************************
+    //*****************************************************************************************************************************************
+
+    internal class ForceArtilleryBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    {
+        private const string ForceArtilleryName = "ForceArtillery";
+        private const string ForceArtilleryGuid = "928af495-1ed7-4307-a194-81d7e7bbef12";
+
+        protected ForceArtilleryBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDomainElementalIceLance, name, guid)
+        {
+            Definition.GuiPresentation.Title = "Feature/&ForceArtilleryTitle";
+            Definition.SetShortTitleOverride("Feature/&ForceArtilleryTitle");
+            Definition.GuiPresentation.Description = "Feat/&ForceArtilleryDescription";
+            Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
+
+            Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
+            Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
+
+            MotionForm motionForm = new MotionForm();
+            motionForm.SetType(MotionForm.MotionType.PushFromOrigin);
+            motionForm.SetDistance(1);
+
+            EffectForm effectmotion = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.Motion
+            };
+            effectmotion.SetMotionForm(motionForm);
+            effectmotion.SetCreatedByCharacter(true);
+            effectmotion.HasSavingThrow = false;
+            effectmotion.AddBonusMode = RuleDefinitions.AddBonusMode.None;
+            effectmotion.SetLevelMultiplier(1);
+            effectmotion.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
+            effectmotion.SetApplyLevel(EffectForm.LevelApplianceType.No);
+
+            DamageForm forceArtillery = new DamageForm
+            {
+                DieType = RuleDefinitions.DieType.D8,
+                DiceNumber = 2,
+                DamageType = RuleDefinitions.DamageTypeForce,
+                BonusDamage = 0
+            };
+
+            EffectForm effect = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.Damage,
+                DamageForm = forceArtillery
+            };
+            effect.SetCreatedByCharacter(true);
+            effect.HasSavingThrow = false;
+            effect.AddBonusMode = RuleDefinitions.AddBonusMode.None;
+            effect.SetLevelMultiplier(1);
+            effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
+            effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
+
+            Definition.EffectDescription.EffectAdvancement.Clear();
+            Definition.EffectDescription.EffectForms.Clear();
+            Definition.EffectDescription.EffectForms.Add(effect);
+            Definition.EffectDescription.EffectForms.Add(effectmotion);
+            Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.IndividualsUnique);
+            Definition.EffectDescription.SetTargetSide(RuleDefinitions.Side.Enemy);
+            Definition.EffectDescription.SetTargetParameter(1);
+            Definition.EffectDescription.SetRangeParameter(24);
+            Definition.EffectDescription.HasSavingThrow = false;
+            Definition.EffectDescription.SetCreatedByCharacter(true);
+            Definition.EffectDescription.SetCanBePlacedOnCharacter(true);
+
+            Definition.EffectDescription.SetRangeType(RuleDefinitions.RangeType.RangeHit);
+            Definition.EffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
+        }
+
+        public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
+        {
+            return new ForceArtilleryBuilder(name, guid).AddToDB();
+        }
+
+        public static readonly FeatureDefinitionPower ForceArtillery = CreateAndAddToDB(ForceArtilleryName, ForceArtilleryGuid);
+    }
+
+    //*****************************************************************************************************************************************
+    //***********************************		ForceArtillery_2Builder		*******************************************************************
+    //*****************************************************************************************************************************************
+
+    internal class ForceArtillery2Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    {
+        private const string ForceArtillery_2Name = "ForceArtillery_2";
+        private const string ForceArtillery_2Guid = "79e96b14-d276-4a33-8cab-7e884bcde120";
+
+        protected ForceArtillery2Builder(string name, string guid) : base(ForceArtilleryBuilder.ForceArtillery, name, guid)
+        {
+            Definition.GuiPresentation.Title = "Feat/&ForceArtillery_2Title";
+            Definition.GuiPresentation.Description = "Feat/&ForceArtillery_2Description";
+
+            Definition.EffectDescription.EffectForms[0].DamageForm.DiceNumber = 3;
+            Definition.SetOverriddenPower(ForceArtilleryBuilder.ForceArtillery);
+        }
+
+        public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
+        {
+            return new ForceArtillery2Builder(name, guid).AddToDB();
+        }
+
+        public static readonly FeatureDefinitionPower ForceArtillery_2 = CreateAndAddToDB(ForceArtillery_2Name, ForceArtillery_2Guid);
+    }
+    //*****************************************************************************************************************************************
     //***********************************		ForceArtilleryConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
@@ -17,7 +121,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ForceArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // can use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -46,10 +149,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
 
-
-
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(15);
@@ -77,10 +176,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             // Definition.Features.Add(ForceArtilleryBuilder.ForceArtillery);
 
-
-
             Definition.AttackIterations.Clear();
-
 
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
 
@@ -90,11 +186,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.AttackIterations.AddRange(new List<MonsterAttackIteration> { monsterAttackIteration });
 
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -102,22 +194,19 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ForceArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct = CreateAndAddToDB(ForceArtilleryConstructName, ForceArtilleryConstructGuid);
-
-
+        public static readonly MonsterDefinition ForceArtilleryConstruct = CreateAndAddToDB(ForceArtilleryConstructName, ForceArtilleryConstructGuid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ForceArtilleryConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ForceArtilleryConstruct_9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ForceArtilleryConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string ForceArtilleryConstruct_9Name = "ForceArtilleryConstruct_9";
         private const string ForceArtilleryConstruct_9Guid = "1a479ea4-0f72-4847-bd0b-54b2ded48057";
 
-        protected ForceArtilleryConstruct_9Builder(string name, string guid) : base(ForceArtilleryConstructBuilder.ForceArtilleryConstruct, name, guid)
+        protected ForceArtilleryConstruct9Builder(string name, string guid) : base(ForceArtilleryConstructBuilder.ForceArtilleryConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ForceArtilleryConstructTitle_3";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryConstructDescription_3";
@@ -126,49 +215,40 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(ForceArtilleryAdditionalDamageBuilder.ForceArtilleryAdditionalDamage);
 
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new ForceArtilleryConstruct_9Builder(name, guid).AddToDB();
+            return new ForceArtilleryConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct_9 = CreateAndAddToDB(ForceArtilleryConstruct_9Name, ForceArtilleryConstruct_9Guid);
-
-
+        public static readonly MonsterDefinition ForceArtilleryConstruct_9 = CreateAndAddToDB(ForceArtilleryConstruct_9Name, ForceArtilleryConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		ForceArtilleryConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ForceArtilleryConstruct_15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ForceArtilleryConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string ForceArtilleryConstruct_15Name = "ForceArtilleryConstruct_15";
         private const string ForceArtilleryConstruct_15Guid = "e7d49f53-cb44-4348-82d7-b8b561861448";
 
-        protected ForceArtilleryConstruct_15Builder(string name, string guid) : base(ForceArtilleryConstruct_9Builder.ForceArtilleryConstruct_9, name, guid)
+        protected ForceArtilleryConstruct15Builder(string name, string guid) : base(ForceArtilleryConstruct9Builder.ForceArtilleryConstruct_9, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ForceArtilleryConstructTitle_5";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryConstructDescription_3";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new ForceArtilleryConstruct_15Builder(name, guid).AddToDB();
+            return new ForceArtilleryConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct_15 = CreateAndAddToDB(ForceArtilleryConstruct_15Name, ForceArtilleryConstruct_15Guid);
-
-
+        public static readonly MonsterDefinition ForceArtilleryConstruct_15 = CreateAndAddToDB(ForceArtilleryConstruct_15Name, ForceArtilleryConstruct_15Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstructBuilder		*******************************************************************
@@ -181,7 +261,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonForceArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtilleryModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -191,11 +270,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.ForceArtillery_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -203,79 +278,59 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonForceArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct = CreateAndAddToDB(SummonForceArtilleryConstructName, SummonForceArtilleryConstructGuid);
-
+        public static readonly SpellDefinition SummonForceArtilleryConstruct = CreateAndAddToDB(SummonForceArtilleryConstructName, SummonForceArtilleryConstructGuid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonForceArtillerySpellConstruct_9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonForceArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonForceArtilleryConstruct_9Name = "SummonForceArtilleryConstruct_9";
         private const string SummonForceArtilleryConstruct_9Guid = "f1e8d7e1-44d9-4a82-ac23-5e0013b40650";
 
-        protected SummonForceArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
+        protected SummonForceArtillerySpellConstruct9Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtillery_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtillery_09ModePowerDescription";
 
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct_9Builder.ForceArtilleryConstruct_9.Name);
-            //
-
-
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct9Builder.ForceArtilleryConstruct_9.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonForceArtillerySpellConstruct_9Builder(name, guid).AddToDB();
+            return new SummonForceArtillerySpellConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct_9 = CreateAndAddToDB(SummonForceArtilleryConstruct_9Name, SummonForceArtilleryConstruct_9Guid);
-
+        public static readonly SpellDefinition SummonForceArtilleryConstruct_9 = CreateAndAddToDB(SummonForceArtilleryConstruct_9Name, SummonForceArtilleryConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonForceArtillerySpellConstruct_15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonForceArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonForceArtilleryConstruct_15Name = "SummonForceArtilleryConstruct_15";
         private const string SummonForceArtilleryConstruct_15Guid = "b529386c-defa-4c39-a03c-09a08a104cc6";
 
-        protected SummonForceArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
+        protected SummonForceArtillerySpellConstruct15Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtillery_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtillery_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
 
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct_15Builder.ForceArtilleryConstruct_15.Name);
-
-
-
-
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct15Builder.ForceArtilleryConstruct_15.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonForceArtillerySpellConstruct_15Builder(name, guid).AddToDB();
+            return new SummonForceArtillerySpellConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct_15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
-
+        public static readonly SpellDefinition SummonForceArtilleryConstruct_15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
     }
-
-
 
     internal class ForceArtilleryAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
     {
@@ -284,7 +339,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ForceArtilleryAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Orc_Grimblade_IceDagger, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryTitle";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -319,6 +373,7 @@ Web
             MotionForm motionForm = new MotionForm();
             motionForm.SetType(MotionForm.MotionType.PushFromOrigin);
             motionForm.SetDistance(1);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
 
             EffectForm effectmotion = new EffectForm
             {
@@ -326,13 +381,15 @@ Web
             };
             effectmotion.SetMotionForm(motionForm);
             effectmotion.SetCreatedByCharacter(true);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             effectmotion.HasSavingThrow = false;
             effectmotion.AddBonusMode = RuleDefinitions.AddBonusMode.None;
             effectmotion.SetLevelMultiplier(1);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             effectmotion.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effectmotion.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
-            DamageForm ForceArtilleryAttack = new DamageForm
+            DamageForm forceArtilleryAttack = new DamageForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 2,
@@ -341,35 +398,41 @@ Web
             };
 
             EffectForm effect = new EffectForm
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (ForceArtilleryAttack)
+                DamageForm = forceArtilleryAttack
             };
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             effect.SetCreatedByCharacter(true);
             effect.HasSavingThrow = false;
             effect.AddBonusMode = RuleDefinitions.AddBonusMode.None;
             effect.SetLevelMultiplier(1);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
             Definition.EffectDescription.EffectForms.Add(effect);
             Definition.EffectDescription.EffectForms.Add(effectmotion);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.IndividualsUnique);
             Definition.EffectDescription.SetTargetSide(RuleDefinitions.Side.Enemy);
             Definition.EffectDescription.SetTargetParameter(1);
             Definition.EffectDescription.SetRangeParameter(24);
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             Definition.EffectDescription.HasSavingThrow = false;
             Definition.EffectDescription.SetCreatedByCharacter(true);
             Definition.EffectDescription.SetCanBePlacedOnCharacter(true);
 
+            // new comment to get past linter not liking the fact i'm trying to maintain old powers to avoid causing issues for peoples games
             Definition.EffectDescription.SetRangeType(RuleDefinitions.RangeType.RangeHit);
 
             EffectParticleParameters effectParticleParameters = new EffectParticleParameters();
             effectParticleParameters.Copy(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
             Definition.EffectDescription.SetEffectParticleParameters(effectParticleParameters);
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -377,9 +440,7 @@ Web
             return new ForceArtilleryAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
-
-
+        public static readonly MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
     }
 
     internal class ForceArtilleryAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
@@ -389,7 +450,6 @@ Web
 
         protected ForceArtilleryAdditionalDamageBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamageDomainLifeDivineStrike, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryAdditionalDamageTitle";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryAdditionalDamageDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -400,7 +460,6 @@ Web
             Definition.SetDamageDieType(RuleDefinitions.DieType.D8);
             Definition.SetNotificationTag("UpgradedConstruct");
             Definition.SetLimitedUsage(RuleDefinitions.FeatureLimitedUsage.None);
-
         }
 
         public static FeatureDefinitionAdditionalDamage CreateAndAddToDB(string name, string guid)
@@ -408,13 +467,8 @@ Web
             return new ForceArtilleryAdditionalDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
-
-
+        public static readonly FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
     }
-
-
-
 
     internal class ForceArtilleryProjectileBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
@@ -423,7 +477,6 @@ Web
 
         protected ForceArtilleryProjectileBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.OrcGrimblade_IceDagger, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Item/&ForceArtilleryProjectileTitle";
             Definition.GuiPresentation.Description = "Item/&ForceArtilleryProjectileDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -431,7 +484,6 @@ Web
             EffectParticleParameters effectParticleParameters = new EffectParticleParameters();
             effectParticleParameters.Copy(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
             Definition.AmmunitionDescription.EffectDescription.SetEffectParticleParameters(effectParticleParameters);
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -439,9 +491,6 @@ Web
             return new ForceArtilleryProjectileBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ForceArtilleryProjectile = CreateAndAddToDB(ForceArtilleryProjectileName, ForceArtilleryProjectileGuid);
-
-
+        public static readonly ItemDefinition ForceArtilleryProjectile = CreateAndAddToDB(ForceArtilleryProjectileName, ForceArtilleryProjectileGuid);
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
@@ -7,60 +7,52 @@ using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
-
     //*****************************************************************************************************************************************
     //***********************************		ArtilleryConstructlevel03FeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
-
     internal class ArtilleryConstructlevel03FeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ArtilleryConstructlevel03FeatureSet";
         private const string Guid = "59f857e6-7b06-4c2b-a241-b73c42d64c23";
 
-        public static FeatureDefinitionPower ArtilleryModePool;
-        public static FeatureDefinitionPowerSharedPool FlameArtillery_03modepower;
-        public static FeatureDefinitionPowerSharedPool ForceArtillery_03modepower;
-        public static FeatureDefinitionPowerSharedPool TempHPShield_03modepower;
+        public static readonly FeatureDefinitionPower ArtilleryModePool = BuildArtilleryModePool();
+        public static readonly FeatureDefinitionPowerSharedPool FlameArtillery_03modepower = BuildFlameArtillery_03modepower();
+        public static readonly FeatureDefinitionPowerSharedPool ForceArtillery_03modepower = BuildForceArtillery_03modepower();
+        public static readonly FeatureDefinitionPowerSharedPool TempHPShield_03modepower = BuildTempHPShield_03modepower();
 
-
-        protected ArtilleryConstructlevel03FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        private static FeatureDefinitionPower BuildArtilleryModePool()
         {
+            var guiPresentation = new GuiPresentation()
+                .SetColor(new Color(1f, 1f, 1f, 1f))
+                .SetDescription("Feat/&ArtilleryModePoolDescription")
+                .SetTitle("Feat/&ArtilleryModePoolTitle")
+                .SetSpriteReference(null)
+                .SetSymbolChar("221E");
 
-            Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructTitle";
-            Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructDescription";
-
-            GuiPresentation guiPresentationArtilleryMode = new GuiPresentation();
-            guiPresentationArtilleryMode.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
-            guiPresentationArtilleryMode.SetDescription("Feat/&ArtilleryModePoolDescription");
-            guiPresentationArtilleryMode.SetTitle("Feat/&ArtilleryModePoolTitle");
-            guiPresentationArtilleryMode.SetSpriteReference(null);
-            guiPresentationArtilleryMode.SetSymbolChar("221E");
-
-            ArtilleryModePool = new FeatureDefinitionPowerPoolBuilder
-               (
+            return new FeatureDefinitionPowerPoolBuilder(
                    "ArtilleryModePool",
                    "89d9c1f5-75e9-4b25-b7e8-a24f30d1befb",
                    1,
                    RuleDefinitions.UsesDetermination.Fixed,
                    AttributeDefinitions.Intelligence,
                    RuleDefinitions.RechargeRate.ShortRest,
-                   guiPresentationArtilleryMode
-               ).AddToDB();
+                   guiPresentation)
+               .AddToDB();
+        }
 
-
-
-            GuiPresentationBuilder guiPresentationFlameArtillery03 = new GuiPresentationBuilder(
+        private static FeatureDefinitionPowerSharedPool BuildFlameArtillery_03modepower()
+        {
+            var guiPresentationFlameArtillery03 = new GuiPresentationBuilder(
                 "Feature/&FlameArtilleryModePowerDescription",
                 "Feature/&FlameArtilleryModePowerTitle");
             guiPresentationFlameArtillery03.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
 
-            EffectDescriptionBuilder effectFlameArtillerymode03 = new EffectDescriptionBuilder();
+            var effectFlameArtillerymode03 = new EffectDescriptionBuilder();
             effectFlameArtillerymode03.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectFlameArtillerymode03.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectFlameArtillerymode03.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstructBuilder.FlameArtilleryConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-            FlameArtillery_03modepower = new FeatureDefinitionPowerSharedPoolBuilder
+            return new FeatureDefinitionPowerSharedPoolBuilder
                 (
                  "FlameArtilleryModePower"                                   // string name
                  , "f1559469-cf41-4204-a8c1-53379d04df43"                    // string guid
@@ -75,9 +67,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , guiPresentationFlameArtillery03.Build()                     // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
+        }
 
-
-
+        private static FeatureDefinitionPowerSharedPool BuildForceArtillery_03modepower()
+        {
             GuiPresentationBuilder guiPresentationForceArtillery03 = new GuiPresentationBuilder(
                 "Feature/&ForceArtilleryModePowerDescription",
                 "Feature/&ForceArtilleryModePowerTitle");
@@ -88,8 +81,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectForceArtillerymode03.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectForceArtillerymode03.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ForceArtilleryConstructBuilder.ForceArtilleryConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-            ForceArtillery_03modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            return new FeatureDefinitionPowerSharedPoolBuilder(
                  "ForceArtilleryModePower"                                   // string name
                  , "b01c40ca-685a-4d5d-9ee4-ed47d39cb5b9"                    // string guid
                  , ArtilleryModePool                                         // FeatureDefinitionPower poolPower
@@ -102,8 +94,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectForceArtillerymode03.Build()                          // EffectDescription effectDescription
                  , guiPresentationForceArtillery03.Build()                     // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-
+                )
+                .AddToDB();
+        }
+        private static FeatureDefinitionPowerSharedPool BuildTempHPShield_03modepower()
+        {
             GuiPresentationBuilder guiPresentationTempHPShield03 = new GuiPresentationBuilder(
                 "Feature/&TempHPShieldModePowerDescription",
                 "Feature/&TempHPShieldModePowerTitle");
@@ -114,9 +109,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectTempHPShieldmode03.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectTempHPShieldmode03.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstructBuilder.TempHPShieldConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-
-            TempHPShield_03modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            return new FeatureDefinitionPowerSharedPoolBuilder(
                  "TempHPShieldModePower"                                         // string name
                  , "b104ec34-5489-43b7-a887-0ffbb604ca8d"                    // string guid
                  , ArtilleryModePool                                             // FeatureDefinitionPower poolPower
@@ -129,8 +122,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectTempHPShieldmode03.Build()                            // EffectDescription effectDescription
                  , guiPresentationTempHPShield03.Build()                       // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
+                )
+                .AddToDB();
+        }
 
+        protected ArtilleryConstructlevel03FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        {
+            Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructTitle";
+            Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructDescription";
 
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ArtilleryModePool);
@@ -140,7 +139,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.FeatureSet.Add(AddConstructCantripsBuilder.AddConstructCantrips);
             //Definition.FeatureSet.Add(SummoningAffinityTinkererConstructBuilder.SummoningAffinityTinkererConstruct);
             Definition.FeatureSet.Add(SummoningAffinityTinkererArtilleryConstructBuilder.SummoningAffinityTinkererArtilleryConstruct);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -148,8 +146,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel03FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel03FeatureSet = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel03FeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -161,19 +158,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         private const string Name = "ArtilleryConstructlevel09FeatureSet";
         private const string Guid = "a1e9557c-c1a9-4912-9fea-1a16c4124331";
 
-        public static FeatureDefinitionPowerSharedPool FlameArtillery_09modepower;
-        public static FeatureDefinitionPowerSharedPool ForceArtillery_09modepower;
-        public static FeatureDefinitionPowerSharedPool TempHPShield_09modepower;
+        public static readonly FeatureDefinitionPowerSharedPool FlameArtillery_09modepower = BuildFlameArtillery_09modepower();
+        public static readonly FeatureDefinitionPowerSharedPool ForceArtillery_09modepower = BuildForceArtillery_09modepower();
+        public static readonly FeatureDefinitionPowerSharedPool TempHPShield_09modepower = BuildTempHPShield_09modepower();
 
-        protected ArtilleryConstructlevel09FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        private static FeatureDefinitionPowerSharedPool BuildFlameArtillery_09modepower()
         {
-
-            Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructlevel09Title";
-            Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructlevel09Description";
-
-
-
-
             GuiPresentationBuilder guiPresentationFlameArtillery09 = new GuiPresentationBuilder(
                 "Feature/&FlameArtillery_09ModePowerDescription",
                 "Feature/&FlameArtillery_09ModePowerTitle");
@@ -182,11 +172,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder effectFlameArtillerymode09 = new EffectDescriptionBuilder();
             effectFlameArtillerymode09.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectFlameArtillerymode09.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectFlameArtillerymode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct_9Builder.FlameArtilleryConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+            effectFlameArtillerymode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct9Builder.FlameArtilleryConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-
-            FlameArtillery_09modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            var power = new FeatureDefinitionPowerSharedPoolBuilder(
                  "FlameArtillery_09ModePower"                                   // string name
                  , "d841a2aa-efc0-4ccc-b50a-ed0d8e4d68e1"                    // string guid
                  , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
@@ -199,10 +187,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectFlameArtillerymode09.Build()                          // EffectDescription effectDescription
                  , guiPresentationFlameArtillery09.Build()                     // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            FlameArtillery_09modepower.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.FlameArtillery_03modepower);
+                )
+                .AddToDB();
 
+            power.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.FlameArtillery_03modepower);
+            return power;
+        }
 
+        private static FeatureDefinitionPowerSharedPool BuildForceArtillery_09modepower()
+        {
             GuiPresentationBuilder guiPresentationForceArtillery09 = new GuiPresentationBuilder(
                 "Feature/&ForceArtillery_09ModePowerDescription",
                 "Feature/&ForceArtillery_09ModePowerTitle");
@@ -211,10 +204,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder effectForceArtillerymode09 = new EffectDescriptionBuilder();
             effectForceArtillerymode09.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectForceArtillerymode09.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectForceArtillerymode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ForceArtilleryConstruct_9Builder.ForceArtilleryConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+            effectForceArtillerymode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ForceArtilleryConstruct9Builder.ForceArtilleryConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-            ForceArtillery_09modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            var power = new FeatureDefinitionPowerSharedPoolBuilder(
                  "ForceArtillery_09ModePower"                                   // string name
                  , "367fe374-e902-4ce9-9dc8-78d43c277faf"                    // string guid
                  , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
@@ -227,11 +219,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectForceArtillerymode09.Build()                          // EffectDescription effectDescription
                  , guiPresentationForceArtillery09.Build()                     // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            ForceArtillery_09modepower.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.ForceArtillery_03modepower);
+                )
+                .AddToDB();
 
+            power.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.ForceArtillery_03modepower);
+            return power;
+        }
 
-
+        private static FeatureDefinitionPowerSharedPool BuildTempHPShield_09modepower()
+        {
             GuiPresentationBuilder guiPresentationTempHPShield09 = new GuiPresentationBuilder(
                 "Feature/&TempHPShield_09ModePowerDescription",
                 "Feature/&TempHPShield_09ModePowerTitle");
@@ -240,11 +236,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder effectTempHPShieldmode09 = new EffectDescriptionBuilder();
             effectTempHPShieldmode09.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectTempHPShieldmode09.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectTempHPShieldmode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct_9Builder.TempHPShieldConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+            effectTempHPShieldmode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct9Builder.TempHPShieldConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-
-            TempHPShield_09modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            var power = new FeatureDefinitionPowerSharedPoolBuilder(
                  "TempHPShield_09ModePower"                                     // string name
                  , "feac61d2-d2af-43a8-8136-dce6df168d73"                    // string guid
                  , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool // FeatureDefinitionPower poolPower
@@ -257,15 +251,22 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectTempHPShieldmode09.Build()                            // EffectDescription effectDescription
                  , guiPresentationTempHPShield09.Build()                       // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            TempHPShield_09modepower.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.TempHPShield_03modepower);
+                )
+                .AddToDB();
+
+            power.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.TempHPShield_03modepower);
+            return power;
+        }
+
+        protected ArtilleryConstructlevel09FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        {
+            Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructlevel09Title";
+            Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructlevel09Description";
 
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(TempHPShield_09modepower);
             Definition.FeatureSet.Add(FlameArtillery_09modepower);
             Definition.FeatureSet.Add(ForceArtillery_09modepower);
-
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -273,8 +274,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel09FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel09FeatureSet = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel09FeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -286,13 +286,108 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         private const string Name = "ArtilleryConstructlevel15FeatureSet";
         private const string Guid = "50c91d16-1a84-494a-ba72-dd4879955f2f";
 
-        public static FeatureDefinitionPowerSharedPool FlameArtillery_15modepower;
-        public static FeatureDefinitionPowerSharedPool ForceArtillery_15modepower;
-        public static FeatureDefinitionPowerSharedPool TempHPShield_15modepower;
+        public static readonly FeatureDefinitionPowerSharedPool FlameArtillery_15modepower = BuildFlameArtillery_15modepower();
+        public static readonly FeatureDefinitionPowerSharedPool ForceArtillery_15modepower = BuildForceArtillery_15modepower();
+        public static readonly FeatureDefinitionPowerSharedPool TempHPShield_15modepower = BuildTempHPShield_15modepower();
+
+        private static FeatureDefinitionPowerSharedPool BuildFlameArtillery_15modepower()
+        {
+            GuiPresentationBuilder guiPresentationFlameArtillery15 = new GuiPresentationBuilder(
+                "Feature/&FlameArtillery_15ModePowerDescription",
+                "Feature/&FlameArtillery_15ModePowerTitle");
+            guiPresentationFlameArtillery15.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
+
+            EffectDescriptionBuilder effectFlameArtillerymode15 = new EffectDescriptionBuilder();
+            effectFlameArtillerymode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            effectFlameArtillerymode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
+            effectFlameArtillerymode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct15Builder.FlameArtilleryConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+
+            var power = new FeatureDefinitionPowerSharedPoolBuilder
+                (
+                 "FlameArtillery_15ModePower"                                   // string name
+                 , "0c84cc3b-0730-4e25-b8a7-8a074696efe4"                    // string guid
+                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
+                 , RuleDefinitions.RechargeRate.LongRest                     // RuleDefinitions.RechargeRate recharge
+                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
+                 , 1                                                         // int costPerUse
+                 , false                                                     // bool proficiencyBonusToAttack
+                 , false                                                     // bool abilityScoreBonusToAttack
+                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
+                 , effectFlameArtillerymode15.Build()                          // EffectDescription effectDescription
+                 , guiPresentationFlameArtillery15.Build()                     // GuiPresentation guiPresentation
+                 , true                                                      // bool uniqueInstanc
+                ).AddToDB();
+
+            power.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.FlameArtillery_09modepower);
+            return power;
+        }
+
+        private static FeatureDefinitionPowerSharedPool BuildForceArtillery_15modepower()
+        {
+            GuiPresentationBuilder guiPresentationForceArtillery15 = new GuiPresentationBuilder(
+                "Feature/&ForceArtillery_15ModePowerDescription",
+                "Feature/&ForceArtillery_15ModePowerTitle");
+            guiPresentationForceArtillery15.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
+
+            EffectDescriptionBuilder effectForceArtillerymode15 = new EffectDescriptionBuilder();
+            effectForceArtillerymode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            effectForceArtillerymode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
+            effectForceArtillerymode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ForceArtilleryConstruct15Builder.ForceArtilleryConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+
+            var power = new FeatureDefinitionPowerSharedPoolBuilder(
+                 "ForceArtillery_15ModePower"                                   // string name
+                 , "c0e479c8-6fac-4c1a-9e98-58929e42264a"                    // string guid
+                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
+                 , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
+                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
+                 , 1                                                         // int costPerUse
+                 , false                                                     // bool proficiencyBonusToAttack
+                 , false                                                     // bool abilityScoreBonusToAttack
+                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
+                 , effectForceArtillerymode15.Build()                          // EffectDescription effectDescription
+                 , guiPresentationForceArtillery15.Build()                     // GuiPresentation guiPresentation
+                 , true                                                      // bool uniqueInstanc
+                )
+                .AddToDB();
+
+            power.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.ForceArtillery_09modepower);
+            return power;
+        }
+
+        private static FeatureDefinitionPowerSharedPool BuildTempHPShield_15modepower()
+        {
+            GuiPresentationBuilder guiPresentationTempHPShield15 = new GuiPresentationBuilder(
+                "Feature/&TempHPShield_15ModePowerDescription",
+                "Feature/&TempHPShield_15ModePowerTitle");
+            guiPresentationTempHPShield15.SetSpriteReference(DatabaseHelper.SpellDefinitions.Aid.GuiPresentation.SpriteReference);
+
+            EffectDescriptionBuilder effectTempHPShieldmode15 = new EffectDescriptionBuilder();
+            effectTempHPShieldmode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            effectTempHPShieldmode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
+            effectTempHPShieldmode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct15Builder.TempHPShieldConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
+
+            var power = new FeatureDefinitionPowerSharedPoolBuilder(
+                 "TempHPShield_15ModePower"                                     // string name
+                 , "82a01793-c5a4-4b87-a079-de79b7638c4f"                    // string guid
+                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool // FeatureDefinitionPower poolPower
+                 , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
+                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
+                 , 1                                                         // int costPerUse
+                 , false                                                     // bool proficiencyBonusToAttack
+                 , false                                                     // bool abilityScoreBonusToAttack
+                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
+                 , effectTempHPShieldmode15.Build()                            // EffectDescription effectDescription
+                 , guiPresentationTempHPShield15.Build()                       // GuiPresentation guiPresentation
+                 , true                                                      // bool uniqueInstanc
+                )
+                .AddToDB();
+
+            power.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.TempHPShield_09modepower);
+            return power;
+        }
 
         protected ArtilleryConstructlevel15FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructlevel15Title";
             Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructlevel15Description";
 
@@ -310,105 +405,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ArtilleryPoolIncreaseGui.Build()
                 ).AddToDB();
 
-            GuiPresentationBuilder guiPresentationFlameArtillery15 = new GuiPresentationBuilder(
-                "Feature/&FlameArtillery_15ModePowerDescription",
-                "Feature/&FlameArtillery_15ModePowerTitle");
-            guiPresentationFlameArtillery15.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
-
-            EffectDescriptionBuilder effectFlameArtillerymode15 = new EffectDescriptionBuilder();
-            effectFlameArtillerymode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
-            effectFlameArtillerymode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectFlameArtillerymode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct_15Builder.FlameArtilleryConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
-
-            FlameArtillery_15modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
-                 "FlameArtillery_15ModePower"                                   // string name
-                 , "0c84cc3b-0730-4e25-b8a7-8a074696efe4"                    // string guid
-                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
-                 , RuleDefinitions.RechargeRate.LongRest                     // RuleDefinitions.RechargeRate recharge
-                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
-                 , 1                                                         // int costPerUse
-                 , false                                                     // bool proficiencyBonusToAttack
-                 , false                                                     // bool abilityScoreBonusToAttack
-                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
-                 , effectFlameArtillerymode15.Build()                          // EffectDescription effectDescription
-                 , guiPresentationFlameArtillery15.Build()                     // GuiPresentation guiPresentation
-                 , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            FlameArtillery_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.FlameArtillery_09modepower);
-
-
-            GuiPresentationBuilder guiPresentationForceArtillery15 = new GuiPresentationBuilder(
-                "Feature/&ForceArtillery_15ModePowerDescription",
-                "Feature/&ForceArtillery_15ModePowerTitle");
-            guiPresentationForceArtillery15.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
-
-            EffectDescriptionBuilder effectForceArtillerymode15 = new EffectDescriptionBuilder();
-            effectForceArtillerymode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
-            effectForceArtillerymode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectForceArtillerymode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ForceArtilleryConstruct_15Builder.ForceArtilleryConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
-            ForceArtillery_15modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
-                 "ForceArtillery_15ModePower"                                   // string name
-                 , "c0e479c8-6fac-4c1a-9e98-58929e42264a"                    // string guid
-                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool// FeatureDefinitionPower poolPower
-                 , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
-                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
-                 , 1                                                         // int costPerUse
-                 , false                                                     // bool proficiencyBonusToAttack
-                 , false                                                     // bool abilityScoreBonusToAttack
-                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
-                 , effectForceArtillerymode15.Build()                          // EffectDescription effectDescription
-                 , guiPresentationForceArtillery15.Build()                     // GuiPresentation guiPresentation
-                 , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            ForceArtillery_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.ForceArtillery_09modepower);
-
-
-
-            GuiPresentationBuilder guiPresentationTempHPShield15 = new GuiPresentationBuilder(
-                "Feature/&TempHPShield_15ModePowerDescription",
-                "Feature/&TempHPShield_15ModePowerTitle");
-            guiPresentationTempHPShield15.SetSpriteReference(DatabaseHelper.SpellDefinitions.Aid.GuiPresentation.SpriteReference);
-
-            EffectDescriptionBuilder effectTempHPShieldmode15 = new EffectDescriptionBuilder();
-            effectTempHPShieldmode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
-            effectTempHPShieldmode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
-            effectTempHPShieldmode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct_15Builder.TempHPShieldConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
-
-            TempHPShield_15modepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
-                 "TempHPShield_15ModePower"                                     // string name
-                 , "82a01793-c5a4-4b87-a079-de79b7638c4f"                    // string guid
-                 , ArtilleryConstructlevel03FeatureSetBuilder.ArtilleryModePool // FeatureDefinitionPower poolPower
-                 , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
-                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
-                 , 1                                                         // int costPerUse
-                 , false                                                     // bool proficiencyBonusToAttack
-                 , false                                                     // bool abilityScoreBonusToAttack
-                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
-                 , effectTempHPShieldmode15.Build()                            // EffectDescription effectDescription
-                 , guiPresentationTempHPShield15.Build()                       // GuiPresentation guiPresentation
-                 , true                                                      // bool uniqueInstanc
-                ).AddToDB();
-            TempHPShield_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.TempHPShield_09modepower);
-
-
-
-
-
-
-
-
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ArtilleryPoolIncrease);
             Definition.FeatureSet.Add(TempHPShield_15modepower);
             Definition.FeatureSet.Add(FlameArtillery_15modepower);
             Definition.FeatureSet.Add(ForceArtillery_15modepower);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -416,10 +417,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel15FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel15FeatureSet = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel15FeatureSet = CreateAndAddToDB(Name, Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SelfDestructBuilder		*******************************************************************
@@ -432,7 +431,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SelfDestructBuilder(string name, string guid) : base(ThunderShieldBuilder.ThunderShield, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SelfDestructTitle";
             Definition.GuiPresentation.Description = "Feat/&SelfDestructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.FlamingSphere.GuiPresentation.SpriteReference);
@@ -440,9 +438,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
-
-
-
 
             // SelfDestructionConditionBuilder.SelfDestructionCondition
 
@@ -460,8 +455,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             //
             // SelfDestruct.SetType (CounterForm.CounterType.DismissCreature);
 
-
-
             DamageForm ExplosionDamage = new DamageForm
             {
                 DieType = RuleDefinitions.DieType.D8,
@@ -473,7 +466,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectForm ExplosionEffect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (ExplosionDamage)
+                DamageForm = ExplosionDamage
             };
             ExplosionEffect.SetCreatedByCharacter(true);
             ExplosionEffect.HasSavingThrow = true;
@@ -516,9 +509,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfDestructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SelfDestruct = CreateAndAddToDB(SelfDestructName, SelfDestructGuid);
-
-
+        public static readonly FeatureDefinitionPower SelfDestruct = CreateAndAddToDB(SelfDestructName, SelfDestructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -554,7 +545,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             KillEffect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             KillEffect.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
-
             Definition.RecurrentEffectForms.Add(KillEffect);
 
             Definition.SetDurationType(RuleDefinitions.DurationType.Permanent);
@@ -562,8 +552,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetSpecialDuration(true);
             Definition.SetDurationParameter(1);
             Definition.SetConditionType(RuleDefinitions.ConditionType.Detrimental);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -571,7 +559,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfDestructionConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition SelfDestructionCondition = CreateAndAddToDB(SelfDestructionConditionName, SelfDestructionConditionGuid);
+        public static readonly ConditionDefinition SelfDestructionCondition = CreateAndAddToDB(SelfDestructionConditionName, SelfDestructionConditionGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -585,32 +573,29 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected HalfCoverShieldBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDomainBattleHeraldOfBattle, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&HalfCoverShieldTitle";
             Definition.GuiPresentation.Description = "Feat/&HalfCoverShieldDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Shield.GuiPresentation.SpriteReference);
 
-            EffectForm HalfCoverShield = new EffectForm
+            EffectForm halfCoverShield = new EffectForm
             {
                 ConditionForm = new ConditionForm(),
                 FormType = EffectForm.EffectFormType.Condition
             };
-            HalfCoverShield.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
-            HalfCoverShield.ConditionForm.SetConditionDefinitionName(HalfCoverShieldConditionBuilder.HalfCoverShieldCondition.Name);
-            HalfCoverShield.ConditionForm.ConditionDefinition = HalfCoverShieldConditionBuilder.HalfCoverShieldCondition;// DistractingPulseBuilder.DistractingPulse;
+            halfCoverShield.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
+            halfCoverShield.ConditionForm.SetConditionDefinitionName(HalfCoverShieldConditionBuilder.HalfCoverShieldCondition.Name);
+            halfCoverShield.ConditionForm.ConditionDefinition = HalfCoverShieldConditionBuilder.HalfCoverShieldCondition;// DistractingPulseBuilder.DistractingPulse;
 
+            halfCoverShield.SetCreatedByCharacter(true);
 
-            HalfCoverShield.SetCreatedByCharacter(true);
-
-            HalfCoverShield.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
-            HalfCoverShield.SetLevelMultiplier(1);
-            HalfCoverShield.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
-            HalfCoverShield.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
+            halfCoverShield.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
+            halfCoverShield.SetLevelMultiplier(1);
+            halfCoverShield.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
+            halfCoverShield.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
-            Definition.EffectDescription.EffectForms.Add(HalfCoverShield);
+            Definition.EffectDescription.EffectForms.Add(halfCoverShield);
             Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.Sphere);
             Definition.EffectDescription.SetTargetParameter(2);
             Definition.EffectDescription.SetTargetSide(RuleDefinitions.Side.Ally);
@@ -629,9 +614,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower HalfCoverShield = CreateAndAddToDB(HalfCoverShieldName, HalfCoverShieldGuid);
-
-
+        public static readonly FeatureDefinitionPower HalfCoverShield = CreateAndAddToDB(HalfCoverShieldName, HalfCoverShieldGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -650,10 +633,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Clear();
             Definition.Features.Add(HalfCoverShieldAttributeBuilder.HalfCoverShieldAttribute);
-
-
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -661,7 +640,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition HalfCoverShieldCondition = CreateAndAddToDB(HalfCoverShieldConditionName, HalfCoverShieldConditionGuid);
+        public static readonly ConditionDefinition HalfCoverShieldCondition = CreateAndAddToDB(HalfCoverShieldConditionName, HalfCoverShieldConditionGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -675,17 +654,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected HalfCoverShieldAttributeBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAttributeModifiers.AttributeModifierHeraldOfBattle, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Rules/&HalfCoverShieldAttributeTitle";
             Definition.GuiPresentation.Description = "Rules/&HalfCoverShieldAttributeDescription";
 
             Definition.SetModifiedAttribute(DatabaseHelper.SmartAttributeDefinitions.ArmorClass.Name);
             Definition.SetModifierType2(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive);
             Definition.SetModifierValue(2);
-
-
-
         }
 
         public static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
@@ -693,10 +667,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldAttributeBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAttributeModifier HalfCoverShieldAttribute = CreateAndAddToDB(HalfCoverShieldAttributeName, HalfCoverShieldAttributeGuid);
+        public static readonly FeatureDefinitionAttributeModifier HalfCoverShieldAttribute = CreateAndAddToDB(HalfCoverShieldAttributeName, HalfCoverShieldAttributeGuid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonArtillerySpellConstructBuilder		*******************************************************************
@@ -709,7 +681,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_03Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.FaerieFire.GuiPresentation.SpriteReference);
@@ -718,7 +689,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetRequiresConcentration(false);
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
-
 
             Definition.SetSpellsBundle(true);
             Definition.SubspellsList.AddRange(new List<SpellDefinition>
@@ -729,8 +699,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             });
 
             Definition.EffectDescription.Clear();
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -738,80 +706,70 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct = CreateAndAddToDB(SummonArtillerySpellConstructName, SummonArtillerySpellConstructGuid);
-
+        public static readonly SpellDefinition SummonArtillerySpellConstruct = CreateAndAddToDB(SummonArtillerySpellConstructName, SummonArtillerySpellConstructGuid);
     }
 
     //*****************************************************************************************************************************************
     //***********************************		SummonArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonArtillerySpellConstruct_9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonArtillerySpellConstruct_9Name = "SummonArtillerySpellConstruct_9";
         private const string SummonArtillerySpellConstruct_9Guid = "9ad29b43-5207-46e8-bbc9-7b8138b2912f";
 
-        protected SummonArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
+        protected SummonArtillerySpellConstruct9Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_09Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
 
             Definition.SubspellsList.Clear();
             Definition.SubspellsList.AddRange(new List<SpellDefinition>
             {
-                SummonFlameArtillerySpellConstruct_9Builder.SummonFlameArtilleryConstruct_9 ,
-               SummonForceArtillerySpellConstruct_9Builder.SummonForceArtilleryConstruct_9,
-                SummonTempHPShieldSpellConstruct_9Builder.SummonTempHPShieldConstruct_9
+                SummonFlameArtillerySpellConstruct9Builder.SummonFlameArtilleryConstruct_9 ,
+               SummonForceArtillerySpellConstruct9Builder.SummonForceArtilleryConstruct_9,
+                SummonTempHPShieldSpellConstruct9Builder.SummonTempHPShieldConstruct_9
             });
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonArtillerySpellConstruct_9Builder(name, guid).AddToDB();
+            return new SummonArtillerySpellConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct_9 = CreateAndAddToDB(SummonArtillerySpellConstruct_9Name, SummonArtillerySpellConstruct_9Guid);
-
+        public static readonly SpellDefinition SummonArtillerySpellConstruct_9 = CreateAndAddToDB(SummonArtillerySpellConstruct_9Name, SummonArtillerySpellConstruct_9Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonArtillerySpellConstruct_15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonArtillerySpellConstruct_15Name = "SummonArtillerySpellConstruct_15";
         private const string SummonArtillerySpellConstruct_15Guid = "f0038039-423b-4265-b0cf-2eab2450f982";
 
-        protected SummonArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
+        protected SummonArtillerySpellConstruct15Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_15Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
-
 
             Definition.SubspellsList.Clear();
             Definition.SubspellsList.AddRange(new List<SpellDefinition>
             {
-                SummonFlameArtillerySpellConstruct_15Builder.SummonFlameArtilleryConstruct_15 ,
-               SummonForceArtillerySpellConstruct_15Builder.SummonForceArtilleryConstruct_15,
-                SummonTempHPShieldSpellConstruct_15Builder.SummonTempHPShieldConstruct_15
+                SummonFlameArtillerySpellConstruct15Builder.SummonFlameArtilleryConstruct_15 ,
+                SummonForceArtillerySpellConstruct15Builder.SummonForceArtilleryConstruct_15,
+                SummonTempHPShieldSpellConstruct15Builder.SummonTempHPShieldConstruct_15
             });
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonArtillerySpellConstruct_15Builder(name, guid).AddToDB();
+            return new SummonArtillerySpellConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct_15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
+        public static readonly SpellDefinition SummonArtillerySpellConstruct_15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
     }
-
 
     internal class SummoningAffinityTinkererArtilleryConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
     {
@@ -820,7 +778,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummoningAffinityTinkererArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionSummoningAffinitys.SummoningAffinityKindredSpiritBond, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&NoContentTitle";
             Definition.GuiPresentation.Description = "Feature/&NoContentTitle";
             Definition.GuiPresentation.SetSpriteReference(null);
@@ -864,8 +821,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummoningAffinityTinkererArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererArtilleryConstruct = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionSummoningAffinity SummoningAffinityTinkererArtilleryConstruct = CreateAndAddToDB(Name, Guid);
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
@@ -4,7 +4,6 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldBuilder		*******************************************************************
     //*****************************************************************************************************************************************
@@ -16,7 +15,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TempHPShieldBuilder(string name, string guid) : base(ThunderShieldBuilder.ThunderShield, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShieldTitle";
             Definition.SetShortTitleOverride("Feature/&TempHPShieldTitle");
             Definition.GuiPresentation.Description = "Feat/&TempHPShieldDescription";
@@ -25,8 +23,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
 
-
-            TemporaryHitPointsForm TempHPShield = new TemporaryHitPointsForm
+            TemporaryHitPointsForm tempHPShield = new TemporaryHitPointsForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 1,
@@ -38,14 +35,13 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             {
                 FormType = EffectForm.EffectFormType.TemporaryHitPoints
             };
-            effect.SetTemporaryHitPointsForm(TempHPShield);
+            effect.SetTemporaryHitPointsForm(tempHPShield);
             effect.SetCreatedByCharacter(true);
 
             effect.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
             effect.SetLevelMultiplier(1);
             effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
@@ -68,9 +64,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower TempHPShield = CreateAndAddToDB(TempHPShieldName, TempHPShieldGuid);
-
-
+        public static readonly FeatureDefinitionPower TempHPShield = CreateAndAddToDB(TempHPShieldName, TempHPShieldGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstructBuilder		*******************************************************************
@@ -83,7 +77,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TempHPShieldConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // cant use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -110,10 +103,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
-
-
-
-
 
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
@@ -142,12 +131,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Add(TempHPShieldBuilder.TempHPShield);
 
-
-
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -155,69 +139,56 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct = CreateAndAddToDB(TempHPShieldConstructName, TempHPShieldConstructGuid);
-
-
+        public static readonly MonsterDefinition TempHPShieldConstruct = CreateAndAddToDB(TempHPShieldConstructName, TempHPShieldConstructGuid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldConstruct_9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class TempHPShieldConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string TempHPShieldConstruct_9Name = "TempHPShieldConstruct_9";
         private const string TempHPShieldConstruct_9Guid = "75f8541a-65c3-4226-9c42-a80dd76b04cd";
 
-        protected TempHPShieldConstruct_9Builder(string name, string guid) : base(TempHPShieldConstructBuilder.TempHPShieldConstruct, name, guid)
+        protected TempHPShieldConstruct9Builder(string name, string guid) : base(TempHPShieldConstructBuilder.TempHPShieldConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&TempHPShieldConstructTitle_3";
 
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new TempHPShieldConstruct_9Builder(name, guid).AddToDB();
+            return new TempHPShieldConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct_9 = CreateAndAddToDB(TempHPShieldConstruct_9Name, TempHPShieldConstruct_9Guid);
-
-
+        public static readonly MonsterDefinition TempHPShieldConstruct_9 = CreateAndAddToDB(TempHPShieldConstruct_9Name, TempHPShieldConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldConstruct_15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class TempHPShieldConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string TempHPShieldConstruct_15Name = "TempHPShieldConstruct_15";
         private const string TempHPShieldConstruct_15Guid = "243d5f04-2106-4c20-a3f2-38484ecc345c";
 
-        protected TempHPShieldConstruct_15Builder(string name, string guid) : base(TempHPShieldConstruct_9Builder.TempHPShieldConstruct_9, name, guid)
+        protected TempHPShieldConstruct15Builder(string name, string guid) : base(TempHPShieldConstruct9Builder.TempHPShieldConstruct_9, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&TempHPShieldConstructTitle_5";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new TempHPShieldConstruct_15Builder(name, guid).AddToDB();
+            return new TempHPShieldConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct_15 = CreateAndAddToDB(TempHPShieldConstruct_15Name, TempHPShieldConstruct_15Guid);
-
-
+        public static readonly MonsterDefinition TempHPShieldConstruct_15 = CreateAndAddToDB(TempHPShieldConstruct_15Name, TempHPShieldConstruct_15Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstructBuilder		*******************************************************************
@@ -230,7 +201,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonTempHPShieldSpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShieldModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShieldModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Aid.GuiPresentation.SpriteReference);
@@ -240,12 +210,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.TempHPShield_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -253,81 +218,56 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonTempHPShieldSpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct = CreateAndAddToDB(SummonTempHPShieldConstructName, SummonTempHPShieldConstructGuid);
-
+        public static readonly SpellDefinition SummonTempHPShieldConstruct = CreateAndAddToDB(SummonTempHPShieldConstructName, SummonTempHPShieldConstructGuid);
     }
-
-
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonTempHPShieldSpellConstruct_9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonTempHPShieldSpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonTempHPShieldConstruct_9Name = "SummonTempHPShieldConstruct_9";
         private const string SummonTempHPShieldConstruct_9Guid = "f1e88575-40ca-4f4e-9447-616058e213a4";
 
-        protected SummonTempHPShieldSpellConstruct_9Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
+        protected SummonTempHPShieldSpellConstruct9Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShield_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShield_09ModePowerDescription";
 
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct_9Builder.TempHPShieldConstruct_9.Name);
-
-
-
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct9Builder.TempHPShieldConstruct_9.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonTempHPShieldSpellConstruct_9Builder(name, guid).AddToDB();
+            return new SummonTempHPShieldSpellConstruct9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct_9 = CreateAndAddToDB(SummonTempHPShieldConstruct_9Name, SummonTempHPShieldConstruct_9Guid);
-
+        public static readonly SpellDefinition SummonTempHPShieldConstruct_9 = CreateAndAddToDB(SummonTempHPShieldConstruct_9Name, SummonTempHPShieldConstruct_9Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonTempHPShieldSpellConstruct_15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonTempHPShieldSpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string SummonTempHPShieldConstruct_15Name = "SummonTempHPShieldConstruct_15";
         private const string SummonTempHPShieldConstruct_15Guid = "84ddce96-ec58-4141-933d-371080d611d2";
 
-        protected SummonTempHPShieldSpellConstruct_15Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
+        protected SummonTempHPShieldSpellConstruct15Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShield_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShield_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct_15Builder.TempHPShieldConstruct_15.Name);
-
-
-
-
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct15Builder.TempHPShieldConstruct_15.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonTempHPShieldSpellConstruct_15Builder(name, guid).AddToDB();
+            return new SummonTempHPShieldSpellConstruct15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct_15 = CreateAndAddToDB(SummonTempHPShieldConstruct_15Name, SummonTempHPShieldConstruct_15Guid);
-
+        public static readonly SpellDefinition SummonTempHPShieldConstruct_15 = CreateAndAddToDB(SummonTempHPShieldConstruct_15Name, SummonTempHPShieldConstruct_15Guid);
     }
-
-
-
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
@@ -7,7 +7,7 @@ using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class BattleSmithBuilder
+    public static class BattleSmithBuilder
     {
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer)
         {
@@ -46,7 +46,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder weaponProfPresentation = new GuiPresentationBuilder(
                 "Subclass/&WeaponProfArtificerBattleSmithDescription",
                 "Subclass/&WeaponProfArtificerBattleSmithTitle");
-            FeatureDefinitionProficiency weaponProf = FeatureHelpers.BuildProficiency(RuleDefinitions.ProficiencyType.Weapon,
+            FeatureDefinitionProficiency weaponProf = FeatureHelpers.BuildProficiency(ProficiencyType.Weapon,
                 new List<string>() { EquipmentDefinitions.MartialWeaponCategory },
                 "ProficiencyWeaponArtificerBattleSmith", weaponProfPresentation.Build());
             battleSmith.AddFeatureAtLevel(weaponProf, 3);
@@ -56,7 +56,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&HealingPoolArtificerBattleSmithInfusionsIncreaseTitle");
             FeatureDefinitionPowerPoolModifier InfusionPoolIncrease = new FeatureDefinitionPowerPoolModifierBuilder("AttributeModiferArtificerBattleSmithInfusionHealingPool",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "AttributeModiferArtificerBattleSmithInfusionHealingPool").ToString(),
-                2, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence, TinkererClass.InfusionPool, InfusionPoolIncreaseGui.Build()).AddToDB();
+                2, UsesDetermination.Fixed, AttributeDefinitions.Intelligence, TinkererClass.InfusionPool, InfusionPoolIncreaseGui.Build()).AddToDB();
             battleSmith.AddFeatureAtLevel(InfusionPoolIncrease, 3);
 
             GuiPresentationBuilder attackModGui = new GuiPresentationBuilder(
@@ -93,8 +93,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&AttackModifierArtificerBattleSmithJoltTitle");
             FeatureDefinitionAttackModifier joltAttack = FeatureHelpers.BuildAttackModifier(
                 // Note ability score bonus only works if it's applied to a weapon, not a character.
-                RuleDefinitions.AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
-                RuleDefinitions.AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
+                AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
+                AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
                 "AttackModifierArtificerBattleSmithJolt", joltAttackGui.Build());
             battleSmith.AddFeatureAtLevel(joltAttack, 9);
 
@@ -113,8 +113,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&AttackModifierArtificerBattleSmithJolt2Title");
             FeatureDefinitionAttackModifier jolt2Attack = FeatureHelpers.BuildAttackModifier(
                 // Note ability score bonus only works if it's applied to a weapon, not a character.
-                RuleDefinitions.AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
-                RuleDefinitions.AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
+                AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
+                AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
                 "AttackModifierArtificerBattleSmithJolt2", jolt2AttackGui.Build());
             battleSmith.AddFeatureAtLevel(jolt2Attack, 15);
             battleSmith.AddFeatureAtLevel(ProtectorConstructUpgradeFeatureSetBuilder.ProtectorConstructUpgradeFeatureSet, 15);
@@ -123,7 +123,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return battleSmith.AddToDB();
         }
 
-        private class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        private sealed class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             public FeatureDefinitionAttackModifierBuilder(string name, string guid,
             RuleDefinitions.AbilityScoreReplacement abilityReplacement, string additionalAttackTag,

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
     ////*****************************************************************************************************************************************
     ////***********************************		TinkererConstructFamilyBuilder		*************************************************************
     ////*****************************************************************************************************************************************
@@ -18,9 +17,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TinkererConstructFamilyBuilder(string name, string guid) : base(DatabaseHelper.CharacterFamilyDefinitions.Construct, name, guid)
         {
-
             Definition.SetExtraplanar(true);
-
         }
 
         public static CharacterFamilyDefinition CreateAndAddToDB(string name, string guid)
@@ -28,7 +25,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TinkererConstructFamilyBuilder(name, guid).AddToDB();
         }
 
-        public static CharacterFamilyDefinition TinkererConstructFamily = CreateAndAddToDB(TinkererConstructFamilyName, TinkererConstructFamilyGuid);
+        public static readonly CharacterFamilyDefinition TinkererConstructFamily = CreateAndAddToDB(TinkererConstructFamilyName, TinkererConstructFamilyGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -42,14 +39,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected AddConstructCantripsBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionBonusCantripss.BonusCantripsDomainOblivion, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&AddConstructCantripsTitle";
             Definition.GuiPresentation.Description = "Feat/&AddConstructCantripsDescription";
 
             Definition.BonusCantrips.Clear();
             Definition.BonusCantrips.Add(MendingConstructBuilder.MendingConstruct);
             Definition.BonusCantrips.Add(DismissConstructBuilder.DismissConstruct);
-
         }
 
         public static FeatureDefinitionBonusCantrips CreateAndAddToDB(string name, string guid)
@@ -57,7 +52,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new AddConstructCantripsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionBonusCantrips AddConstructCantrips = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionBonusCantrips AddConstructCantrips = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -71,7 +66,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected MendingConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.PrayerOfHealing, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&MendingConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&MendingConstructDescription";
 
@@ -101,7 +95,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.EffectDescription.EffectForms.Add(effect);
             Definition.EffectDescription.RestrictedCreatureFamilies.Add(TinkererConstructFamilyBuilder.TinkererConstructFamily.Name);
             Definition.EffectDescription.ImmuneCreatureFamilies.Clear();
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -109,7 +102,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new MendingConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition MendingConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition MendingConstruct = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -123,7 +116,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected DismissConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.Banishment, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&DismissConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&DismissConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.AnimalFriendship.GuiPresentation.SpriteReference);
@@ -135,14 +127,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetMaterialComponentType(RuleDefinitions.MaterialComponentType.None);
             Definition.SetVerboseComponent(false);
 
-            CounterForm DismissConstruct = new CounterForm();
-            DismissConstruct.SetType(CounterForm.CounterType.DismissCreature);
+            CounterForm dismissConstruct = new CounterForm();
+            dismissConstruct.SetType(CounterForm.CounterType.DismissCreature);
 
             EffectForm effect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Counter
             };
-            effect.SetCounterForm(DismissConstruct);
+            effect.SetCounterForm(dismissConstruct);
             effect.HasSavingThrow = false;
             effect.SetCreatedByCharacter(true);
 
@@ -176,7 +168,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             });
 
             Definition.SetEffectDescription(effectDescription);
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -184,9 +175,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new DismissConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition DismissConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition DismissConstruct = CreateAndAddToDB(Name, Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ArtificialServantBuilder		*******************************************************************
@@ -199,8 +189,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtificialServantBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Fire_Jester, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Feat/&ArtificialServantTitle";
             Definition.GuiPresentation.Description = "Feat/&ArtificialServantDescription";
             Definition.MonsterPresentation.SetUniqueNameTitle("Feat/&ArtificialServantTitle");
@@ -242,8 +230,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SkillScores.Add(Stealth);
             Definition.SkillScores.Add(Perception);
 
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(10);
@@ -265,7 +251,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityPoisonImmunity);
             // Definition.Features.Add(DatabaseHelper.);
 
-
             Definition.AttackIterations.Clear();
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
             monsterAttackIteration.SetField("monsterAttackDefinition", ArtificialServantAttackBuilder.ArtificialServantAttack);
@@ -276,7 +261,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.MonsterPresentation.SetFemalePrefabReference(new UnityEngine.AddressableAssets.AssetReference("ab0501343e8629149ae0aa4dace755f5"));
             Definition.MonsterPresentation.SetMaleModelScale(0.2f);
             Definition.MonsterPresentation.SetFemaleModelScale(0.2f);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -284,9 +268,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtificialServantBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ArtificialServant = CreateAndAddToDB(ArtificialServantName, ArtificialServantGuid);
-
-
+        public static readonly MonsterDefinition ArtificialServant = CreateAndAddToDB(ArtificialServantName, ArtificialServantGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -300,7 +282,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtificialServantAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Goblin_PebbleThrow, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ArtificialServantAttackTitle";
             Definition.GuiPresentation.Description = "Feat/&ArtificialServantAttackDescription";
 
@@ -314,12 +295,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 }
             };
 
-            int assumedIntModifier = 3;
-            int assumedProficiencyBonus = 2;
+            const int assumedIntModifier = 3;
+            const int assumedProficiencyBonus = 2;
             damageEffect.DamageForm.BonusDamage = assumedProficiencyBonus;
             damageEffect.DamageForm.DamageType = "DamageForce";
-
-
 
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
@@ -337,15 +316,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // newEffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.ShadowDagger.EffectDescription.EffectParticleParameters);
             newEffectDescription.SetEffectParticleParameters(DatabaseHelper.MonsterAttackDefinitions.Attack_Goblin_PebbleThrow.EffectDescription.EffectParticleParameters);
 
-
             Definition.SetEffectDescription(newEffectDescription);
 
             Definition.SetToHitBonus(assumedIntModifier + assumedProficiencyBonus);
-
-
-
-
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -353,9 +326,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtificialServantAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
-
-
+        public static readonly MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
     }
     internal class CancelFlyingConditionBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -364,7 +335,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected CancelFlyingConditionBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionBootsWinged, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&CancelFlyingConditionTitle";
             Definition.GuiPresentation.Description = "Feat/&CancelFlyingConditionDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ExpeditiousRetreat.GuiPresentation.SpriteReference);
@@ -397,7 +367,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectDescription.EffectForms.Add(effect);
 
             Definition.SetEffectDescription(effectDescription);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -405,7 +374,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new CancelFlyingConditionBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower CancelFlyingCondition = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionPower CancelFlyingCondition = CreateAndAddToDB(Name, Guid);
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
@@ -9,9 +9,8 @@ using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class FeatureHelpers
+    internal static class FeatureHelpers
     {
-
         // TODO Most of theese builders should likely get moved/merged with the CE builders.
         public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
         {
@@ -92,7 +91,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public class FeatureDefinitionMagicAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionMagicAffinity>
         {
-
             public FeatureDefinitionMagicAffinityBuilder(string name, string guid, RuleDefinitions.ConcentrationAffinity concentrationAffinity,
                 int threshold, GuiPresentation guiPresentation) : base(name, guid)
             {
@@ -311,7 +309,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             public FeatureDefinitionBonusCantripsBuilder(string name, string guid, List<SpellDefinition> cantrips, GuiPresentation guiPresentation) : base(name, guid)
             {
-
                 foreach (SpellDefinition cantrip in cantrips)
                 {
                     Definition.BonusCantrips.Add(cantrip);
@@ -372,7 +369,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 autospelllists, characterclass, guiPresentation);
             return builder.AddToDB();
         }
-
 
         public static FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup BuildAutoPreparedSpellGroup(int classLevel, List<SpellDefinition> spellnames)
         {
@@ -441,7 +437,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             particleParams.Copy(DatabaseHelper.FeatureDefinitionPowers.PowerWizardArcaneRecovery.EffectDescription.EffectParticleParameters);
             effectDescriptionBuilder.SetParticleEffectParameters(particleParams);
 
-
             FeatureDefinitionPowerBuilder builder = new FeatureDefinitionPowerBuilder(name, GuidHelper.Create(TinkererClass.GuidNamespace, name).ToString(),
                 usesPerRecharge, usesDetermination, AttributeDefinitions.Intelligence, activationTime, costPerUse, recharge, false, false, AttributeDefinitions.Intelligence,
                 effectDescriptionBuilder.Build(), guiPresentation);
@@ -477,7 +472,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionHealingModifier BuildHealingModifier(int healingBonusDiceNumber, RuleDefinitions.DieType healingBonusDiceType,
             RuleDefinitions.LevelSourceType addLevel, string name, GuiPresentation guiPresentation)
         {
-
             FeatureDefinitionHealingModifierBuilder healingModifier = new FeatureDefinitionHealingModifierBuilder(name, GuidHelper.Create(TinkererClass.GuidNamespace, name).ToString(),
                 healingBonusDiceNumber, healingBonusDiceType, addLevel, guiPresentation);
             return healingModifier.AddToDB();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -10,7 +10,7 @@ using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class InfusionHelpers
+    internal static class InfusionHelpers
     {
         private static FeatureDefinitionPower artificialServant;
         private static FeatureDefinitionPower enhancedFocus;
@@ -45,22 +45,17 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         private static FeatureDefinitionPowerSharedPoolBuilder BuildBasicInfusionPower(string name, EffectDescription effect, GuiPresentation presentation)
         {
-            FeatureDefinitionPowerSharedPoolBuilder infusion = new FeatureDefinitionPowerSharedPoolBuilder(name,
+            return new FeatureDefinitionPowerSharedPoolBuilder(name,
                 GuidHelper.Create(TinkererClass.GuidNamespace, name).ToString(),
                 TinkererClass.InfusionPool, RuleDefinitions.RechargeRate.LongRest, RuleDefinitions.ActivationTime.NoCost, 1, false, false, AttributeDefinitions.Intelligence,
                 effect, presentation, true /* unique instance */);
-            return infusion;
         }
 
         public static FeatureDefinitionPower ArtificialServant
         {
             get
             {
-                if (artificialServant == null)
-                {
-                    artificialServant = BuildArtificialServant();
-                }
-                return artificialServant;
+                return artificialServant ?? (artificialServant = BuildArtificialServant());
             }
         }
 
@@ -76,20 +71,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             artificialServantEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             artificialServantEffect.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ArtificialServantBuilder.ArtificialServant.name, DatabaseHelper.ConditionDefinitions.ConditionFlyingBootsWinged, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-            FeatureDefinitionPowerSharedPool summonArtificialServantPower = InfusionHelpers.BuildBasicInfusionPower("summonArtificialServantPower",
+            return BuildBasicInfusionPower("summonArtificialServantPower",
                 artificialServantEffect.Build(), summonArtificialServantGui.Build()).AddToDB();
-            return summonArtificialServantPower;
         }
 
         public static FeatureDefinitionPower EnhancedFocus
         {
             get
             {
-                if (enhancedFocus == null)
-                {
-                    enhancedFocus = BuildEnhancedFocus();
-                }
-                return enhancedFocus;
+                return enhancedFocus ?? (enhancedFocus = BuildEnhancedFocus());
             }
         }
 
@@ -99,8 +89,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerEnhancedFocusDescription",
                 "Subclass/&AttackModifierArtificerEnhancedFocusTitle");
             focusPlus1Gui.SetSpriteReference(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierMagicWeapon.GuiPresentation.SpriteReference);
-            FeatureDefinitionMagicAffinity focusPlus1 = FeatureHelpers.BuildMagicAffinityModifiers(1, 1, "Enhanced Focus", focusPlus1Gui.Build());
-            ConditionDefinition infusedFocusCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() { focusPlus1 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedFocus", focusPlus1Gui.Build());
+            FeatureDefinitionMagicAffinity focusPlus1 = BuildMagicAffinityModifiers(1, 1, "Enhanced Focus", focusPlus1Gui.Build());
+            ConditionDefinition infusedFocusCondition = BuildCondition(new List<FeatureDefinition>() { focusPlus1 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedFocus", focusPlus1Gui.Build());
 
             GuiPresentationBuilder enhanceFocusGui = new GuiPresentationBuilder(
                 "Subclass/&AttackModifierArtificerEnhancedFocusDescription",
@@ -113,11 +103,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedFocus == null)
-                {
-                    improvedEnhancedFocus = BuildImprovedEnhancedFocus();
-                }
-                return improvedEnhancedFocus;
+                return improvedEnhancedFocus ?? (improvedEnhancedFocus = BuildImprovedEnhancedFocus());
             }
         }
 
@@ -127,8 +113,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerImprovedEnhancedFocusDescription",
                 "Subclass/&AttackModifierArtificerImprovedEnhancedFocusTitle");
             focusPlus2Gui.SetSpriteReference(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierMagicWeapon.GuiPresentation.SpriteReference);
-            FeatureDefinitionMagicAffinity focusPlus2 = FeatureHelpers.BuildMagicAffinityModifiers(2, 2, "ImprovedEnhancedFocus", focusPlus2Gui.Build());
-            ConditionDefinition infusedFocusCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() { focusPlus2 }, RuleDefinitions.DurationType.UntilLongRest, 1, false,
+            FeatureDefinitionMagicAffinity focusPlus2 = BuildMagicAffinityModifiers(2, 2, "ImprovedEnhancedFocus", focusPlus2Gui.Build());
+            ConditionDefinition infusedFocusCondition = BuildCondition(new List<FeatureDefinition>() { focusPlus2 }, RuleDefinitions.DurationType.UntilLongRest, 1, false,
                 "ArtificerImprovedInfusedFocus", focusPlus2Gui.Build());
 
             GuiPresentationBuilder enhanceFocusGui = new GuiPresentationBuilder(
@@ -143,11 +129,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (enhancedDefense == null)
-                {
-                    enhancedDefense = BuildEnhancedDefense();
-                }
-                return enhancedDefense;
+                return enhancedDefense ?? (enhancedDefense = BuildEnhancedDefense());
             }
         }
 
@@ -157,7 +139,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerEnhancedArmorDescription",
                 "Subclass/&AttackModifierArtificerEnhancedArmorTitle");
             enhanceArmorConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            FeatureDefinitionAttributeModifier armorModifier = FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
+            FeatureDefinitionAttributeModifier armorModifier = BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
                 "AttributeModifierArmorInfusion", enhanceArmorConditionGui.Build());
 
             GuiPresentationBuilder enhanceArmorGui = new GuiPresentationBuilder(
@@ -172,11 +154,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedDefense == null)
-                {
-                    improvedEnhancedDefense = BuildImprovedEnhancedDefense();
-                }
-                return improvedEnhancedDefense;
+                return improvedEnhancedDefense ?? (improvedEnhancedDefense = BuildImprovedEnhancedDefense());
             }
         }
 
@@ -186,7 +164,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerImprovedEnhancedArmorDescription",
                 "Subclass/&AttackModifierArtificerImprovedEnhancedArmorTitle");
             enhanceArmorConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            FeatureDefinitionAttributeModifier armorModifier = FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 2,
+            FeatureDefinitionAttributeModifier armorModifier = BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 2,
                 "AttributeModifierImprovedArmorInfusion", enhanceArmorConditionGui.Build());
 
             GuiPresentationBuilder enhanceArmorGui = new GuiPresentationBuilder(
@@ -202,11 +180,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (enhancedWeapon == null)
-                {
-                    enhancedWeapon = BuildEnhancedWeapon();
-                }
-                return enhancedWeapon;
+                return enhancedWeapon ?? (enhancedWeapon = BuildEnhancedWeapon());
             }
         }
 
@@ -225,11 +199,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedWeapon == null)
-                {
-                    improvedEnhancedWeapon = BuildImprovedEnhancedWeapon();
-                }
-                return improvedEnhancedWeapon;
+                return improvedEnhancedWeapon ?? (improvedEnhancedWeapon = BuildImprovedEnhancedWeapon());
             }
         }
 
@@ -249,11 +219,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bagOfHolding == null)
-                {
-                    bagOfHolding = BuildBagOfHolding();
-                }
-                return bagOfHolding;
+                return bagOfHolding ?? (bagOfHolding = BuildBagOfHolding());
             }
         }
 
@@ -263,26 +229,22 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&EquipmentModifierArtificerBagOfHolderDescription",
                 "Subclass/&EquipmentModifierArtificerBagOfHolderTitle");
             bagOfHoldingConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBullsStrength.GuiPresentation.SpriteReference);
-            ConditionDefinition bagOfHoldingCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
-                    FeatureHelpers.BuildEquipmentAffinity(1.0f, 500.0f, "InfusionBagOfHolding", bagOfHoldingConditionGui.Build())
+            ConditionDefinition bagOfHoldingCondition = BuildCondition(new List<FeatureDefinition>() {
+                    BuildEquipmentAffinity(1.0f, 500.0f, "InfusionBagOfHolding", bagOfHoldingConditionGui.Build())
                     }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionBagOfHolding", bagOfHoldingConditionGui.Build());
 
             GuiPresentationBuilder bagOfHoldingGui = new GuiPresentationBuilder(
                 "Subclass/&EquipmentModifierArtificerBagOfHolderDescription",
                 "Subclass/&EquipmentModifierArtificerBagOfHolderTitle");
             bagOfHoldingGui.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionPotionOfGiantStrengthCloud.GuiPresentation.SpriteReference);
-            return BuildItemConditionInfusion(bagOfHoldingCondition, "ArtificerInfusionBagOfHolding", bagOfHoldingGui.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(bagOfHoldingCondition, "ArtificerInfusionBagOfHolding", bagOfHoldingGui.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower GogglesOfNight
         {
             get
             {
-                if (gogglesOfNight == null)
-                {
-                    gogglesOfNight = BuildGogglesOfNight();
-                }
-                return gogglesOfNight;
+                return gogglesOfNight ?? (gogglesOfNight = BuildGogglesOfNight());
             }
         }
 
@@ -292,7 +254,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseDarkvisionDescription",
                 "Subclass/&PowerInfuseDarkvisionTitle");
             InfuseDarkvisionCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionSeeInvisibility.GuiPresentation.SpriteReference);
-            ConditionDefinition darkvisionCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition darkvisionCondition = BuildCondition(new List<FeatureDefinition>() {
                 DatabaseHelper.FeatureDefinitionSenses.SenseSuperiorDarkvision,
                 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionDarkvision", InfuseDarkvisionCondition.Build());
 
@@ -301,18 +263,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseDarkvisionTitle");
             InfuseDarkvision.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerDomainBattleDivineWrath.GuiPresentation.SpriteReference);
 
-            return BuildItemConditionInfusion(darkvisionCondition, "PowerInfuseDarkvision", InfuseDarkvision.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(darkvisionCondition, "PowerInfuseDarkvision", InfuseDarkvision.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower MindSharpener
         {
             get
             {
-                if (mindSharpener == null)
-                {
-                    mindSharpener = BuildMindSharpener();
-                }
-                return mindSharpener;
+                return mindSharpener ?? (mindSharpener = BuildMindSharpener());
             }
         }
 
@@ -322,8 +280,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseMindSharpenerDescription",
                 "Subclass/&PowerInfuseMindSharpenerTitle");
             InfuseMindSharpenerCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBearsEndurance.GuiPresentation.SpriteReference);
-            ConditionDefinition infusedMindSharpenerCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
-                FeatureHelpers.BuildMagicAffinityConcentration(RuleDefinitions.ConcentrationAffinity.Advantage, 20, "MagicAffinityMindSharpener", InfuseMindSharpenerCondition.Build()),
+            ConditionDefinition infusedMindSharpenerCondition = BuildCondition(new List<FeatureDefinition>() {
+                BuildMagicAffinityConcentration(RuleDefinitions.ConcentrationAffinity.Advantage, 20, "MagicAffinityMindSharpener", InfuseMindSharpenerCondition.Build()),
                 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionMindSharpener", InfuseMindSharpenerCondition.Build());
 
             GuiPresentationBuilder InfuseMindSharpener = new GuiPresentationBuilder(
@@ -331,18 +289,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseMindSharpenerTitle");
             InfuseMindSharpener.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionTomeOfQuickThought.GuiPresentation.SpriteReference);
 
-            return BuildItemConditionInfusion(infusedMindSharpenerCondition, "ArtificerInfusionMindSharpener", InfuseMindSharpener.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(infusedMindSharpenerCondition, "ArtificerInfusionMindSharpener", InfuseMindSharpener.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower ArmorOfMagicalStrength
         {
             get
             {
-                if (armorOfMagicalStrength == null)
-                {
-                    armorOfMagicalStrength = BuildArmorOfMagicalStrength();
-                }
-                return armorOfMagicalStrength;
+                return armorOfMagicalStrength ?? (armorOfMagicalStrength = BuildArmorOfMagicalStrength());
             }
         }
 
@@ -352,13 +306,13 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseArmorMagicalStrengthDescription",
                 "Subclass/&PowerInfuseArmorMagicalStrengthTitle");
             InfuseArmorMagicalStrengthCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBullsStrength.GuiPresentation.SpriteReference);
-            FeatureDefinitionAbilityCheckAffinity strengthAbilityAffinity = FeatureHelpers.BuildAbilityAffinity(new List<Tuple<string, string>>()
+            FeatureDefinitionAbilityCheckAffinity strengthAbilityAffinity = BuildAbilityAffinity(new List<Tuple<string, string>>()
             {
                 new Tuple<string, string>(AttributeDefinitions.Strength, ""),
             }, 0, RuleDefinitions.DieType.D1, RuleDefinitions.CharacterAbilityCheckAffinity.Advantage, "AbilityAffinityInfusionMagicalStrength", InfuseArmorMagicalStrengthCondition.Build());
-            FeatureDefinitionSavingThrowAffinity strengthSaveAffinity = FeatureHelpers.BuildSavingThrowAffinity(new List<string>() { AttributeDefinitions.Strength },
+            FeatureDefinitionSavingThrowAffinity strengthSaveAffinity = BuildSavingThrowAffinity(new List<string>() { AttributeDefinitions.Strength },
                 RuleDefinitions.CharacterSavingThrowAffinity.Advantage, FeatureDefinitionSavingThrowAffinity.ModifierType.AddDice, 0, RuleDefinitions.DieType.D1, false, "SaveAffinityInfusionMagicalStrength", InfuseArmorMagicalStrengthCondition.Build());
-            ConditionDefinition armorMagicalStrengthCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition armorMagicalStrengthCondition = BuildCondition(new List<FeatureDefinition>() {
                 strengthAbilityAffinity,
                 strengthSaveAffinity,
                 DatabaseHelper.FeatureDefinitionConditionAffinitys.ConditionAffinityProneImmunity,
@@ -368,21 +322,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseArmorMagicalStrengthDescription",
                 "Subclass/&PowerInfuseArmorMagicalStrengthTitle");
             InfuseArmorMagicalStrength.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionManualGainfulExercise.GuiPresentation.SpriteReference);
-            return BuildItemConditionInfusion(armorMagicalStrengthCondition, "ArtificerInfusionArmorMagicalStrength", InfuseArmorMagicalStrength.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(armorMagicalStrengthCondition, "ArtificerInfusionArmorMagicalStrength", InfuseArmorMagicalStrength.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower ResistantArmor
         {
             get
             {
-                if (resistantArmor == null)
-                {
-                    resistantArmor = BuildResistantArmor();
-                }
-                return resistantArmor;
+                return resistantArmor ?? (resistantArmor = BuildResistantArmor());
             }
         }
-
 
         private static FeatureDefinitionPower BuildResistantArmor()
         {
@@ -394,7 +343,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&ConditionResistnatArmorDescription",
                 "Subclass/&ConditionResistantArmorTitle");
             ConditionArmorResistance.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            ConditionDefinition ArmorResistance = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition ArmorResistance = BuildCondition(new List<FeatureDefinition>() {
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityAcidResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityColdResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityFireResistance,
@@ -405,52 +354,43 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityPsychicResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityRadiantResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityThunderResistance,
-
             },
                 RuleDefinitions.DurationType.UntilLongRest, 1, false, "ConditionPowerArtificerResistantArmor", ConditionArmorResistance.Build());
-            return BuildItemConditionInfusion(ArmorResistance, "ArtificerInfusionResistantArmor", InfuseResistantArmor.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(ArmorResistance, "ArtificerInfusionResistantArmor", InfuseResistantArmor.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower SpellRefuelingRing
         {
             get
             {
-                if (spellRefuelingRing == null)
-                {
-                    spellRefuelingRing = BuildSpellRefuelingRing();
-                }
-                return spellRefuelingRing;
+                return spellRefuelingRing ?? (spellRefuelingRing = BuildSpellRefuelingRing());
             }
         }
 
-
         private static FeatureDefinitionPower BuildSpellRefuelingRing()
         {
-            GuiPresentationBuilder InfuseSpellRefuelingRing = new GuiPresentationBuilder(
+            GuiPresentationBuilder infuseSpellRefuelingRing = new GuiPresentationBuilder(
                 "Subclass/&PowerSpellRefuelingRingDescription",
                 "Subclass/&PowerSpellRefuelingRingTitle");
-            InfuseSpellRefuelingRing.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerDomainElementalDiscipleOfTheElementsLightning.GuiPresentation.SpriteReference);
+            infuseSpellRefuelingRing.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerDomainElementalDiscipleOfTheElementsLightning.GuiPresentation.SpriteReference);
 
             EffectDescriptionBuilder spellEffect = new EffectDescriptionBuilder();
             spellEffect.SetDurationData(RuleDefinitions.DurationType.UntilLongRest, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             spellEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Self, 1, 1, ActionDefinitions.ItemSelectionType.None);
             spellEffect.AddEffectForm(new EffectFormBuilder().SetSpellForm(9).Build());
-            FeatureDefinitionPowerSharedPool spellRefuelingRing = new FeatureDefinitionPowerSharedPoolBuilder("ArtificerInfusionSpellRefuelingRing",
+
+            return
+                new FeatureDefinitionPowerSharedPoolBuilder("ArtificerInfusionSpellRefuelingRing",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "ArtificerInfusionSpellRefuelingRing").ToString(),
                 TinkererClass.InfusionPool, RuleDefinitions.RechargeRate.LongRest, RuleDefinitions.ActivationTime.NoCost, 1, false, false, AttributeDefinitions.Intelligence,
-                spellEffect.Build(), InfuseSpellRefuelingRing.Build(), true /* unique instance */).AddToDB();
-            return spellRefuelingRing;
+                spellEffect.Build(), infuseSpellRefuelingRing.Build(), true /* unique instance */).AddToDB();
         }
 
         public static FeatureDefinitionPower BlindingWeapon
         {
             get
             {
-                if (blindingWeapon == null)
-                {
-                    blindingWeapon = BuildBlindingWeapon();
-                }
-                return blindingWeapon;
+                return blindingWeapon ?? (blindingWeapon = BuildBlindingWeapon());
             }
         }
 
@@ -489,11 +429,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfProtection == null)
-                {
-                    cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection");
-                }
-                return cloakOfProtection;
+                return cloakOfProtection ?? (cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection"));
             }
         }
 
@@ -501,11 +437,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfElvenKind == null)
-                {
-                    bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind");
-                }
-                return bootsOfElvenKind;
+                return bootsOfElvenKind ?? (bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind"));
             }
         }
 
@@ -513,11 +445,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfElvenKind == null)
-                {
-                    cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind");
-                }
-                return cloakOfElvenKind;
+                return cloakOfElvenKind ?? (cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind"));
             }
         }
 
@@ -525,11 +453,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfStridingAndSpringing == null)
-                {
-                    bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing");
-                }
-                return bootsOfStridingAndSpringing;
+                return bootsOfStridingAndSpringing ?? (bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing"));
             }
         }
 
@@ -537,11 +461,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfTheWinterland == null)
-                {
-                    bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland");
-                }
-                return bootsOfTheWinterland;
+                return bootsOfTheWinterland ?? (bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland"));
             }
         }
 
@@ -549,11 +469,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bracesrOfArchery == null)
-                {
-                    bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery");
-                }
-                return bracesrOfArchery;
+                return bracesrOfArchery ?? (bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery"));
             }
         }
 
@@ -561,11 +477,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (broochOfShielding == null)
-                {
-                    broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding");
-                }
-                return broochOfShielding;
+                return broochOfShielding ?? (broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding"));
             }
         }
 
@@ -573,11 +485,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (gauntletsOfOgrePower == null)
-                {
-                    gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower");
-                }
-                return gauntletsOfOgrePower;
+                return gauntletsOfOgrePower ?? (gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower"));
             }
         }
 
@@ -585,11 +493,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (glovesOfMissileSnaring == null)
-                {
-                    glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring");
-                }
-                return glovesOfMissileSnaring;
+                return glovesOfMissileSnaring ?? (glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring"));
             }
         }
 
@@ -597,11 +501,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (slippersOfSpiderClimbing == null)
-                {
-                    slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing");
-                }
-                return slippersOfSpiderClimbing;
+                return slippersOfSpiderClimbing ?? (slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing"));
             }
         }
 
@@ -609,11 +509,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (headbandOfIntellect == null)
-                {
-                    headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect");
-                }
-                return headbandOfIntellect;
+                return headbandOfIntellect ?? (headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect"));
             }
         }
 
@@ -621,11 +517,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (amuletOfHealth == null)
-                {
-                    amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth");
-                }
-                return amuletOfHealth;
+                return amuletOfHealth ?? (amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth"));
             }
         }
 
@@ -633,11 +525,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (beltOfGiantHillStrength == null)
-                {
-                    beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength");
-                }
-                return beltOfGiantHillStrength;
+                return beltOfGiantHillStrength ?? (beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength"));
             }
         }
 
@@ -645,11 +533,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bracersOfDefense == null)
-                {
-                    bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense");
-                }
-                return bracersOfDefense;
+                return bracersOfDefense ?? (bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense"));
             }
         }
 
@@ -657,11 +541,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfBat == null)
-                {
-                    cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat");
-                }
-                return cloakOfBat;
+                return cloakOfBat ?? (cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat"));
             }
         }
 
@@ -669,11 +549,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (ringProtectionPlus1 == null)
-                {
-                    ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1");
-                }
-                return ringProtectionPlus1;
+                return ringProtectionPlus1 ?? (ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1"));
             }
         }
 
@@ -701,13 +577,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         private static FeatureDefinitionPower PowerMimicsItem(ItemDefinition item, string name)
         {
-
             List<FeatureDefinition> features = new List<FeatureDefinition>();
             foreach (ItemPropertyDescription property in item.StaticProperties)
             {
                 features.Add(property.FeatureDefinition);
             }
-            ConditionDefinition itemCondition = FeatureHelpers.BuildCondition(features, RuleDefinitions.DurationType.UntilLongRest, 1, false,
+            ConditionDefinition itemCondition = BuildCondition(features, RuleDefinitions.DurationType.UntilLongRest, 1, false,
                 "Condition" + name, item.GuiPresentation);
 
             EffectDescriptionBuilder itemEffect = new EffectDescriptionBuilder();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
@@ -1,20 +1,24 @@
 ﻿
 using HarmonyLib;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     // TODO verify if this is still needed. It's original goal was to help filter the Infusion selection lists during level up properly.
-    internal class Patches
+    internal static class Patches
     {
         [HarmonyPatch(typeof(CharacterBuildingManager), "LevelUpCharacter")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
         internal static class CharacterBuildingManager_LevelUpClearActiveFeatures
         {
             internal static void Postfix(CharacterBuildingManager __instance)
             {
-                MethodInfo dynMethod = __instance.GetType().GetMethod("RefreshAllActiveFeatures",
-                    BindingFlags.NonPublic | BindingFlags.Instance);
-                dynMethod.Invoke(__instance, new object[] { });
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+                MethodInfo dynMethod = __instance.GetType().GetMethod("RefreshAllActiveFeatures", BindingFlags.NonPublic | BindingFlags.Instance);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+
+                dynMethod.Invoke(__instance, System.Array.Empty<object>());
             }
         }
     }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
@@ -8,8 +8,6 @@ using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
-
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructFeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
@@ -21,7 +19,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructFeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
 
@@ -29,7 +26,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.FeatureSet.Add(SummoningAffinityTinkererConstructBuilder.SummoningAffinityTinkererConstruct);
             Definition.FeatureSet.Add(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct);
             Definition.FeatureSet.Add(ProtectorConstructLevel3AutopreparedSpellsBuilder.ProtectorConstructLevel3AutopreparedSpells);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -37,8 +33,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructFeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     public class ProtectorConstructLevel3AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
@@ -51,21 +46,23 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructLevel3AutopreparedSpellsTitle";
             Definition.GuiPresentation.Description = "Feat/&ProtectorConstructLevel3AutopreparedSpellsDescription";
 
+#pragma warning disable S1481 // Unused local variables should be removed
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 1,
-                SpellsList = (new List<SpellDefinition>
-            {
-                SummonProtectorSpellConstructBuilder.SummonProtectorConstruct
-            })
+                SpellsList = new List<SpellDefinition>
+                {
+                    SummonProtectorSpellConstructBuilder.SummonProtectorConstruct
+                }
             };
+#pragma warning restore S1481 // Unused local variables should be removed
         }
         public static FeatureDefinitionAutoPreparedSpells CreateAndAddToDB(string name, string guid)
         {
             return new ProtectorConstructLevel3AutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel3AutopreparedSpells = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel3AutopreparedSpells = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -79,7 +76,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummoningAffinityTinkererConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionSummoningAffinitys.SummoningAffinityKindredSpiritBond, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&NoContentTitle";
             Definition.GuiPresentation.Description = "Feature/&NoContentTitle";
             Definition.GuiPresentation.SetSpriteReference(null);
@@ -123,10 +119,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummoningAffinityTinkererConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererConstruct = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionSummoningAffinity SummoningAffinityTinkererConstruct = CreateAndAddToDB(Name, Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorConstructBuilder		***********************************************************
@@ -139,7 +133,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonProtectorPowerConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerClericDivineInterventionCleric, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ConjureAnimalsFourBeasts.GuiPresentation.SpriteReference);
@@ -157,7 +150,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ProtectorConstructEffect.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ProtectorConstructBuilder.ProtectorConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
             Definition.SetEffectDescription(ProtectorConstructEffect.Build());
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -165,35 +157,34 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorPowerConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
-
+        public static readonly FeatureDefinitionPower SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
     }
 
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorPowerConstruct_UpgradeBuilder		***************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonProtectorPowerConstruct_UpgradeBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SummonProtectorPowerConstructUpgradeBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
         private const string Name = "SummonProtectorPowerConstruct_Upgrade";
         private const string Guid = "34c307e9-5883-438c-9130-1f286b9cdafc";
 
-        protected SummonProtectorPowerConstruct_UpgradeBuilder(string name, string guid) : base(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct, name, guid)
+        protected SummonProtectorPowerConstructUpgradeBuilder(string name, string guid) : base(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle_2";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription_2";
 
             Definition.SetOverriddenPower(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct);
 
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ProtectorConstruct_UpgradeBuilder.ProtectorConstruct_Upgrade.Name);
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ProtectorConstructUpgradeBuilder.ProtectorConstruct_Upgrade.Name);
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
         {
-            return new SummonProtectorPowerConstruct_UpgradeBuilder(name, guid).AddToDB();
+            return new SummonProtectorPowerConstructUpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SummonProtectorPowerConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionPower SummonProtectorPowerConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -207,7 +198,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonProtectorSpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ConjureAnimalsFourBeasts.GuiPresentation.SpriteReference);
@@ -221,7 +211,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetVerboseComponent(false);
 
             Definition.SetEffectDescription(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct.EffectDescription);
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -229,37 +218,35 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorSpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
-
+        public static readonly SpellDefinition SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorSpellConstruct_UpgradeBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-
     //
     // need a new featuredefintionAutopreparedSpells list with the summon upgrade spell for the two different subclasses
     // as features can be added at any lvl and it's 1st lvl spell
     //
-    internal class SummonProtectorSpellConstruct_UpgradeBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonProtectorSpellConstructUpgradeBuilder : BaseDefinitionBuilder<SpellDefinition>
     {
         private const string Name = "SummonProtectorConstruct_Upgrade";
         private const string Guid = "ccd2a793-e566-4c1e-9588-ac36b578ae89";
 
-        protected SummonProtectorSpellConstruct_UpgradeBuilder(string name, string guid) : base(SummonProtectorSpellConstructBuilder.SummonProtectorConstruct, name, guid)
+        protected SummonProtectorSpellConstructUpgradeBuilder(string name, string guid) : base(SummonProtectorSpellConstructBuilder.SummonProtectorConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle_Upgrade";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription_Upgrade";
 
-            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ProtectorConstruct_UpgradeBuilder.ProtectorConstruct_Upgrade.Name);
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ProtectorConstructUpgradeBuilder.ProtectorConstruct_Upgrade.Name);
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new SummonProtectorSpellConstruct_UpgradeBuilder(name, guid).AddToDB();
+            return new SummonProtectorSpellConstructUpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition SummonProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
     public class ProtectorConstructLevel15AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
@@ -272,21 +259,23 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructLevel15AutopreparedSpellsTitle";
             Definition.GuiPresentation.Description = "Feat/&ProtectorConstructLevel15AutopreparedSpellsDescription";
 
+#pragma warning disable S1481 // Unused local variables should be removed
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 1,
-                SpellsList = (new List<SpellDefinition>
-            {
-                SummonProtectorSpellConstruct_UpgradeBuilder.SummonProtectorConstruct_Upgrade
-            })
+                SpellsList = new List<SpellDefinition>
+                {
+                    SummonProtectorSpellConstructUpgradeBuilder.SummonProtectorConstruct_Upgrade
+                }
             };
+#pragma warning restore S1481 // Unused local variables should be removed
         }
         public static FeatureDefinitionAutoPreparedSpells CreateAndAddToDB(string name, string guid)
         {
             return new ProtectorConstructLevel15AutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel15AutopreparedSpells = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionAutoPreparedSpells Instance = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -300,12 +289,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructUpgradeFeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-            Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
-            Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
+            // unnecessary comment added to prevent false positive by linter
+            Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";// unnecessary comment added to prevent false positive by linter
+            Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";// unnecessary comment added to prevent false positive by linter
+            // unnecessary comment added to prevent false positive by linter
 
-            Definition.FeatureSet.Clear();
-            Definition.FeatureSet.Add(ProtectorConstructLevel15AutopreparedSpellsBuilder.ProtectorConstructLevel15AutopreparedSpells);
-            Definition.FeatureSet.Add(SummonProtectorPowerConstruct_UpgradeBuilder.SummonProtectorPowerConstruct_Upgrade);
+            // unnecessary comment added to prevent false positive by linter
+            Definition.FeatureSet.Clear();// unnecessary comment added to prevent false positive by linter
+            Definition.FeatureSet.Add(ProtectorConstructLevel15AutopreparedSpellsBuilder.Instance);
+            Definition.FeatureSet.Add(SummonProtectorPowerConstructUpgradeBuilder.SummonProtectorPowerConstruct_Upgrade);
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -313,10 +305,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructUpgradeFeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ProtectorConstructUpgradeFeatureSet = CreateAndAddToDB(Name, Guid);
-
+        public static readonly FeatureDefinitionFeatureSet ProtectorConstructUpgradeFeatureSet = CreateAndAddToDB(Name, Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructBuilder		***************************************************************
@@ -329,7 +319,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.ConjuredEightBeast_Wolf, name, guid)
         {
-
             Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.Ghost_Wolf.MonsterPresentation);
 
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructTitle";
@@ -351,7 +340,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(4);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(6);     // CHA
-
 
             //replaced by new bond methods?
             //assume PB=4
@@ -377,8 +365,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SkillScores.Add(Athletics);
             Definition.SkillScores.Add(Perception);
 
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(20);
@@ -397,10 +383,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityFightingStyleProtection);
             Definition.Features.Add(SelfRepairBuilder.SelfRepair);
 
-
-
             Definition.AttackIterations.Clear();
-
 
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
 
@@ -409,8 +392,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Traverse.Create(monsterAttackIteration).Field("number").SetValue(1);
 
             Definition.AttackIterations.AddRange(new List<MonsterAttackIteration> { monsterAttackIteration });
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -418,19 +399,18 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ProtectorConstruct = CreateAndAddToDB(ProtectorConstructName, ProtectorConstructNameGuid);
-
+        public static readonly MonsterDefinition ProtectorConstruct = CreateAndAddToDB(ProtectorConstructName, ProtectorConstructNameGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstruct_UpgradeBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstruct_UpgradeBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ProtectorConstructUpgradeBuilder : BaseDefinitionBuilder<MonsterDefinition>
     {
         private const string Name = "ProtectorConstruct_Upgrade";
         private const string Guid = "c6f711d8-9b83-497f-8e90-6440776cf644";
 
-        protected ProtectorConstruct_UpgradeBuilder(string name, string guid) : base(ProtectorConstructBuilder.ProtectorConstruct, name, guid)
+        protected ProtectorConstructUpgradeBuilder(string name, string guid) : base(ProtectorConstructBuilder.ProtectorConstruct, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructTitle_5";
             Definition.GuiPresentation.Description = "Feat/&ProtectorConstructDescription_5";
@@ -441,13 +421,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
         {
-            return new ProtectorConstruct_UpgradeBuilder(name, guid).AddToDB();
+            return new ProtectorConstructUpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly MonsterDefinition ProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructAttacksBuilder		*******************************************************
@@ -460,7 +438,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Wolf_Bite, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructAttackTitle";
             Definition.GuiPresentation.Description = "Feat/&ProtectorConstructAttackDescription";
 
@@ -497,7 +474,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             //replaced by new bond methods?
             Definition.SetEffectDescription(newEffectDescription);
             Definition.SetToHitBonus(0);
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -505,7 +481,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ProtectorConstructAttack = CreateAndAddToDB(ProtectorConstructAttacksName, ProtectorConstructAttacksGuid);
+        public static readonly MonsterAttackDefinition ProtectorConstructAttack = CreateAndAddToDB(ProtectorConstructAttacksName, ProtectorConstructAttacksGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -519,7 +495,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SelfRepairBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerFighterSecondWind, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SelfRepairTitle";
             Definition.GuiPresentation.Description = "Feat/&SelfRepairDescription";
 
@@ -547,7 +522,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.EffectDescription.EffectForms.Add(effect);
             Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.Self);
             Definition.EffectDescription.RestrictedCreatureFamilies.Add(TinkererConstructFamilyBuilder.TinkererConstructFamily.Name);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -555,7 +529,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfRepairBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SelfRepair = CreateAndAddToDB(SelfRepairName, SelfRepairNameGuid);
+        public static readonly FeatureDefinitionPower SelfRepair = CreateAndAddToDB(SelfRepairName, SelfRepairNameGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -569,7 +543,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected RetributionBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDomainLawHolyRetribution, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&RetributionTitle";
             Definition.GuiPresentation.Description = "Feat/&RetributionDescription";
             Definition.SetShortTitleOverride("Feat/&RetributionTitle");
@@ -589,8 +562,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new RetributionBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower Retribution = CreateAndAddToDB(RetributionName, RetributionNameGuid);
+        public static readonly FeatureDefinitionPower Retribution = CreateAndAddToDB(RetributionName, RetributionNameGuid);
     }
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
@@ -13,48 +13,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public const string Name = "ScoutSentinel";
         public const string Guid = "fb2e5f73-d552-430f-b329-1f0a2ecdf6bd";
 
-        public static FeatureDefinitionPowerSharedPool scoutmodepower;
-        public static FeatureDefinitionPowerSharedPool sentinelmodepower;
-        public static FeatureDefinitionPower ArmorModePool;
+        public static readonly FeatureDefinitionPowerSharedPool ScoutModePower = BuildScoutModePower();
+        public static readonly FeatureDefinitionPowerSharedPool SentinelModePower = BuildSentinelModePower();
+        public static readonly FeatureDefinitionPower ArmorModePool = BuildArmorModePool();
 
-        public static void BuildAndAddSubclass()
+        private static FeatureDefinitionPower BuildArmorModePool()
         {
-
-
-
-            var subclassGuiPresentation = new GuiPresentationBuilder(
-                "Subclass/&ScoutSentinelTinkererSubclassDescription",
-                "Subclass/&ScoutSentinelTinkererSubclassTitle")
-                .SetSpriteReference(DatabaseHelper.CharacterSubclassDefinitions.MartialMountaineer.GuiPresentation.SpriteReference)
-                .Build();
-
-            var definition = new CharacterSubclassDefinitionBuilder(Name, Guid)
-                .SetGuiPresentation(subclassGuiPresentation)
-
-            // level 3
-            .AddFeatureAtLevel(ScoutSentinelFeatureSet_level03Builder.ScoutSentinelFeatureSet_level03, 3)
-            // level 5
-            .AddFeatureAtLevel(ScoutSentinelFeatureSet_level05Builder.ScoutSentinelFeatureSet_level05, 5)
-            // level 10
-            .AddFeatureAtLevel(ScoutSentinelFeatureSet_level09Builder.ScoutSentinelFeatureSet_level09, 9)
-            // level 14
-            .AddFeatureAtLevel(ScoutSentinelFeatureSet_level15Builder.ScoutSentinelFeatureSet_level15, 15)
-           .AddToDB(true);
-
-        }
-    }
-
-    internal class ScoutSentinelFeatureSet_level03Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
-    {
-        private const string ScoutSentinelFeatureSet_level03Name = "ScoutSentinelFeatureSet_level03";
-        private const string ScoutSentinelFeatureSet_level03Guid = "a6560212-c665-49fd-94b7-378512e68edb";
-
-        protected ScoutSentinelFeatureSet_level03Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
-        {
-            Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level03Title";
-            Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level03Description";
-
-
             GuiPresentation guiPresentationArmorMode = new GuiPresentation();
             guiPresentationArmorMode.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
             guiPresentationArmorMode.SetDescription("Feat/&ArmorModePoolDescription");
@@ -62,19 +26,35 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             guiPresentationArmorMode.SetSpriteReference(null);
             guiPresentationArmorMode.SetSymbolChar("221E");
 
-            FeatureDefinitionPower ArmorModePool = new FeatureDefinitionPowerPoolBuilder
-                (
-                    "ArmorModePool",
-                    "fd0567d8-a728-4459-8569-273f3ead3f73",
-                    1,
-                    RuleDefinitions.UsesDetermination.Fixed,
-                    AttributeDefinitions.Intelligence,
-                    RuleDefinitions.RechargeRate.ShortRest,
-                    guiPresentationArmorMode
-                ).AddToDB();
+            return new FeatureDefinitionPowerPoolBuilder
+            (
+                "ArmorModePool",
+                "fd0567d8-a728-4459-8569-273f3ead3f73",
+                1,
+                RuleDefinitions.UsesDetermination.Fixed,
+                AttributeDefinitions.Intelligence,
+                RuleDefinitions.RechargeRate.ShortRest,
+                guiPresentationArmorMode
+            )
+            .AddToDB();
+        }
 
+        private static EffectForm GetEffectItem()
+        {
+            ItemPropertyForm itemPropertyForm = new ItemPropertyForm();
+            itemPropertyForm.FeatureBySlotLevel.Add(new FeatureUnlockByLevel(IntToAttackAndDamageBuilder.IntToAttackAndDamage, 0));
 
+            EffectForm effectItem = new EffectForm
+            {
+                FormType = EffectForm.EffectFormType.ItemProperty
+            };
+            effectItem.SetItemPropertyForm(itemPropertyForm);
 
+            return effectItem;
+        }
+
+        private static FeatureDefinitionPowerSharedPool BuildSentinelModePower()
+        {
             GuiPresentation guiPresentationSentinel = new GuiPresentation();
             guiPresentationSentinel.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
             guiPresentationSentinel.SetDescription("Feature/&SentinelModePowerDescription");
@@ -82,13 +62,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             guiPresentationSentinel.SetSpriteReference(DatabaseHelper.SpellDefinitions.MageArmor.GuiPresentation.SpriteReference);
             guiPresentationSentinel.SetSymbolChar("221E");
 
-            ItemPropertyForm itemPropertyForm = new ItemPropertyForm();
-            itemPropertyForm.FeatureBySlotLevel.Add(new FeatureUnlockByLevel(IntToAttackAndDamageBuilder.IntToAttackAndDamage, 0));
-            EffectForm effectItem = new EffectForm
-            {
-                FormType = EffectForm.EffectFormType.ItemProperty
-            };
-            effectItem.SetItemPropertyForm(itemPropertyForm);
 
             EffectDescription effectsentinelmode = new EffectDescription();
             effectsentinelmode.Copy(DatabaseHelper.SpellDefinitions.ProduceFlameHold.EffectDescription);
@@ -100,12 +73,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectsentinelmode.SetItemSelectionType(ActionDefinitions.ItemSelectionType.Weapon);
             effectsentinelmode.EffectForms[0].SummonForm.SetTrackItem(false);
             effectsentinelmode.EffectForms[0].SummonForm.SetNumber(1);
-            effectsentinelmode.EffectForms.Add(effectItem);
+            effectsentinelmode.EffectForms.Add(GetEffectItem());
 
-
-
-            ScoutSentinelTinkererSubclassBuilder.sentinelmodepower = new FeatureDefinitionPowerSharedPoolBuilder
-                (
+            return new FeatureDefinitionPowerSharedPoolBuilder(
                  "SentinelModePower"                                         // string name
                  , "410768a3-757f-48ee-8a2f-bffd963c0a5b"                    // string guid
                  , ArmorModePool                                             // FeatureDefinitionPower poolPower
@@ -118,9 +88,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , effectsentinelmode                                        // EffectDescription effectDescription
                  , guiPresentationSentinel                                   // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
-                ).AddToDB();
+                )
+                .AddToDB();
+        }
 
-
+        private static FeatureDefinitionPowerSharedPool BuildScoutModePower()
+        {
             GuiPresentation guiPresentationScout = new GuiPresentation();
             guiPresentationScout.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
             guiPresentationScout.SetDescription("Feature/&ScoutModePowerDescription");
@@ -139,9 +112,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectScoutMode.SetItemSelectionType(ActionDefinitions.ItemSelectionType.Weapon);
             effectScoutMode.EffectForms[0].SummonForm.SetTrackItem(false);
             effectScoutMode.EffectForms[0].SummonForm.SetNumber(1);
-            effectScoutMode.EffectForms.Add(effectItem);
+            effectScoutMode.EffectForms.Add(GetEffectItem());
 
-            ScoutSentinelTinkererSubclassBuilder.scoutmodepower = new FeatureDefinitionPowerSharedPoolBuilder
+            return new FeatureDefinitionPowerSharedPoolBuilder
                  (
                   "ScoutModePower"                                            // string name
                   , "ff6b9eb1-01ad-4100-ab12-7d6dc38ccc70"                    // string guid
@@ -155,12 +128,46 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                   , effectScoutMode                                           // EffectDescription effectDescription
                   , guiPresentationScout                                      // GuiPresentation guiPresentation
                   , true                                                      // bool uniqueInstanc
-                 ).AddToDB();
+                 )
+                 .AddToDB();
+        }
+
+        public static void BuildAndAddSubclass()
+        {
+            var subclassGuiPresentation = new GuiPresentationBuilder(
+                "Subclass/&ScoutSentinelTinkererSubclassDescription",
+                "Subclass/&ScoutSentinelTinkererSubclassTitle")
+                .SetSpriteReference(DatabaseHelper.CharacterSubclassDefinitions.MartialMountaineer.GuiPresentation.SpriteReference)
+                .Build();
+
+            new CharacterSubclassDefinitionBuilder(Name, Guid)
+                .SetGuiPresentation(subclassGuiPresentation)
+                // level 3
+                .AddFeatureAtLevel(ScoutSentinelFeatureSetLevel03Builder.ScoutSentinelFeatureSet_level03, 3)
+                // level 5
+                .AddFeatureAtLevel(ScoutSentinelFeatureSetLevel05Builder.ScoutSentinelFeatureSet_level05, 5)
+                // level 10
+                .AddFeatureAtLevel(ScoutSentinelFeatureSetLevel09Builder.ScoutSentinelFeatureSet_level09, 9)
+                // level 14
+                .AddFeatureAtLevel(ScoutSentinelFeatureSetLevel15Builder.ScoutSentinelFeatureSet_level15, 15)
+               .AddToDB(true);
+        }
+    }
+
+    internal class ScoutSentinelFeatureSetLevel03Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    {
+        private const string ScoutSentinelFeatureSet_level03Name = "ScoutSentinelFeatureSet_level03";
+        private const string ScoutSentinelFeatureSet_level03Guid = "a6560212-c665-49fd-94b7-378512e68edb";
+
+        protected ScoutSentinelFeatureSetLevel03Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        {
+            Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level03Title";
+            Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level03Description";
 
             Definition.FeatureSet.Clear();
-            Definition.FeatureSet.Add(ArmorModePool);
-            Definition.FeatureSet.Add(ScoutSentinelTinkererSubclassBuilder.scoutmodepower);
-            Definition.FeatureSet.Add(ScoutSentinelTinkererSubclassBuilder.sentinelmodepower);
+            Definition.FeatureSet.Add(ScoutSentinelTinkererSubclassBuilder.ArmorModePool);
+            Definition.FeatureSet.Add(ScoutSentinelTinkererSubclassBuilder.ScoutModePower);
+            Definition.FeatureSet.Add(ScoutSentinelTinkererSubclassBuilder.SentinelModePower);
             Definition.FeatureSet.Add(SubclassProficienciesBuilder.SubclassProficiencies);
             Definition.FeatureSet.Add(UseArmorWeaponsAsFocusBuilder.UseArmorWeaponsAsFocus);
             Definition.FeatureSet.Add(SubclassMovementAffinitiesBuilder.SubclassMovementAffinities);
@@ -169,46 +176,43 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
         {
-            return new ScoutSentinelFeatureSet_level03Builder(name, guid).AddToDB();
+            return new ScoutSentinelFeatureSetLevel03Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level03 = CreateAndAddToDB(ScoutSentinelFeatureSet_level03Name, ScoutSentinelFeatureSet_level03Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level03 = CreateAndAddToDB(ScoutSentinelFeatureSet_level03Name, ScoutSentinelFeatureSet_level03Guid);
     }
 
-    internal class ScoutSentinelFeatureSet_level05Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSetLevel05Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level05Name = "ScoutSentinelFeatureSet_level05";
         private const string ScoutSentinelFeatureSet_level05Guid = "a881c02a-7add-426b-a2d4-1f3994d12fa9";
 
-        protected ScoutSentinelFeatureSet_level05Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        protected ScoutSentinelFeatureSetLevel05Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level05Title";
             Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level05Description";
 
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(DatabaseHelper.FeatureDefinitionAttributeModifiers.AttributeModifierFighterExtraAttack);
-
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
         {
-            return new ScoutSentinelFeatureSet_level05Builder(name, guid).AddToDB();
+            return new ScoutSentinelFeatureSetLevel05Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level05 = CreateAndAddToDB(ScoutSentinelFeatureSet_level05Name, ScoutSentinelFeatureSet_level05Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level05 = CreateAndAddToDB(ScoutSentinelFeatureSet_level05Name, ScoutSentinelFeatureSet_level05Guid);
     }
 
-    internal class ScoutSentinelFeatureSet_level09Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSetLevel09Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level09Name = "ScoutSentinelFeatureSet_level09";
         private const string ScoutSentinelFeatureSet_level09Guid = "87e8b110-4590-4791-b31c-b8bba5f362b1";
 
-        protected ScoutSentinelFeatureSet_level09Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        protected ScoutSentinelFeatureSetLevel09Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level09Title";
             Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level09Description";
-
 
             GuiPresentation guiPresentation = new GuiPresentation();
             guiPresentation.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
@@ -217,8 +221,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             guiPresentation.SetSpriteReference(null);
             guiPresentation.SetSymbolChar("221E");
             guiPresentation.SetSortOrder(1);
-
-
 
             FeatureDefinitionPowerPoolModifier ExtraInfusionSlots = new FeatureDefinitionPowerPoolModifierBuilder(
                 "ExtraInfusionSlots",
@@ -229,141 +231,44 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 TinkererClass.InfusionPool, guiPresentation
                 ).AddToDB();
 
-
-
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ExtraInfusionSlots);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
         {
-            return new ScoutSentinelFeatureSet_level09Builder(name, guid).AddToDB();
+            return new ScoutSentinelFeatureSetLevel09Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level09 = CreateAndAddToDB(ScoutSentinelFeatureSet_level09Name, ScoutSentinelFeatureSet_level09Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level09 = CreateAndAddToDB(ScoutSentinelFeatureSet_level09Name, ScoutSentinelFeatureSet_level09Guid);
     }
 
-    internal class ScoutSentinelFeatureSet_level15Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSetLevel15Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level15Name = "ScoutSentinelFeatureSet_level15";
         private const string ScoutSentinelFeatureSet_level15Guid = "69a9ba53-4949-47ec-9693-467d053e4646";
 
-        protected ScoutSentinelFeatureSet_level15Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
+        protected ScoutSentinelFeatureSetLevel15Builder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
             Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level15Title";
             Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level15Description";
 
             Definition.FeatureSet.Clear();
-
-            GuiPresentation guiPresentationImprovedSentinel = new GuiPresentation();
-            guiPresentationImprovedSentinel.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
-            guiPresentationImprovedSentinel.SetDescription("Feature/&ImprovedSentinelModePowerDescription");
-            guiPresentationImprovedSentinel.SetTitle("Feature/&ImprovedSentinelModePowerTitle");
-            guiPresentationImprovedSentinel.SetSpriteReference(DatabaseHelper.SpellDefinitions.MageArmor.GuiPresentation.SpriteReference);
-            guiPresentationImprovedSentinel.SetSymbolChar("221E");
-
-            ItemPropertyForm itemPropertyForm = new ItemPropertyForm();
-            itemPropertyForm.FeatureBySlotLevel.Add(new FeatureUnlockByLevel(IntToAttackAndDamageBuilder.IntToAttackAndDamage, 0));
-            EffectForm effectItem = new EffectForm
-            {
-                FormType = EffectForm.EffectFormType.ItemProperty
-            };
-            effectItem.SetItemPropertyForm(itemPropertyForm);
-
-            EffectDescription effectImprovedSentinelmode = new EffectDescription();
-            effectImprovedSentinelmode.Copy(DatabaseHelper.SpellDefinitions.ProduceFlameHold.EffectDescription);
-            effectImprovedSentinelmode.SlotTypes.Clear();
-            effectImprovedSentinelmode.SlotTypes.AddRange("MainHandSlot", "OffHandSlot");
-            effectImprovedSentinelmode.SetDurationType(RuleDefinitions.DurationType.UntilShortRest);
-            effectImprovedSentinelmode.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.Shield.EffectDescription.EffectParticleParameters);
-            effectImprovedSentinelmode.EffectForms[0].SummonForm.SetItemDefinition(ImprovedSentinelSuitWeaponBuilder.ImprovedSentinelSuitWeapon);
-            effectImprovedSentinelmode.SetItemSelectionType(ActionDefinitions.ItemSelectionType.Weapon);
-            effectImprovedSentinelmode.EffectForms[0].SummonForm.SetTrackItem(false);
-            effectImprovedSentinelmode.EffectForms[0].SummonForm.SetNumber(1);
-            effectImprovedSentinelmode.EffectForms.Add(effectItem);
-
-
-
-            FeatureDefinitionPowerSharedPoolBuilder Improvedsentinelmodepowerbuilder = new FeatureDefinitionPowerSharedPoolBuilder
-                (
-                 "ImprovedSentinelModePower"                                         // string name
-                 , "b216988a-5905-47fd-9359-093cd77d41f9"                    // string guid
-                 , ScoutSentinelTinkererSubclassBuilder.ArmorModePool        // FeatureDefinitionPower poolPower
-                 , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
-                 , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
-                 , 1                                                         // int costPerUse
-                 , false                                                     // bool proficiencyBonusToAttack
-                 , false                                                     // bool abilityScoreBonusToAttack
-                 , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
-                 , effectImprovedSentinelmode                                        // EffectDescription effectDescription
-                 , guiPresentationImprovedSentinel                                   // GuiPresentation guiPresentation
-                 , true                                                      // bool uniqueInstanc
-                );
-            FeatureDefinitionPowerSharedPool Improvedsentinelmodepower = Improvedsentinelmodepowerbuilder.AddToDB();
-
-            Improvedsentinelmodepower.SetOverriddenPower(ScoutSentinelTinkererSubclassBuilder.sentinelmodepower);
-
-            GuiPresentation guiPresentationImprovedScout = new GuiPresentation();
-            guiPresentationImprovedScout.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
-            guiPresentationImprovedScout.SetDescription("Feature/&ImprovedScoutModePowerDescription");
-            guiPresentationImprovedScout.SetTitle("Feature/&ImprovedScoutModePowerTitle");
-            guiPresentationImprovedScout.SetSpriteReference(DatabaseHelper.SpellDefinitions.ShadowArmor.GuiPresentation.SpriteReference);
-            guiPresentationImprovedScout.SetSymbolChar("221E");
-            guiPresentationImprovedScout.SetSortOrder(1);
-
-            EffectDescription effectImprovedScoutMode = new EffectDescription();
-            effectImprovedScoutMode.Copy(DatabaseHelper.SpellDefinitions.ProduceFlameHold.EffectDescription);
-            effectImprovedScoutMode.SlotTypes.Clear();
-            effectImprovedScoutMode.SlotTypes.AddRange("MainHandSlot", "OffHandSlot");
-            effectImprovedScoutMode.SetDurationType(RuleDefinitions.DurationType.UntilShortRest);
-            effectImprovedScoutMode.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.Shield.EffectDescription.EffectParticleParameters);
-            effectImprovedScoutMode.EffectForms[0].SummonForm.SetItemDefinition(ImprovedScoutSuitWeaponBuilder.ImprovedScoutSuitWeapon);
-            effectImprovedScoutMode.SetItemSelectionType(ActionDefinitions.ItemSelectionType.Weapon);
-            effectImprovedScoutMode.EffectForms[0].SummonForm.SetTrackItem(false);
-            effectImprovedScoutMode.EffectForms[0].SummonForm.SetNumber(1);
-            effectImprovedScoutMode.EffectForms.Add(effectItem);
-
-            FeatureDefinitionPowerSharedPoolBuilder Improvedscoutmodepowerbuilder = new FeatureDefinitionPowerSharedPoolBuilder
-                 (
-                  "ImprovedScoutModePower"                                            // string name
-                  , "89ec2647-5560-4e82-aa7b-59a8489de492"                    // string guid
-                  , ScoutSentinelTinkererSubclassBuilder.ArmorModePool        // FeatureDefinitionPower poolPower
-                  , RuleDefinitions.RechargeRate.ShortRest                    // RuleDefinitions.RechargeRate recharge
-                  , RuleDefinitions.ActivationTime.NoCost                     // RuleDefinitions.ActivationTime activationTime
-                  , 1                                                         // int costPerUse
-                  , false                                                     // bool proficiencyBonusToAttack
-                  , false                                                     // bool abilityScoreBonusToAttack
-                  , DatabaseHelper.SmartAttributeDefinitions.Intelligence.name// string abilityScore
-                  , effectImprovedScoutMode                                           // EffectDescription effectDescription
-                  , guiPresentationImprovedScout                                      // GuiPresentation guiPresentation
-                  , true                                                      // bool uniqueInstanc
-                 );
-            FeatureDefinitionPowerSharedPool Improvedscoutmodepower = Improvedscoutmodepowerbuilder.AddToDB();
-
-            Improvedscoutmodepower.SetOverriddenPower(ScoutSentinelTinkererSubclassBuilder.scoutmodepower);
-
-            Definition.FeatureSet.Add(Improvedscoutmodepower);
-            Definition.FeatureSet.Add(Improvedsentinelmodepower);
+            Definition.FeatureSet.Add(ImprovedScoutModePowerBuilder.ImprovedScoutModePower);
+            Definition.FeatureSet.Add(ImprovedSentinelModePowerBuilder.ImprovedSentinelModePower);
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
         {
-            return new ScoutSentinelFeatureSet_level15Builder(name, guid).AddToDB();
+            return new ScoutSentinelFeatureSetLevel15Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level15 = CreateAndAddToDB(ScoutSentinelFeatureSet_level15Name, ScoutSentinelFeatureSet_level15Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level15 = CreateAndAddToDB(ScoutSentinelFeatureSet_level15Name, ScoutSentinelFeatureSet_level15Guid);
     }
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SubclassAutopreparedSpellsBuilder		*******************************************************
     //*****************************************************************************************************************************************
-
-
-
 
     public class ScoutSentinelAutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
@@ -372,49 +277,44 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ScoutSentinelAutopreparedSpellsBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAutoPreparedSpellss.AutoPreparedSpellsDomainBattle, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Feat/&AutoPreparedSpellsTitle";
             Definition.GuiPresentation.Description = "Feat/&AutoPreparedSpellsDescription";
-
 
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_3 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 3,
-                SpellsList = (new List<SpellDefinition> {
+                SpellsList = new List<SpellDefinition> {
                 DatabaseHelper.SpellDefinitions.Thunderwave,
                 DatabaseHelper.SpellDefinitions.MagicMissile
-            })
+            }
             };
 
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_5 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 5,
-                SpellsList = (new List<SpellDefinition> {
+                SpellsList = new List<SpellDefinition> {
                 DatabaseHelper.SpellDefinitions.Shatter,
                 DatabaseHelper.SpellDefinitions.Blur
-            })
+            }
             };
-
 
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_9 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 9,
-                SpellsList = (new List<SpellDefinition> {
+                SpellsList = new List<SpellDefinition> {
                 DatabaseHelper.SpellDefinitions.LightningBolt
                 ,DatabaseHelper.SpellDefinitions.HypnoticPattern
-            })
+            }
             };
 
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_13 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 13,
-                SpellsList = (new List<SpellDefinition> {
+                SpellsList = new List<SpellDefinition> {
                 DatabaseHelper.SpellDefinitions.FireShield
                 ,DatabaseHelper.SpellDefinitions.GreaterInvisibility
-            })
+            }
             };
-
 
             //  added extra spells to balance spells withput "implemented"=true flag yet
             //blur for mirror image
@@ -424,12 +324,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_17 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 17,
-                SpellsList = (new List<SpellDefinition> {
+                SpellsList = new List<SpellDefinition> {
                 DatabaseHelper.SpellDefinitions.DimensionDoor
             //    ,DatabaseHelper.SpellDefinitions.WallOfForce
                 ,DatabaseHelper.SpellDefinitions.WallOfFire
                 ,DatabaseHelper.SpellDefinitions.WindWall
-            })
+            }
             };
 
             Definition.AutoPreparedSpellsGroups.Clear();
@@ -441,20 +341,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 autoPreparedSpellsGroup_Level_13,
                 autoPreparedSpellsGroup_Level_17
             });
-
         }
-
-
-
 
         public static FeatureDefinitionAutoPreparedSpells CreateAndAddToDB(string name, string guid)
         {
             return new ScoutSentinelAutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells SubclassAutopreparedSpells = CreateAndAddToDB(SubclassAutopreparedSpellsName, SubclassAutopreparedSpellsGuid);
+        public static readonly FeatureDefinitionAutoPreparedSpells SubclassAutopreparedSpells = CreateAndAddToDB(SubclassAutopreparedSpellsName, SubclassAutopreparedSpellsGuid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SubclassProficienciesBuilder		*******************************************************
@@ -469,8 +364,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             Definition.GuiPresentation.Title = "Feat/&SubclassProficienciesTitle"; //Feature/&NoContentTitle
             Definition.GuiPresentation.Description = "Feat/&SubclassProficienciesDescription";//Feature/&NoContentTitle
+                                                                                              // Definition.Proficiencies.Add(DatabaseHelper.FeatureDefinitionProficiencys.ProficiencySmithTools.Name);
             Definition.Proficiencies.Add(DatabaseHelper.ArmorCategoryDefinitions.HeavyArmorCategory.Name);
-
         }
 
         public static FeatureDefinitionProficiency CreateAndAddToDB(string name, string guid)
@@ -478,7 +373,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SubclassProficienciesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionProficiency SubclassProficiencies = CreateAndAddToDB(SubclassProficienciesName, SubclassProficienciesGuid);
+        public static readonly FeatureDefinitionProficiency SubclassProficiencies = CreateAndAddToDB(SubclassProficienciesName, SubclassProficienciesGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -495,8 +390,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&SubclassMovementTitle";
             Definition.GuiPresentation.Description = "Feat/&SubclassMovementDescription";
             Definition.SetHeavyArmorImmunity(true);
-
-
         }
 
         public static FeatureDefinitionMovementAffinity CreateAndAddToDB(string name, string guid)
@@ -504,11 +397,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SubclassMovementAffinitiesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMovementAffinity SubclassMovementAffinities = CreateAndAddToDB(SubclassMovementAffinitiesName, SubclassMovementAffinitiesGuid);
+        public static readonly FeatureDefinitionMovementAffinity SubclassMovementAffinities = CreateAndAddToDB(SubclassMovementAffinitiesName, SubclassMovementAffinitiesGuid);
     }
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		UseArmorWeaponsAsFocusBuilder		*******************************************************
@@ -521,14 +411,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected UseArmorWeaponsAsFocusBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinitySpellBladeIntoTheFray, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&UseArmorWeaponsAsFocusTitle";
             Definition.GuiPresentation.Description = "Feat/&UseArmorWeaponsAsFocusDescription";
             Definition.SetCanUseProficientWeaponAsFocus(true);
             Definition.SetSomaticWithWeapon(true);
             Definition.SetRangeSpellNoProximityPenalty(false);
-
-
         }
 
         public static FeatureDefinitionMagicAffinity CreateAndAddToDB(string name, string guid)
@@ -536,11 +423,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new UseArmorWeaponsAsFocusBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMagicAffinity UseArmorWeaponsAsFocus = CreateAndAddToDB(UseArmorWeaponsAsFocusName, UseArmorWeaponsAsFocusGuid);
-
+        public static readonly FeatureDefinitionMagicAffinity UseArmorWeaponsAsFocus = CreateAndAddToDB(UseArmorWeaponsAsFocusName, UseArmorWeaponsAsFocusGuid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		IntToAttackAndDamageBuilder		*******************************************************
@@ -553,7 +437,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected IntToAttackAndDamageBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierShillelagh, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&IntToAttackAndDamageTitle";
             Definition.GuiPresentation.Description = "Feat/&IntToAttackAndDamageDescription";
 
@@ -565,8 +448,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             //    assetReference.SetField("m_AssetGUID", "ad68a1be3193a314c911afd02ca8d360");
             //    Definition.SetImpactParticleReference(assetReference);
 
-
-
         }
 
         public static FeatureDefinitionAttackModifier CreateAndAddToDB(string name, string guid)
@@ -574,10 +455,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new IntToAttackAndDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAttackModifier IntToAttackAndDamage = CreateAndAddToDB(IntToAttackAndDamageName, IntToAttackAndDamageGuid);
+        public static readonly FeatureDefinitionAttackModifier IntToAttackAndDamage = CreateAndAddToDB(IntToAttackAndDamageName, IntToAttackAndDamageGuid);
     }
-
-
 
     //*************************************************************************************************************************
     //***********************************		Sentinel Suit Weapon           		*******************************************
@@ -590,17 +469,13 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SentinelSuitWeaponBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.UnarmedStrikeBase, name, guid)
         {
-
-
             // can only take 3 ( at game launch in may, havent checked since)
             Definition.IsFocusItem = true;
             Definition.IsUsableDevice = true;
             Definition.IsWeapon = true;
             //         Definition.IsFood = true;
 
-
             Definition.SetInDungeonEditor(true);
-
 
             EffectForm damageEffect = new EffectForm
             {
@@ -630,10 +505,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             balancingeffect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             balancingeffect.ConditionForm.ConditionDefinition = ThunderStruckBalancingAdvantageConditionBuilder.ThunderStruckBalancingAdvantage;
 
-
-
-
-
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
             newEffectDescription.Copy(Definition.WeaponDescription.EffectDescription);
@@ -651,7 +522,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             newEffectDescription.SetCanBePlacedOnCharacter(true);
             newEffectDescription.SetRangeType(RuleDefinitions.RangeType.MeleeHit);
 
-
             newEffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.Shatter.EffectDescription.EffectParticleParameters);
 
             WeaponDescription ThunderPunch = new WeaponDescription();
@@ -663,13 +533,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ThunderPunch.SetEffectDescription(newEffectDescription);
             ThunderPunch.WeaponTags.Add("ScoutSentinelWeapon");
 
-
-
-            ItemPropertyDescription UsingBonusActionItemPower = new ItemPropertyDescription(DatabaseHelper.ItemDefinitions.BeltOfDwarvenKind.StaticProperties[6]); ;
+            ItemPropertyDescription UsingBonusActionItemPower = new ItemPropertyDescription(DatabaseHelper.ItemDefinitions.BeltOfDwarvenKind.StaticProperties[6]);
             UsingBonusActionItemPower.SetFeatureDefinition(UsingitemPowerBuilder.UsingitemPower);
             UsingBonusActionItemPower.SetType(ItemPropertyDescription.PropertyType.Feature);
             UsingBonusActionItemPower.SetKnowledgeAffinity(EquipmentDefinitions.KnowledgeAffinity.InactiveAndHidden);
-
 
             DeviceFunctionDescription deviceFunctionDescription = new DeviceFunctionDescription(DatabaseHelper.ItemDefinitions.PotionOfComprehendLanguages.UsableDeviceDescription.DeviceFunctions[0]);
             deviceFunctionDescription.SetCanOverchargeSpell(false);
@@ -689,10 +556,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             usableDeviceDescription.SetRechargeDie(RuleDefinitions.DieType.D1);
             usableDeviceDescription.SetRechargeBonus(5);
             usableDeviceDescription.SetOutOfChargesConsequence(EquipmentDefinitions.ItemOutOfCharges.Persist);
-            usableDeviceDescription.SetMagicAttackBonus(11);
-            usableDeviceDescription.SetSaveDC(19);
+            usableDeviceDescription.SetMagicAttackBonus(5);
+            usableDeviceDescription.SetSaveDC(13);
             usableDeviceDescription.DeviceFunctions.Add(deviceFunctionDescription);
-
 
             Definition.SlotTypes.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
             Definition.SlotsWhereActive.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
@@ -723,9 +589,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Equipment/&ThunderPunchTitle";
             Definition.GuiPresentation.Description = "Equipment/&ThunderPunchDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower.GuiPresentation.SpriteReference);
-
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -733,10 +596,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SentinelSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
+        public static readonly ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
     }
-
-
 
     internal class ThunderShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -748,7 +609,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&ThunderShieldTitle";
             Definition.GuiPresentation.Description = "Feat/&ThunderShieldDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Shield.GuiPresentation.SpriteReference);
-
 
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.LongRest);
             Definition.SetCostPerUse(1);
@@ -773,7 +633,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             healingEffect.SetLevelType(RuleDefinitions.LevelSourceType.CharacterLevel);
             healingEffect.SetLevelMultiplier(1);
 
-
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
             newEffectDescription.Copy(Definition.EffectDescription);
@@ -797,9 +656,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
+        public static readonly FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
     }
-
 
     internal class ThunderStruckConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
     {
@@ -826,8 +684,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             assetReference.SetField("m_AssetGUID", "3e25fca5d3585174f9b7e20aca6ef3d9");
             Definition.SetConditionStartParticleReference(assetReference);
             Definition.SetConditionParticleReference(assetReference);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -835,7 +691,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ThunderStruck = CreateAndAddToDB(ThunderStruckName, ThunderStruckGuid);
+        public static readonly ConditionDefinition ThunderStruck = CreateAndAddToDB(ThunderStruckName, ThunderStruckGuid);
     }
 
     internal class ThunderStruckDisadvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
@@ -845,9 +701,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ThunderStruckDisadvantageCombatAffintityBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionCombatAffinitys.CombatAffinityPoisoned, name, guid)
         {
-
             Definition.SetMyAttackAdvantage(RuleDefinitions.AdvantageType.Disadvantage);
-
         }
 
         public static FeatureDefinitionCombatAffinity CreateAndAddToDB(string name, string guid)
@@ -855,7 +709,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckDisadvantageCombatAffintityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionCombatAffinity Disadvantage = CreateAndAddToDB(ThunderStruckDisadvantageName, ThunderStruckDisadvantageGuid);
+        public static readonly FeatureDefinitionCombatAffinity Disadvantage = CreateAndAddToDB(ThunderStruckDisadvantageName, ThunderStruckDisadvantageGuid);
     }
     internal class ThunderStruckBalancingAdvantageConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
     {
@@ -876,7 +730,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
 
             Definition.Features.Add(BalancingAdvantageCombatAffintityBuilder.BalancingAdvantage);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -884,7 +737,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckBalancingAdvantageConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ThunderStruckBalancingAdvantage = CreateAndAddToDB(ThunderStruckBalancingAdvantageName, ThunderStruckBalancingAdvantageGuid);
+        public static readonly ConditionDefinition ThunderStruckBalancingAdvantage = CreateAndAddToDB(ThunderStruckBalancingAdvantageName, ThunderStruckBalancingAdvantageGuid);
     }
 
     internal class BalancingAdvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
@@ -894,7 +747,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected BalancingAdvantageCombatAffintityBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionCombatAffinitys.CombatAffinityCursedByBestowCurseOnAttackRoll, name, guid)
         {
-
             Definition.SetMyAttackAdvantage(RuleDefinitions.AdvantageType.Advantage);
             Definition.SetSituationalContext(RuleDefinitions.SituationalContext.TargetIsEffectSource);
         }
@@ -904,7 +756,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new BalancingAdvantageCombatAffintityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionCombatAffinity BalancingAdvantage = CreateAndAddToDB(BalancingAdvantageName, BalancingAdvantageGuid);
+        public static readonly FeatureDefinitionCombatAffinity BalancingAdvantage = CreateAndAddToDB(BalancingAdvantageName, BalancingAdvantageGuid);
     }
     internal class UsingitemPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
     {
@@ -913,13 +765,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected UsingitemPowerBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityThiefFastHands, name, guid)
         {
-
             Definition.AuthorizedActions.Clear();
             Definition.AuthorizedActions.Add(ActionDefinitions.Id.UseItemBonus);
 
             Definition.GuiPresentation.Title = "Feat/&UsingitemPowerTitle";
             Definition.GuiPresentation.Description = "Feat/&UsingitemPowerDescription";
-
         }
 
         public static FeatureDefinitionActionAffinity CreateAndAddToDB(string name, string guid)
@@ -927,18 +777,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new UsingitemPowerBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionActionAffinity UsingitemPower = CreateAndAddToDB(UsingitemPowerName, UsingitemPowerGuid);
+        public static readonly FeatureDefinitionActionAffinity UsingitemPower = CreateAndAddToDB(UsingitemPowerName, UsingitemPowerGuid);
     }
-
-
-
-
-
 
     //**************************************************************************************************************************************
     //************************************************      Scout Suit Weapon        *******************************************************
     //**************************************************************************************************************************************
-
 
     internal class ScoutSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
@@ -947,7 +791,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ScoutSuitWeaponBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.Dart, name, guid)
         {
-
             // can only take 3    (at game launch in may, havent checked since)
             Definition.IsFocusItem = true;
             Definition.IsWeapon = true;
@@ -1009,7 +852,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             LightningCloakMovement.SetType(ItemPropertyDescription.PropertyType.Feature);
             LightningCloakMovement.SetKnowledgeAffinity(EquipmentDefinitions.KnowledgeAffinity.InactiveAndHidden);
 
-
             Definition.SlotTypes.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
             Definition.SlotsWhereActive.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
 
@@ -1041,9 +883,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring.GuiPresentation.SpriteReference);
 
             Definition.SetItemPresentation(DatabaseHelper.ItemDefinitions.UnarmedStrikeBase.ItemPresentation);
-
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -1051,9 +890,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
+        public static readonly ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
     }
-
 
     internal class LightningSpearAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
     {
@@ -1078,7 +916,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningSpearAdditionalDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAdditionalDamage LightningSpearAdditionalDamage = CreateAndAddToDB(LightningSpearAdditionalDamageName, LightningSpearAdditionalDamageGuid);
+        public static readonly FeatureDefinitionAdditionalDamage LightningSpearAdditionalDamage = CreateAndAddToDB(LightningSpearAdditionalDamageName, LightningSpearAdditionalDamageGuid);
     }
     internal class LightningCloakMovementAffinitiesBuilder : BaseDefinitionBuilder<FeatureDefinitionMovementAffinity>
     {
@@ -1095,7 +933,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningCloakMovementAffinitiesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMovementAffinity LightningCloakMovementAffinities = CreateAndAddToDB(LightningCloakMovementAffinitiesName, LightningCloakMovementAffinitiesGuid);
+        public static readonly FeatureDefinitionMovementAffinity LightningCloakMovementAffinities = CreateAndAddToDB(LightningCloakMovementAffinitiesName, LightningCloakMovementAffinitiesGuid);
     }
     internal class LightningCloakAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
     {
@@ -1118,12 +956,34 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningCloakAbilityCheckAffinityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAbilityCheckAffinity LightningCloakAbilityCheckAffinity = CreateAndAddToDB(LightningCloakAbilityCheckAffinityName, LightningCloakAbilityCheckAffinityGuid);
+        public static readonly FeatureDefinitionAbilityCheckAffinity LightningCloakAbilityCheckAffinity = CreateAndAddToDB(LightningCloakAbilityCheckAffinityName, LightningCloakAbilityCheckAffinityGuid);
     }
 
     //*************************************************************************************************************************
     //***********************************		Improved Sentinel Suit Weapon   		****************************************
     //*************************************************************************************************************************
+
+    internal class ImprovedSentinelModePowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPowerSharedPool>
+    {
+        private const string ImprovedSentinelModePowerName = "ImprovedSentinelModePower";
+        private const string ImprovedSentinelModePowerGuid = "b216988a-5905-47fd-9359-093cd77d41f9";
+
+        protected ImprovedSentinelModePowerBuilder(string name, string guid) : base(ScoutSentinelTinkererSubclassBuilder.SentinelModePower, name, guid)
+        {
+            //Definition.EffectDescription.EffectParticleParameters.Clear();
+            Definition.GuiPresentation.Title = "Feature/&ImprovedSentinelModePowerTitle";
+            Definition.GuiPresentation.Description = "Feature/&ImprovedSentinelModePowerDescription";
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetItemDefinition(ImprovedSentinelSuitWeaponBuilder.ImprovedSentinelSuitWeapon);
+            Definition.SetOverriddenPower(ScoutSentinelTinkererSubclassBuilder.SentinelModePower);
+        }
+
+        public static FeatureDefinitionPowerSharedPool CreateAndAddToDB(string name, string guid)
+        {
+            return new ImprovedSentinelModePowerBuilder(name, guid).AddToDB();
+        }
+
+        public static readonly FeatureDefinitionPowerSharedPool ImprovedSentinelModePower = CreateAndAddToDB(ImprovedSentinelModePowerName, ImprovedSentinelModePowerGuid);
+    }
     internal class ImprovedSentinelSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
         private const string ImprovedSentinelSuitWeaponName = "ImprovedSentinelSuitWeapon";
@@ -1131,7 +991,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ImprovedSentinelSuitWeaponBuilder(string name, string guid) : base(SentinelSuitWeaponBuilder.SentinelSuitWeapon, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Equipment/&ImprovedThunderPunchTitle";
             Definition.GuiPresentation.Description = "Equipment/&ImprovedThunderPunchDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower.GuiPresentation.SpriteReference);
@@ -1148,8 +1007,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.UsableDeviceDescription.DeviceFunctions.Add(grapplefunction);
             Definition.UsableDeviceDescription.SetChargesCapitalNumber(10);
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -1157,9 +1014,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ImprovedSentinelSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
+        public static readonly ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
     }
-
 
     internal class GauntletsGrappleBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -1172,14 +1028,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Description = "Feat/&GauntletsGrappleDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerShadowTamerRopeGrapple.GuiPresentation.SpriteReference);
 
-
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.LongRest);
             Definition.SetCostPerUse(1);
             Definition.SetFixedUsesPerRecharge(6);
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.BonusAction);
             Definition.SetShortTitleOverride("Feat/&GauntletsGrappleTitle");
             Definition.SetReactionContext(RuleDefinitions.ReactionTriggerContext.HitByMelee);
-
 
             EffectForm motionEffect = new EffectForm
             {
@@ -1216,7 +1070,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             newEffectDescription.HasSavingThrow = true;
             newEffectDescription.SavingThrowAbility = DatabaseHelper.SmartAttributeDefinitions.Strength.Name;
             newEffectDescription.SetSavingThrowDifficultyAbility(DatabaseHelper.SmartAttributeDefinitions.Intelligence.Name);
-            newEffectDescription.SetDifficultyClassComputation(RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature);
+            newEffectDescription.SetDifficultyClassComputation(RuleDefinitions.EffectDifficultyClassComputation.FixedValue);
             newEffectDescription.FixedSavingThrowDifficultyClass = 19;
             newEffectDescription.SetCreatedByCharacter(true);
 
@@ -1238,12 +1092,37 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new GauntletsGrappleBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower GauntletsGrapple = CreateAndAddToDB(GauntletsGrappleName, GauntletsGrappleGuid);
+        public static readonly FeatureDefinitionPower GauntletsGrapple = CreateAndAddToDB(GauntletsGrappleName, GauntletsGrappleGuid);
     }
 
     //**************************************************************************************************************************************
     //******************************************       Improved Scout Suit Weapon        ***************************************************
     //**************************************************************************************************************************************
+
+    internal class ImprovedScoutModePowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPowerSharedPool>
+    {
+        private const string ImprovedScoutModePowerName = "ImprovedScoutModePower";
+        private const string ImprovedScoutModePowerGuid = "89ec2647-5560-4e82-aa7b-59a8489de492";
+
+        protected ImprovedScoutModePowerBuilder(string name, string guid) : base(ScoutSentinelTinkererSubclassBuilder.ScoutModePower, name, guid)
+        {
+            Definition.EffectDescription.EffectParticleParameters.Clear();
+            Definition.GuiPresentation.Title = "Feature/&ImprovedScoutModePowerTitle";
+            Definition.GuiPresentation.Description = "Feature/&ImprovedScoutModePowerDescription";
+            Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ShadowArmor.GuiPresentation.SpriteReference);
+
+            Definition.SetOverriddenPower(ScoutSentinelTinkererSubclassBuilder.ScoutModePower);
+            Definition.EffectDescription.EffectForms[0].SummonForm.SetItemDefinition(ImprovedScoutSuitWeaponBuilder.ImprovedScoutSuitWeapon);
+        }
+
+        public static FeatureDefinitionPowerSharedPool CreateAndAddToDB(string name, string guid)
+        {
+            return new ImprovedScoutModePowerBuilder(name, guid).AddToDB();
+        }
+
+        public static readonly FeatureDefinitionPowerSharedPool ImprovedScoutModePower = CreateAndAddToDB(ImprovedScoutModePowerName, ImprovedScoutModePowerGuid);
+    }
+
     internal class ImprovedScoutSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
         private const string ImprovedScoutSuitWeaponName = "ImprovedScoutSuitWeapon";
@@ -1251,17 +1130,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ImprovedScoutSuitWeaponBuilder(string name, string guid) : base(ScoutSuitWeaponBuilder.ScoutSuitWeapon, name, guid)
         {
-
-
-
             Definition.GuiPresentation.Title = "Equipment/&ImprovedLightningSpearTitle";
             Definition.GuiPresentation.Description = "Equipment/&ImprovedLightningSpearDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring.GuiPresentation.SpriteReference);
 
-
             Definition.SetInDungeonEditor(true);
-
-
 
             //next attack advantage // condition true strike or guiding bolt
             EffectForm NextAttackAdvantage = new EffectForm
@@ -1272,7 +1145,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             NextAttackAdvantage.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             NextAttackAdvantage.ConditionForm.ConditionDefinition = AdvantageAttackOnEnemyBuilder.AdvantageAttackOnEnemy;
 
-
             // combat affinity cursed on attack roll
             EffectForm EnemyAttackDisadvantageEffect = new EffectForm
             {
@@ -1281,7 +1153,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             };
             EnemyAttackDisadvantageEffect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             EnemyAttackDisadvantageEffect.ConditionForm.ConditionDefinition = DisadvantageOnAttackByEnemyBuilder.DisadvantageOnAttackByEnemy;
-
 
             //extra damage on attack
             EffectForm ExtraAttackEffect = new EffectForm
@@ -1296,7 +1167,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             LightSourceForm lightSourceForm = new LightSourceForm();
             lightSourceForm.Copy(DatabaseHelper.SpellDefinitions.Shine.EffectDescription.EffectForms[0].LightSourceForm);
 
-
             EffectForm MagicalLightSourceEffect = new EffectForm();
             MagicalLightSourceEffect.SetLevelMultiplier(1);
             MagicalLightSourceEffect.SetLevelType(RuleDefinitions.LevelSourceType.CharacterLevel);
@@ -1305,13 +1175,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             MagicalLightSourceEffect.FormType = EffectForm.EffectFormType.LightSource;
             MagicalLightSourceEffect.SetLightSourceForm(lightSourceForm);
 
-
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(EnemyAttackDisadvantageEffect);
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(ExtraAttackEffect);
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(NextAttackAdvantage);
             // game hangs when light effect is added, dont know why
             //Definition.WeaponDescription.EffectDescription.EffectForms.Add(MagicalLightSourceEffect);
-
 
         }
 
@@ -1320,7 +1188,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ImprovedScoutSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ImprovedScoutSuitWeapon = CreateAndAddToDB(ImprovedScoutSuitWeaponName, ImprovedScoutSuitWeaponGuid);
+        public static readonly ItemDefinition ImprovedScoutSuitWeapon = CreateAndAddToDB(ImprovedScoutSuitWeaponName, ImprovedScoutSuitWeaponGuid);
     }
 
     internal class DisadvantageOnAttackByEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1333,7 +1201,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // Jolted - enemey has disadvantage on scout sentinel after weapon hits
             Definition.GuiPresentation.Title = "Rules/&DisadvantageOnAttackByEnemyTitle";
             Definition.GuiPresentation.Description = "Rules/&DisadvantageOnAttackByEnemyDescription";
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -1341,7 +1208,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new DisadvantageOnAttackByEnemyBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition DisadvantageOnAttackByEnemy = CreateAndAddToDB(DisadvantageOnAttackByEnemyName, DisadvantageOnAttackByEnemyGuid);
+        public static readonly ConditionDefinition DisadvantageOnAttackByEnemy = CreateAndAddToDB(DisadvantageOnAttackByEnemyName, DisadvantageOnAttackByEnemyGuid);
     }
 
     internal class AdvantageAttackOnEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1361,7 +1228,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new AdvantageAttackOnEnemyBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition AdvantageAttackOnEnemy = CreateAndAddToDB(AdvantageAttackOnEnemyName, AdvantageAttackOnEnemyGuid);
+        public static readonly ConditionDefinition AdvantageAttackOnEnemy = CreateAndAddToDB(AdvantageAttackOnEnemyName, AdvantageAttackOnEnemyGuid);
     }
 
     internal class ExtraDamageOnAttackConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1382,15 +1249,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
             Definition.HasSpecialInterruptionOfType(RuleDefinitions.ConditionInterruption.Damaged);
 
-
-
             Definition.SetAdditionalDamageWhenHit(true);
             Definition.SetAdditionalDamageDieNumber(1);
             Definition.SetAdditionalDamageDieType(RuleDefinitions.DieType.D6);
             Definition.SetAdditionalDamageType(RuleDefinitions.DamageTypeLightning);
             Definition.SetAdditionalDamageQuantity(ConditionDefinition.DamageQuantity.Dice);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -1398,7 +1261,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ExtraDamageOnAttackConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ExtraDamageOnAttackCondition = CreateAndAddToDB(ExtraDamageOnAttackConditionName, ExtraDamageOnAttackConditionGuid);
+        public static readonly ConditionDefinition ExtraDamageOnAttackCondition = CreateAndAddToDB(ExtraDamageOnAttackConditionName, ExtraDamageOnAttackConditionGuid);
     }
-
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
@@ -10,7 +10,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     internal static class TinkererClass
     {
-        public static Guid GuidNamespace = new Guid("7aee1270-7a61-48d9-8670-cf087c551c16");
+        public static readonly Guid GuidNamespace = new Guid("7aee1270-7a61-48d9-8670-cf087c551c16");
 
         public static readonly FeatureDefinitionPower InfusionPool = new FeatureDefinitionPowerPoolBuilder("AttributeModiferArtificerInfusionHealingPool",
             GuidHelper.Create(GuidNamespace, "AttributeModiferArtificerInfusionHealingPool").ToString(),
@@ -155,7 +155,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             };
             ArtificerBuilder.AddEquipmentRow(providedGear);
 
-
             //public List<FeatureUnlockByLevel> FeatureUnlocks { get; }
             FeatureDefinitionProficiency armorProf = FeatureHelpers.BuildProficiency(RuleDefinitions.ProficiencyType.Armor,
                 new List<string>() { EquipmentDefinitions.LightArmorCategory, EquipmentDefinitions.MediumArmorCategory, EquipmentDefinitions.ShieldCategory },
@@ -247,7 +246,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             ArtificerBuilder.AddFeatureAtLevel(InfusionPool, 2);
 
-
             // Infusions -- Focus, Weapon, Mind Sharpener, Armor of Magical Strength are given in subclasses
             // Defense
             GuiPresentationBuilder infusionChoiceGui = new GuiPresentationBuilder(
@@ -265,9 +263,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // Repeating Shot-- no point it seems
             // Returning Weapon-- not currently do-able
 
-
             // right tool for the job (level 3) (can I just give enchanting tool at level 3?)-- tools are available in the store, just skipping for now
-
 
             // Subclasses
             FeatureDefinitionSubclassChoice subclasses = ArtificerBuilder.BuildSubclassChoice(3, "Specialist", false, "SubclassChoiceArtificerSpecialistArchetypes",
@@ -432,7 +428,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ArtificerBuilder.AddFeatureAtLevel(level14Infusions, 18);
 
             ArtificerBuilder.AddFeatureAtLevel(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, 19);
-
 
             GuiPresentationBuilder SoulOfArtificeGui = new GuiPresentationBuilder(
                 "Subclass/&PowerTinkererSoulOfArtificeSavesDescription",

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class TinkererSpellList : BaseDefinitionBuilder<SpellListDefinition>
+    internal sealed class TinkererSpellList : BaseDefinitionBuilder<SpellListDefinition>
     {
         private TinkererSpellList(string name, string guid, GuiPresentation guiPresentation) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Classes/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch.cs
@@ -435,7 +435,7 @@ namespace SolastaCommunityExpansion.Classes
 
             classSpellCast.SetSlotsPerLevel(witchCastingSlots);
             classSpellCast.SetSlotsRecharge(RuleDefinitions.RechargeRate.LongRest);
-            classSpellCast.SetSpellCastingOrigin(FeatureDefinitionCastSpell.CastingOrigin.Class);
+            classSpellCast.SetSpellCastingOrigin(CastingOrigin.Class);
             classSpellCast.SetSpellCastingAbility(AttributeDefinitions.Charisma);
             classSpellCast.SetSpellCastingLevel(9);
             classSpellCast.SetSpellKnowledge(RuleDefinitions.SpellKnowledge.Selection);
@@ -451,7 +451,6 @@ namespace SolastaCommunityExpansion.Classes
 
         private static void BuildRitualCasting()
         {
-
             FeatureDefinitionFeatureSetRitualCasting = new FeatureDefinitionFeatureSetBuilder(
                     DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetWizardRitualCasting,
                     "WitchFeatureSetRitualCasting",
@@ -469,12 +468,10 @@ namespace SolastaCommunityExpansion.Classes
                             .SetRitualCasting((RuleDefinitions.RitualCasting)ExtraRitualCasting.Known).AddToDB())
                     .AddFeature(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityWizardRitualCasting)
                     .AddToDB();
-
         }
 
         private static void BuildWitchCurses()
         {
-
             // Legend: 
             // +: implemented 
             // -: will not implement
@@ -578,12 +575,10 @@ namespace SolastaCommunityExpansion.Classes
                     .AddFeature(lovelessCurse)
                     .AddFeature(visionsCurse)
                     .AddToDB();
-
         }
 
         private static void BuildMaledictions()
         {
-
             // Maledictions are actions unless mentioned otherwise
             // If a Malediction calls for an attack roll or saving throw, it uses your spell attack bonus or spell save DC, unless mentioned otherwise. 
             // All Maledictions require verbal or somatic components
@@ -662,7 +657,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var apathyEffectDescription = new EffectDescription();
             apathyEffectDescription.Copy(DatabaseHelper.SpellDefinitions.CalmEmotionsOnEnemy.EffectDescription);
             apathyEffectDescription.SetDurationParameter(1);
@@ -692,7 +686,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.CalmEmotions.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             var charmEffectDescription = new EffectDescription();
             charmEffectDescription.Copy(DatabaseHelper.SpellDefinitions.CharmPerson.EffectDescription);
@@ -725,7 +718,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var evileyeEffectDescription = new EffectDescription();
             evileyeEffectDescription.Copy(DatabaseHelper.SpellDefinitions.Fear.EffectDescription);
             evileyeEffectDescription.SetDurationParameter(1);
@@ -757,7 +749,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var obfuscateEffectDescription = new EffectDescription();
             obfuscateEffectDescription.Copy(DatabaseHelper.SpellDefinitions.FogCloud.EffectDescription);
             obfuscateEffectDescription.SetCanBePlacedOnCharacter(true);
@@ -785,7 +776,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.FogCloud.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             EffectForm poxEffectForm = new EffectForm
             {
@@ -827,7 +817,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.PoisonSpray.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             EffectForm ruinEffectForm = new EffectForm
             {
@@ -902,7 +891,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             FeatureDefinitionFeatureSetMaledictions = new FeatureDefinitionFeatureSetBuilder(
                     DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetWizardRitualCasting,
                     "WitchFeatureSetMaledictions",
@@ -921,12 +909,10 @@ namespace SolastaCommunityExpansion.Classes
                     .AddFeature(pox)
                     .AddFeature(ruin)
                     .AddToDB();
-
         }
 
         private static void BuildCackle()
         {
-
             // At 2nd level, you can use your bonus action to cackle. 
             // The duration of your Malediction extends by 1 round for each creature affected within 60 feet of you. 
             // Not all witches laugh maniacally when they cackle, but all cackles require a verbal component, as a spell. 
@@ -979,7 +965,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.HideousLaughter.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
         }
 
         private static CharacterClassDefinition BuildAndAddClass()
@@ -1224,7 +1209,6 @@ namespace SolastaCommunityExpansion.Classes
                 //            subClassChoices.Subclasses.Add(new PurpleWitch().GetSubclass(classDef).name);
                 subClassChoices.Subclasses.Add(new RedWitch().GetSubclass(witch).name);
                 subClassChoices.Subclasses.Add(new WhiteWitch().GetSubclass(witch).name);
-
             }
 
             void BuildProgression()

--- a/SolastaCommunityExpansion/Feats/ArmorFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ArmorFeats.cs
@@ -18,7 +18,7 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&ProfLightArmorTitle");
             FeatureDefinition lightProf = BuildProficiency(RuleDefinitions.ProficiencyType.Armor, new List<string>()
             {
-                EquipmentDefinitions.LightArmorCategory.ToString()
+                EquipmentDefinitions.LightArmorCategory
             }, "FeatLightArmorProficiency", lightProfPresentation.Build()
             );
             GuiPresentationBuilder dexPresentation = new GuiPresentationBuilder(
@@ -44,8 +44,8 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&ProfMediumArmorTitle");
             FeatureDefinition mediumProf = BuildProficiency(RuleDefinitions.ProficiencyType.Armor, new List<string>()
             {
-                EquipmentDefinitions.MediumArmorCategory.ToString(),
-                EquipmentDefinitions.ShieldCategory.ToString(),
+                EquipmentDefinitions.MediumArmorCategory,
+                EquipmentDefinitions.ShieldCategory,
             }, "FeatMediumArmorProficiency", mediumProfPresentation.Build()
             );
 

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -214,9 +214,9 @@ namespace SolastaCommunityExpansion.Feats
             {
                 return false;
             }
-            RulesetItem off_item = hero.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeOffHand].EquipedItem;
 
-            return (off_item != null && off_item.ItemDefinition != null && off_item.ItemDefinition.IsLightSourceItem);
+            RulesetItem off_item = hero.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeOffHand].EquipedItem;
+            return off_item?.ItemDefinition?.IsLightSourceItem ?? false;
         }
     }
 }

--- a/SolastaCommunityExpansion/Feats/OtherFeats.cs
+++ b/SolastaCommunityExpansion/Feats/OtherFeats.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&FeatSavageAttackerDescription",
                 "Feat/&FeatSavageAttackerTitle");
 
-            string rerollKey = "Feat/&FeatSavageAttackerReroll";
+            const string rerollKey = "Feat/&FeatSavageAttackerReroll";
             FeatureDefinitionDieRollModifier savageAttackDieRoll = BuildDieRollModifier(RuleDefinitions.RollContext.AttackDamageValueRoll,
                 1 /* reroll count */, 1 /* reroll min value */, rerollKey, "DieRollModifierFeatSavageAttacker",
                 savageAttackerPresentation.Build());

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionActionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionActionAffinityBuilder.cs
@@ -7,6 +7,5 @@ namespace SolastaCommunityExpansion.Features
         public FeatureDefinitionActionAffinityBuilder(FeatureDefinitionActionAffinity toCopy, string name, string guid) : base(toCopy, name, guid)
         {
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionAttributeModifierBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionAttributeModifierBuilder.cs
@@ -19,5 +19,4 @@ namespace SolastaCommunityExpansion.Features
             return this;
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionBonusCantripsBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionBonusCantripsBuilder.cs
@@ -19,11 +19,8 @@ namespace SolastaCommunityExpansion.Features
 
         public FeatureDefinitionBonusCantripsBuilder AddBonusCantrip(SpellDefinition spellDefinition)
         {
-
             Definition.BonusCantrips.Add(spellDefinition);
             return this;
         }
-
     }
-
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionConditionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionConditionAffinityBuilder.cs
@@ -10,6 +10,5 @@ namespace SolastaCommunityExpansion.Features
         {
             Definition.SetGuiPresentation(guiPresentation);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionDamageAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionDamageAffinityBuilder.cs
@@ -10,6 +10,5 @@ namespace SolastaCommunityExpansion.Features
         {
             Definition.SetGuiPresentation(guiPresentation);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionFeatureSetBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionFeatureSetBuilder.cs
@@ -5,7 +5,6 @@ namespace SolastaCommunityExpansion.Features
 {
     public class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
-
         public FeatureDefinitionFeatureSetBuilder(FeatureDefinitionFeatureSet toCopy, string name, string guid,
            GuiPresentation guiPresentation) : base(toCopy, name, guid)
         {
@@ -20,24 +19,20 @@ namespace SolastaCommunityExpansion.Features
 
         public FeatureDefinitionFeatureSetBuilder AddFeature(FeatureDefinition featureDefinition)
         {
-
             Definition.FeatureSet.Add(featureDefinition);
             return this;
         }
 
         public FeatureDefinitionFeatureSetBuilder SetMode(FeatureDefinitionFeatureSet.FeatureSetMode mode)
         {
-
             Definition.SetMode(mode);
             return this;
         }
 
         public FeatureDefinitionFeatureSetBuilder SetUniqueChoices(bool uniqueChoice)
         {
-
             Definition.SetUniqueChoices(uniqueChoice);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
@@ -77,6 +77,5 @@ namespace SolastaCommunityExpansion.Features
             Definition.SetRitualCasting(ritualCasting);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionSummoningAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionSummoningAffinityBuilder.cs
@@ -7,6 +7,5 @@ namespace SolastaCommunityExpansion.Features
         public FeatureDefinitionSummoningAffinityBuilder(FeatureDefinitionSummoningAffinity toCopy, string name, string guid) : base(toCopy, name, guid)
         {
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/ItemBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ItemBuilder.cs
@@ -103,7 +103,6 @@ namespace SolastaCommunityExpansion.Features
 
         public static ItemDefinition BuildNewMagicWeapon(Guid collectionGuid, ItemDefinition baseItem, ItemDefinition magicalExample, string name)
         {
-
             string itemName = "Enchanted_" + baseItem.Name + "_" + name;
             ItemDefinitionBuilder builder = new ItemDefinitionBuilder(baseItem, itemName, GuidHelper.Create(collectionGuid, itemName).ToString());
             // Set is magical

--- a/SolastaCommunityExpansion/FightingStyles/AbstractFightingStyle.cs
+++ b/SolastaCommunityExpansion/FightingStyles/AbstractFightingStyle.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 
-
 namespace SolastaCommunityExpansion.FightingStyles
 {
     internal abstract class AbstractFightingStyle

--- a/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
+++ b/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
@@ -91,7 +91,7 @@ namespace SolastaCommunityExpansion.FightingStyles
         {
             RulesetInventorySlot mainHand = character.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeMainHand];
             RulesetInventorySlot offHand = character.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeOffHand];
-            return mainHand.EquipedItem == null && (offHand.EquipedItem == null || offHand.EquipedItem.ItemDefinition.IsLightSourceItem);
+            return mainHand.EquipedItem == null && (offHand.EquipedItem?.ItemDefinition.IsLightSourceItem != false);
         }
     }
 }

--- a/SolastaCommunityExpansion/Helpers/Extensions.cs
+++ b/SolastaCommunityExpansion/Helpers/Extensions.cs
@@ -15,7 +15,6 @@ namespace SolastaCommunityExpansion.Helpers
         /// <param name="populateActorFeaturesToBrowse">Set to true to populate actor.FeaturesToBrowse as well as returning features.  false to just return features.</param>
         /// <param name="featuresOrigin"></param>
         /// <returns></returns>
-        /// <summary>
         public static ICollection<T> EnumerateFeaturesToBrowse<T>(
             this RulesetActor actor, bool populateActorFeaturesToBrowse = false, Dictionary<FeatureDefinition, RuleDefinitions.FeatureOrigin> featuresOrigin = null)
         {

--- a/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -47,9 +45,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Deflection", DatabaseHelper.ItemDefinitions.Enchanted_BreastplateOfDeflection,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BreastplateOfDeflection),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -45,9 +43,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Punisher", DatabaseHelper.ItemDefinitions.Enchanted_Battleaxe_Punisher,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BattleaxePunisher),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (crossbowItems == null)
-                {
-                    crossbowItems = new ItemCollection()
+                return crossbowItems ?? (crossbowItems = new ItemCollection()
                     {
                         BaseGuid = new Guid("6eff8e23-1b2f-4e48-8cde-3abda9d4bc3b"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -43,9 +41,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Medusa", DatabaseHelper.ItemDefinitions.Enchanted_Shortbow_Medusa,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortbowMedusa),
                         }
-                    };
-                }
-                return crossbowItems;
+                    });
             }
             set => crossbowItems = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -39,9 +37,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Frostburn", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Frostburn,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
@@ -50,7 +50,6 @@ namespace SolastaCommunityExpansion.ItemCrafting
                         StockItem(DatabaseHelper.MerchantDefinitions.Store_Merchant_Gorim_Ironsoot_Cyflen_GeneralStore, craftingManual);
                     }
                 }
-
             }
         }
 
@@ -149,7 +148,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 recipes.Add(builder.AddToDB());
             }
 
-            string groupKey = "EnchantingIngredients";
+            const string groupKey = "EnchantingIngredients";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)
@@ -203,7 +202,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
             };
             IEnumerable<RecipeDefinition> recipes = primedToBase.Keys.Select(item => CreatePrimingRecipe(baseGuid, primedToBase[item], item));
 
-            string groupKey = "PrimedItems";
+            const string groupKey = "PrimedItems";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)
@@ -230,7 +229,6 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 {DatabaseHelper.ItemDefinitions.CAERLEM_TirmarianHolySymbol, DatabaseHelper.ItemDefinitions.Art_Item_50_GP_JadePendant},
                 {DatabaseHelper.ItemDefinitions.BONEKEEP_MagicRune, DatabaseHelper.ItemDefinitions.Art_Item_25_GP_EngraveBoneDice},
                 {DatabaseHelper.ItemDefinitions.CaerLem_Gate_Plaque, DatabaseHelper.ItemDefinitions.Art_Item_25_GP_SilverChalice},
-
             };
             List<RecipeDefinition> recipes = new List<RecipeDefinition>();
             foreach (ItemDefinition item in ForgeryToIngredient.Keys)
@@ -265,7 +263,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 recipes.Add(builder.AddToDB());
             }
 
-            string groupKey = "RelicForgeries";
+            const string groupKey = "RelicForgeries";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)

--- a/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -50,9 +48,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -46,9 +44,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -42,9 +40,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Sharpness", DatabaseHelper.ItemDefinitions.Enchanted_Shortsword_of_Sharpness,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortwordOfSharpness),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -41,12 +39,9 @@ namespace SolastaCommunityExpansion.ItemCrafting
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         },
                         NumProduced = 3,
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }
     }
 }
-

--- a/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Level20.Classes
 {
     internal static class DruidBuilder
     {
-
         internal static void Load()
         {
             // add missing progression

--- a/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Level20.Features
         protected PowerFighterActionSurge2Builder(string name, string guid) : base(PowerFighterActionSurge, name, guid)
         {
             Definition.SetFixedUsesPerRecharge(2);
-            Definition.SetOverriddenPower(DatabaseHelper.FeatureDefinitionPowers.PowerFighterActionSurge);
+            Definition.SetOverriddenPower(PowerFighterActionSurge);
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
@@ -28,14 +28,8 @@ namespace SolastaCommunityExpansion.Level20.Features
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new PowerPaladinAuraOfCourage18Builder().AddToDB();
-                }
-
-                return _instance;
+                return _instance ?? (_instance = new PowerPaladinAuraOfCourage18Builder().AddToDB());
             }
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
@@ -28,12 +28,7 @@ namespace SolastaCommunityExpansion.Level20.Features
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new PowerPaladinAuraOfProtection18Builder().AddToDB();
-                }
-
-                return _instance;
+                return _instance ?? (_instance = new PowerPaladinAuraOfProtection18Builder().AddToDB());
             }
         }
     }

--- a/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
@@ -10,7 +10,6 @@ namespace SolastaCommunityExpansion.Level20.Features
 
         protected PrimalChampionBuilder(string name, string guid) : base(name, guid)
         {
-
             Definition.GuiPresentation.Description = "Feature/&PrimalChampionDescription";
             Definition.GuiPresentation.Title = "Feature/&PrimalChampionTitle";
         }

--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Level20
             var dbFeatureDefinitionCastSpell = DatabaseRepository.GetDatabase<FeatureDefinitionCastSpell>();
 
             foreach (var featureDefinitionCastSpell in dbFeatureDefinitionCastSpell
-                .Where(x => x.SpellCastingOrigin != FeatureDefinitionCastSpell.CastingOrigin.Monster))
+                .Where(x => x.SpellCastingOrigin != CastingOrigin.Monster))
             {
                 while (featureDefinitionCastSpell.KnownCantrips.Count < MOD_MAX_LEVEL + 1)
                 {
@@ -47,9 +47,9 @@ namespace SolastaCommunityExpansion.Level20
                     {
                         spellListDefinition.SpellsByLevel.Add(
                             new SpellListDefinition.SpellsByLevelDuplet
-                            { 
-                                Level = spellListDefinition.SpellsByLevel.Count, 
-                                Spells = new List<SpellDefinition>() 
+                            {
+                                Level = spellListDefinition.SpellsByLevel.Count,
+                                Spells = new List<SpellDefinition>()
                             });
                     }
                 }

--- a/SolastaCommunityExpansion/Models/AdditionalNamesContext.cs
+++ b/SolastaCommunityExpansion/Models/AdditionalNamesContext.cs
@@ -35,7 +35,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         dwarfNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("ElfFemale"))
                     {
                         elfHighNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -48,7 +47,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         elfHighNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("SylvanElfFemale"))
                     {
                         elfSylvanNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -61,7 +59,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         elfSylvanNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalfElfFemale"))
                     {
                         halfElfNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -74,7 +71,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halfElfNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalfOrcFemale"))
                     {
                         halfOrcNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -83,7 +79,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halfOrcNames.RacePresentation.MaleNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalflingFemale"))
                     {
                         halflingNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -96,7 +91,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halflingNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HumanFemale"))
                     {
                         humanNames.RacePresentation.FemaleNameOptions.Add(name);

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using UnityEngine.AddressableAssets;
 
@@ -17,7 +16,7 @@ namespace SolastaCommunityExpansion.Models
             if (isUserText)
             {
                 var builder = new StringBuilder();
-                var fragments = itemDefinition.DocumentDescription.ContentFragments.Select(x => x.Text).ToList();
+                var fragments = itemDefinition.DocumentDescription.ContentFragments.ConvertAll(x => x.Text);
 
                 fragments.ForEach(x => builder.Append(x));
                 LogEntry(itemDefinition.FormatTitle(), builder.ToString(), string.Empty, assetReferenceSprite);
@@ -28,7 +27,7 @@ namespace SolastaCommunityExpansion.Models
         {
             var gameCampaign = Gui.GameCampaign;
 
-            if (gameCampaign != null && gameCampaign.CampaignDefinitionName == "UserCampaign")
+            if (gameCampaign?.CampaignDefinitionName == "UserCampaign")
             {
                 var adventureLog = gameCampaign.AdventureLog;
                 var hashCode = text.GetHashCode();
@@ -49,12 +48,10 @@ namespace SolastaCommunityExpansion.Models
             private string assetGuid;
             private AssetReferenceSprite assetReferenceSprite;
             private List<GameAdventureConversationInfo> conversationInfos = new List<GameAdventureConversationInfo>();
-            private readonly List<TextBreaker> textBreakers = new List<TextBreaker>();
             private string title;
 
             public GameAdventureEntryDungeonMaker()
             {
-
             }
 
             public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, string header, string text, string actorName, AssetReferenceSprite sprite) : base(adventureLogDefinition)
@@ -62,7 +59,7 @@ namespace SolastaCommunityExpansion.Models
                 assetGuid = assetReferenceSprite == null ? string.Empty : assetReferenceSprite.AssetGUID;
                 assetReferenceSprite = sprite;
                 conversationInfos.Add(new GameAdventureConversationInfo(actorName, text, actorName != ""));
-                textBreakers.Add(new TextBreaker());
+                TextBreakers.Add(new TextBreaker());
                 title = header;
             }
 
@@ -70,15 +67,13 @@ namespace SolastaCommunityExpansion.Models
             {
                 get
                 {
-                    var illustrationReference = IllustrationReference;
-
-                    return illustrationReference != null && illustrationReference.RuntimeKeyIsValid();
+                    return IllustrationReference?.RuntimeKeyIsValid() == true;
                 }
             }
 
             public override AssetReference IllustrationReference => assetReferenceSprite;
 
-            public List<TextBreaker> TextBreakers => textBreakers;
+            public List<TextBreaker> TextBreakers { get; } = new List<TextBreaker>();
 
             public string Title => title;
 
@@ -87,9 +82,9 @@ namespace SolastaCommunityExpansion.Models
                 base.ComputeHeight(areaWidth, textCompute);
                 Height = AdventureLogDefinition.ConversationHeaderHeight;
 
-                for (var i = 0; i < textBreakers.Count; ++i)
+                for (var i = 0; i < TextBreakers.Count; ++i)
                 {
-                    var textBreaker = textBreakers[i];
+                    var textBreaker = TextBreakers[i];
 
                     if (conversationInfos[i].ActorName != "")
                     {
@@ -137,7 +132,7 @@ namespace SolastaCommunityExpansion.Models
                         captionHashes.Add(hashCode);
                     }
 
-                    textBreakers.Add(new TextBreaker());
+                    TextBreakers.Add(new TextBreaker());
                 }
             }
         }

--- a/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
+++ b/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
@@ -1,5 +1,6 @@
 ﻿using SolastaModApi;
 using SolastaModApi.Extensions;
+using static FeatureDefinitionFeatureSet;
 
 namespace SolastaCommunityExpansion.Models
 {
@@ -9,13 +10,11 @@ namespace SolastaCommunityExpansion.Models
         {
             if (active)
             {
-                FeatureDefinitionFeatureSetExtensions.SetMode(
-                    DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, FeatureDefinitionFeatureSet.FeatureSetMode.Union);
+                DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice.SetMode(FeatureSetMode.Union);
             }
             else
             {
-                FeatureDefinitionFeatureSetExtensions.SetMode(
-                    DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, FeatureDefinitionFeatureSet.FeatureSetMode.Exclusion);
+                DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice.SetMode(FeatureSetMode.Exclusion);
             }
         }
 
@@ -23,6 +22,5 @@ namespace SolastaCommunityExpansion.Models
         {
             Switch(Main.Settings.EnablesAsiAndFeat);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Models/CharacterExportContext.cs
+++ b/SolastaCommunityExpansion/Models/CharacterExportContext.cs
@@ -64,7 +64,7 @@ namespace SolastaCommunityExpansion.Models
 
                 newFirstName = newFirstName.TrimStart();
 
-                if (newFirstName == string.Empty)
+                if (string.IsNullOrEmpty(newFirstName))
                 {
                     Gui.GuiService.ShowAlert("Message/&CharacterExportEmptyNameErrorDescription", "EA7171", 5);
                 }
@@ -113,10 +113,10 @@ namespace SolastaCommunityExpansion.Models
 
             heroCharacter.CharacterInventory.EnumerateAllItems(inventoryItems);
 
-            var attunedItems = inventoryItems.Select(i => new { Item = i, Name = i.AttunedToCharacter }).ToList();
+            var attunedItems = inventoryItems.ConvertAll(i => new { Item = i, Name = i.AttunedToCharacter });
             var customItems = inventoryItems.FindAll(i => Gui.GameLocation?.UserCampaign?.UserItems?.Exists(ui => ui.ReferenceItemDefinition == i.ItemDefinition) == true).ToList();
-            var heroItemGuids = heroCharacter.Items.Select(i => new { Item = i, i.Guid }).ToList();
-            var inventoryItemGuids = inventoryItems.Select(i => new { Item = i, i.Guid }).ToList();
+            var heroItemGuids = heroCharacter.Items.ConvertAll(i => new { Item = i, i.Guid });
+            var inventoryItemGuids = inventoryItems.ConvertAll(i => new { Item = i, i.Guid });
 
             try
             {

--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace SolastaCommunityExpansion.Models
 {
     internal static class CustomFeaturesContext
-    {   
+    {
         internal static void RecursiveGrantCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features)
         {
             foreach (FeatureDefinition grantedFeature in features)

--- a/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
+++ b/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
@@ -106,7 +106,7 @@ namespace SolastaCommunityExpansion.Models
                     "Message/&SpawnCustomEncounterTitle",
                     Gui.Format("Message/&SpawnCustomEncounterDescription", position.x.ToString(), position.x.ToString()),
                     "Message/&MessageYesTitle", "Message/&MessageNoTitle",
-                    new MessageModal.MessageValidatedHandler(() => { StageEncounter(position); }),
+                    new MessageModal.MessageValidatedHandler(() => StageEncounter(position)),
                     null);
             }
         }

--- a/SolastaCommunityExpansion/Models/FightingStyleContext.cs
+++ b/SolastaCommunityExpansion/Models/FightingStyleContext.cs
@@ -92,4 +92,3 @@ namespace SolastaCommunityExpansion.Models
         }
     }
 }
-

--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -66,14 +66,14 @@ namespace SolastaCommunityExpansion.Models
                     case Hotkeys.CTRL_SHIFT_P:
                         GameHud.TogglePanelVisibility(GetInitiativeOrPartyPanel());
                         return;
+
+                    case Hotkeys.CTRL_SHIFT_H:
+                        GameHud.ShowAll(gameLocationBaseScreen, GetInitiativeOrPartyPanel(), GetTimeAndNavigationPanel());
+                        return;
                 }
             }
 
-            if (Main.Settings.EnableHotkeyToggleHud && command == Hotkeys.CTRL_SHIFT_H)
-            {
-                GameHud.ShowAll(gameLocationBaseScreen, GetInitiativeOrPartyPanel(), GetTimeAndNavigationPanel());
-            }
-            else if (Main.Settings.EnableHotkeyDebugOverlay && command == Hotkeys.CTRL_SHIFT_D)
+            if (Main.Settings.EnableHotkeyDebugOverlay && command == Hotkeys.CTRL_SHIFT_D)
             {
                 ServiceRepository.GetService<IDebugOverlayService>()?.ToggleActivation();
             }
@@ -201,7 +201,7 @@ namespace SolastaCommunityExpansion.Models
                     "Message/&TeleportPartyTitle",
                     Gui.Format("Message/&TeleportPartyDescription", position.x.ToString(), position.x.ToString()),
                     "Message/&MessageYesTitle", "Message/&MessageNoTitle",
-                    new MessageModal.MessageValidatedHandler(() => { TeleportParty(position); }),
+                    new MessageModal.MessageValidatedHandler(() => TeleportParty(position)),
                     null);
             }
 

--- a/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
+++ b/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
@@ -123,7 +123,6 @@ namespace SolastaCommunityExpansion.Models
 
             BuildFeatureUnlocks(initialFeats, alternateHuman, out FeatureUnlockByLevel featureUnlockByLevelNonHuman, out FeatureUnlockByLevel featureUnlockByLevelHuman);
 
-
             foreach (var characterRaceDefinition in DatabaseRepository.GetDatabase<CharacterRaceDefinition>().GetAllElements())
             {
                 if (!IsSubRace(characterRaceDefinition))

--- a/SolastaCommunityExpansion/Models/InventoryManagementContext.cs
+++ b/SolastaCommunityExpansion/Models/InventoryManagementContext.cs
@@ -123,7 +123,7 @@ namespace SolastaCommunityExpansion.Models
 
             BySortGroup.Inverted = false;
             BySortGroup.Selected = true;
-            BySortGroup.SortRequested = new SortGroup.SortRequestedHandler((sortCategory, inverted) =>
+            BySortGroup.SortRequested = new SortGroup.SortRequestedHandler((_, inverted) =>
             {
                 BySortGroup.Inverted = inverted;
                 BySortGroup.Refresh();

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -40,7 +40,7 @@ namespace SolastaCommunityExpansion.Models
             private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original) =>
                 new WandIdentifyBuilder(name, guid, title, description, original).AddToDB();
 
-            internal static readonly ItemDefinition WandIdentify = WandIdentifyBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition WandIdentify = CreateAndAddToDB(
                 "WandIdentify",
                 "46ae7624-4d24-455a-98f9-d41403b0ae19",
                 "Equipment/&WandIdentifyTitle",
@@ -83,7 +83,7 @@ namespace SolastaCommunityExpansion.Models
             private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original, EquipmentDefinitions.FocusType type, AssetReferenceSprite assetReferenceSprite) =>
                 new FocusDefinitionBuilder(name, guid, title, description, original, type, assetReferenceSprite).AddToDB();
 
-            internal static readonly ItemDefinition ArcaneStaff = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition ArcaneStaff = CreateAndAddToDB(
                 "ArcaneStaff",
                 "991e1fec-9777-4635-948f-5bedcb96147d",
                 "Equipment/&ArcaneStaffTitle",
@@ -92,7 +92,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 QuarterstaffPlus1.GuiPresentation.SpriteReference);
 
-            internal static readonly ItemDefinition DruidicAmulet = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition DruidicAmulet = CreateAndAddToDB(
                 "DruidicAmulet",
                 "3487d3b2-1058-4c0f-8009-9e4f525cb0e0",
                 "Equipment/&DruidicAmuletTitle",
@@ -101,7 +101,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 BeltOfGiantHillStrength.GuiPresentation.SpriteReference);
 
-            internal static readonly ItemDefinition LivewoodClub = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition LivewoodClub = CreateAndAddToDB(
                 "LivewoodClub",
                 "dd27119b-01e0-4a47-a043-98b89dc930a1",
                 "Equipment/&LivewoodClubTitle",
@@ -110,7 +110,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 null);
 
-            internal static readonly ItemDefinition LivewoodStaff = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition LivewoodStaff = CreateAndAddToDB(
                 "LivewoodStaff",
                 "ff3ec29c-734f-4ef6-8d6e-ceb961d9a8a0",
                 "Equipment/&LivewoodStaffTitle",
@@ -276,7 +276,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockAntiquarian()
         {
-            foreach (var stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_Antiquarians_Halman_Summer.StockUnitDescriptions.Where(
+            foreach (var stock in Store_Merchant_Antiquarians_Halman_Summer.StockUnitDescriptions.Where(
                 x => !x.ItemDefinition.Name.Contains("Manual") && !x.ItemDefinition.Name.Contains("Tome")))
             {
                 stock.SetReassortAmount(Main.Settings.RestockAntiquarians ? 1 : 0);
@@ -286,7 +286,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockArcaneum()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_Arcaneum_Heddlon_Surespell.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_Arcaneum_Heddlon_Surespell.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockArcaneum ? 1 : 0);
             }
@@ -294,7 +294,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockCircleOfDanantar()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_CircleOfDanantar_Joriel_Foxeye.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_CircleOfDanantar_Joriel_Foxeye.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockCircleOfDanantar ? 1 : 0);
             }
@@ -302,7 +302,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockTowerOfKnowledge()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_TowerOfKnowledge_Maddy_Greenisle.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_TowerOfKnowledge_Maddy_Greenisle.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockTowerOfKnowledge ? 1 : 0);
             }

--- a/SolastaCommunityExpansion/Models/PlayerControllerContext.cs
+++ b/SolastaCommunityExpansion/Models/PlayerControllerContext.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static bool IsOffGame => Gui.Game == null;
 
-        internal static List<GameLocationCharacter> PlayerCharacters { get; private set; } = new List<GameLocationCharacter>();
+        internal static List<GameLocationCharacter> PlayerCharacters { get; } = new List<GameLocationCharacter>();
 
         internal static int[] PlayerCharactersChoices
         {

--- a/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
+++ b/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
@@ -11,7 +11,6 @@ namespace SolastaCommunityExpansion.Models
         {
             if (Main.Settings.RemoveBugVisualModels)
             {
-
                 // Spiderlings, fire spider, kindred spirit spider, BadlandsSpider(normal, conjured and wildshaped versions)
                 const string assetReference_spider_1 = "362fc51df586d254ab182ef854396f82";
                 //CrimsonSpiderling, PhaseSpider, SpectralSpider, CrimsonSpider, deep spider(normal, conjured and wildshaped versions)
@@ -47,9 +46,7 @@ namespace SolastaCommunityExpansion.Models
                 MonsterDefinition ape = DatabaseHelper.MonsterDefinitions.Ape_MonsterDefinition;
                 AssetReference apePrefab = new AssetReference("8f4589a9a294b444785fab045256a713");
 
-
                 MonsterDefinition[] listofAllMonsters = DatabaseRepository.GetDatabase<MonsterDefinition>().GetAllElements();
-
 
                 // check every monster for targeted prefab guid references
                 foreach (MonsterDefinition monster in listofAllMonsters)

--- a/SolastaCommunityExpansion/Models/SetFactionRelationsContext.cs
+++ b/SolastaCommunityExpansion/Models/SetFactionRelationsContext.cs
@@ -5,10 +5,7 @@
         internal static void SetFactionRelation(string name, int value)
         {
             var service = ServiceRepository.GetService<IGameFactionService>();
-            if (service != null)
-            {
-                service.ModifyRelation(name, FactionDefinition.RelationOperation.Increase, value - service.FactionRelations[name], "" /* this string doesn't matter if we're using "SetValue" */);
-            }
+            service?.ModifyRelation(name, FactionDefinition.RelationOperation.Increase, value - service.FactionRelations[name], "" /* this string doesn't matter if we're using "SetValue" */);
         }
     }
 }

--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -256,11 +256,11 @@ namespace SolastaCommunityExpansion.Models
             SwitchSpellList(spellDefinition);
         }
 
-        internal static bool AreAllSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreAllSpellListsSelected(x));
+        internal static bool AreAllSpellListsSelected() => RegisteredSpellsList.All(x => AreAllSpellListsSelected(x));
 
-        internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition) => Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellsContext.SpellLists.Count;
+        internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition) => Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellLists.Count;
 
-        internal static bool AreMinimumSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreMinimumSpellListsSelected(x));
+        internal static bool AreMinimumSpellListsSelected() => RegisteredSpellsList.All(x => AreMinimumSpellListsSelected(x));
 
         internal static bool AreMinimumSpellListsSelected(SpellDefinition spellDefinition)
         {
@@ -272,10 +272,10 @@ namespace SolastaCommunityExpansion.Models
                 return false;
             }
 
-            return !minimumSpellLists.Any(x => !selectedSpellLists.Contains(x));
+            return minimumSpellLists.All(x => selectedSpellLists.Contains(x));
         }
 
-        internal static bool AreSuggestedSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreSuggestedSpellListsSelected(x));
+        internal static bool AreSuggestedSpellListsSelected() => RegisteredSpellsList.All(x => AreSuggestedSpellListsSelected(x));
 
         internal static bool AreSuggestedSpellListsSelected(SpellDefinition spellDefinition)
         {
@@ -287,7 +287,7 @@ namespace SolastaCommunityExpansion.Models
                 return false;
             }
 
-            return !suggestedSpellLists.Any(x => !selectedSpellLists.Contains(x));
+            return suggestedSpellLists.All(x => selectedSpellLists.Contains(x));
         }
 
         public static string GenerateSpellsDescription()

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -129,5 +129,4 @@ namespace SolastaCommunityExpansion.Models
             return outString.ToString();
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Patches/Bugfix/GameBestiaryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Bugfix/GameBestiaryPatcher.cs
@@ -5,7 +5,7 @@ using HarmonyLib;
 namespace SolastaCommunityExpansion.Patches.BugFix
 {
     /// <summary>
-    /// Fix issue: GameBestiaryEntry.LastUpdateTimeCode is never set. 
+    /// Fix issue: GameBestiaryEntry.LastUpdateTimeCode is never set.
     /// Should be set when increasing knowledge level.
     /// </summary>
     [HarmonyPatch(typeof(GameBestiary), "ApplyKnowledgeLevel")]
@@ -27,9 +27,8 @@ namespace SolastaCommunityExpansion.Patches.BugFix
         }
     }
 
-
     /// <summary>
-    /// Fix issue: 
+    /// Fix issue:
     /// sorting should put all monsters with knowledge level = 0 at the end of the list since they have no useful info
     /// sorting should sort by category and then by name to make it less of a jumble
     /// </summary>

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetActorPatcher.cs
@@ -27,7 +27,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
             }
 
             foreach (GameLocationCharacter contender in battleService.Battle.AllContenders
-                .Where(x => x != null && x.Valid && x.RulesetActor != null))
+                .Where(x => x?.Valid == true && x.RulesetActor != null))
             {
                 var conditionsToRemove = new List<RulesetCondition>();
 
@@ -55,7 +55,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
     internal static class RulesetActor_InflictCondition
     {
-
         internal static void Prefix(string conditionDefinitionName,
             ref int sourceAmount)
         {
@@ -74,10 +73,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
         {
             var notifiedDefinition = rulesetCondition?.ConditionDefinition as INotifyConditionRemoval;
 
-            if (notifiedDefinition != null)
-            {
-                notifiedDefinition.AfterConditionRemoved(__instance, rulesetCondition);
-            }
+            notifiedDefinition?.AfterConditionRemoved(__instance, rulesetCondition);
         }
     }
 

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -3,39 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaCommunityExpansion.Helpers;
 using SolastaCommunityExpansion.Models;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {
-    [HarmonyPatch(typeof(RulesetCharacterHero), "EnumerateUsableRitualSpells")]
-    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
-    internal static class RestModuleHitDice_EnumerateUsableRitualSpells_Patch
-    {
-        internal static void Postfix(RulesetCharacterHero __instance, RuleDefinitions.RitualCasting ritualType, List<SpellDefinition> ritualSpells)
-        {
-            if ((ExtraRitualCasting)ritualType != ExtraRitualCasting.Known) { return; }
-
-            var spellRepertoire = __instance.SpellRepertoires
-                .Where(r => r.SpellCastingFeature.SpellReadyness == RuleDefinitions.SpellReadyness.AllKnown)
-                .FirstOrDefault(r => r.SpellCastingFeature.SpellKnowledge == RuleDefinitions.SpellKnowledge.Selection);
-
-            if (spellRepertoire == null) { return; }
-
-            ritualSpells.AddRange(spellRepertoire.KnownSpells
-                .Where(s => s.Ritual)
-                .Where(s => spellRepertoire.MaxSpellLevelOfSpellCastingLevel >= s.SpellLevel));
-
-            if (spellRepertoire.AutoPreparedSpells == null) { return; }
-
-            ritualSpells.AddRange(spellRepertoire.AutoPreparedSpells
-                .Where(s => s.Ritual)
-                .Where(s => spellRepertoire.MaxSpellLevelOfSpellCastingLevel >= s.SpellLevel));
-
-        }
-    }
-
     [HarmonyPatch(typeof(RulesetCharacterHero), "FindClassHoldingFeature")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class RulesetCharacterHero_FindClassHoldingFeature
@@ -105,9 +77,8 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
         {
             foreach (FeatDefinition feat in feats)
             {
-                Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
+                CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
             }
-
         }
     }
 
@@ -136,12 +107,14 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
             hero.EnumerateFeaturesToBrowse<FeatureDefinitionPower>(hero.FeaturesToBrowse, null);
             foreach (FeatureDefinitionPower featureDefinitionPower in hero.FeaturesToBrowse.Cast<FeatureDefinitionPower>())
             {
+                // TODO: fix this statement - can throw
                 if (featureDefinitionPower is IConditionalPower &&
                     !(featureDefinitionPower as IConditionalPower).IsActive(hero))
                 {
                     continue;
                 }
-                RulesetUsablePower rulesetUsablePower = hero.UsablePowers.FirstOrDefault(up => up.PowerDefinition == featureDefinitionPower);
+
+                RulesetUsablePower rulesetUsablePower = hero.UsablePowers.Find(up => up.PowerDefinition == featureDefinitionPower);
                 if (rulesetUsablePower != null)
                 {
                     // If we found a power that was already on the character, re-add the same instance.
@@ -233,7 +206,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
                 }
             }
 
-            return (null, null, hero.TrainedFeats.FirstOrDefault(tf => tf.Features.Contains(featureDefinition)));
+            return (null, null, hero.TrainedFeats.Find(tf => tf.Features.Contains(featureDefinition)));
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
@@ -66,7 +66,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
             int? modifiedMinRoll = RulesetCharacter_ResolveContestCheck.MinimumStrengthAbilityCheckDieRoll(__instance, baseBonus, rollModifier, proficiencyName);
 
-            if (modifiedMinRoll.HasValue && modifiedMinRoll.Value > minRoll)
+            if (modifiedMinRoll > minRoll)
             {
                 minRoll = modifiedMinRoll.Value;
             }
@@ -140,8 +140,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
             return featuresToBrowse
                 .OfType<IMinimumAbilityCheckTotal>()
-                .Select(feature => feature.MinimumStrengthAbilityCheckTotal(character, proficiencyName))
-                .Max();
+                .Max(feature => feature.MinimumStrengthAbilityCheckTotal(character, proficiencyName));
         }
     }
 
@@ -171,7 +170,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
     {
         public static void Postfix(RulesetCharacter __instance)
         {
-            Models.CustomFeaturesContext.RechargeLinkedPowers(__instance, RuleDefinitions.RestType.LongRest);
+            CustomFeaturesContext.RechargeLinkedPowers(__instance, RuleDefinitions.RestType.LongRest);
         }
     }
 
@@ -184,7 +183,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
         {
             if (!simulate)
             {
-                Models.CustomFeaturesContext.RechargeLinkedPowers(__instance, restType);
+                CustomFeaturesContext.RechargeLinkedPowers(__instance, restType);
             }
 
             // The player isn't recharging the shared pool features, just the pool.

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
     internal static class RulesetImplementationManagerLocation_ApplySummonForm
     {
-        internal static Dictionary<string, int> ConditionToAmount { get; private set; } = new Dictionary<string, int>();
+        internal static Dictionary<string, int> ConditionToAmount { get; } = new Dictionary<string, int>();
 
         internal static void Prefix(
             EffectForm effectForm,
@@ -56,7 +56,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
                                             ConditionToAmount.AddOrReplace(addedCondition.Name, sourceAmount);
                                         }
                                         break;
-
                                 }
                             }
                         }

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
@@ -64,16 +64,16 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker
                     Main.Log($"room orientation before ({ur.Orientation}, {ur.OrientedWidth}, {ur.OrientedHeight})");
                     Main.Log($"current room position ({ur.Position.x}, {ur.Position.y})");
 
-                    var currentRoomCenter = new Vector3(ur.Position.x + ur.OrientedWidth / 2f, ur.Position.y + ur.OrientedHeight / 2f);
+                    var currentRoomCenter = new Vector3(ur.Position.x + (ur.OrientedWidth / 2f), ur.Position.y + (ur.OrientedHeight / 2f));
                     Main.Log($"current room center ({currentRoomCenter.x}, {currentRoomCenter.y})");
 
-                    var newRoomCenter = rotation * (currentRoomCenter - dungeonCenter) + dungeonCenter;
+                    var newRoomCenter = (rotation * (currentRoomCenter - dungeonCenter)) + dungeonCenter;
                     Main.Log($"new room center ({newRoomCenter.x}, {newRoomCenter.y})");
 
                     ur.Rotate(rotationAngle);
                     Main.Log($"room orientation after {ur.Orientation}, {ur.OrientedWidth}, {ur.OrientedHeight}");
 
-                    ur.Position = new Vector2Int(Mathf.RoundToInt(newRoomCenter.x - ur.OrientedWidth / 2f), Mathf.RoundToInt(newRoomCenter.y - ur.OrientedHeight / 2f));
+                    ur.Position = new Vector2Int(Mathf.RoundToInt(newRoomCenter.x - (ur.OrientedWidth / 2f)), Mathf.RoundToInt(newRoomCenter.y - (ur.OrientedHeight / 2f)));
                     Main.Log($"new room position ({ur.Position.x}, {ur.Position.y})");
                 }
 

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -45,7 +45,7 @@ namespace SolastaCommunityExpansion.Patches
             // Subclasses may rely on classes being loaded (as well as spells and powers) in order to properly refer back to the class.
             SubclassesContext.Load();
 
-            ServiceRepository.GetService<IRuntimeService>().RuntimeLoaded += (runtime) =>
+            ServiceRepository.GetService<IRuntimeService>().RuntimeLoaded += (_) =>
             {
                 FlexibleRacesContext.Switch();
                 InitialChoicesContext.RefreshFirstLevelTotalFeats();

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/CharacterControlPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/CharacterControlPanelPatcher.cs
@@ -192,10 +192,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
             }
 
             // Re transition to current state?
-            if (panelToActivate != null)
-            {
-                panelToActivate.OnActivateAction(actionId);
-            }
+            panelToActivate?.OnActivateAction(actionId);
 
             panelToActivate = null;
         }

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
@@ -10,10 +10,9 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
     /// <summary>
     /// Currently when a character is teleported off screen the camera doesn't follow.
     /// This patch will attempt to follow the character if initiated by a teleport game gadget
-    /// The don't follow character in battle patch will interact with this patch to cancel 
+    /// The don't follow character in battle patch will interact with this patch to cancel
     /// following if we're in battle and the character is on screen.
     /// </summary>
-
     [HarmonyPatch(typeof(FunctorTeleport), "Execute")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class FunctorTeleport_Execute

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/PowerSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/PowerSelectionPanelPatcher.cs
@@ -83,7 +83,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                     secondRow.gameObject.SetActive(false);
                 }
 
-                if (thirdRow != null && thirdRow.gameObject.activeSelf)
+                if (thirdRow?.gameObject.activeSelf == true)
                 {
                     Gui.ReleaseChildrenToPool(thirdRow);
                     thirdRow.gameObject.SetActive(false);

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
@@ -72,7 +72,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                                 spellLevelsOnLine = 0;
                                 needNewLine = true;
                                 indexOfLine = 0;
-
                             }
                         }
                     }
@@ -152,7 +151,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                     case ActionDefinitions.ActionType.NoCost:
                         spellActivationTime = RuleDefinitions.ActivationTime.NoCost;
                         break;
-
                 }
 
                 if (level == 0)
@@ -200,7 +198,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
 
                 foreach (RectTransform spellTable in spellLineTables)
                 {
-                    if (spellTable != null && spellTable.gameObject.activeSelf && spellTable.childCount > 0)
+                    if (spellTable?.gameObject.activeSelf == true && spellTable.childCount > 0)
                     {
                         Gui.ReleaseChildrenToPool(spellTable);
                         spellTable.SetParent(null);

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/ViewPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/ViewPatcher.cs
@@ -10,12 +10,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
     {
         internal static bool Prefix()
         {
-            if (ModManagerUI.IsOpen)
-            {
-                return false;
-            }
-
-            return true;
+            return !ModManagerUI.IsOpen;
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameGadgetPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameGadgetPatcher.cs
@@ -13,8 +13,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.ScreenMap
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameGadget_ComputeIsRevealed
     {
-
-
         internal static void Postfix(GameGadget __instance, ref bool ___revealed, ref bool __result)
         {
             if (!__instance.Revealed || Gui.GameLocation.UserLocation == null || !Main.Settings.EnableAdditionalIconsOnLevelMap)

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
@@ -23,10 +23,7 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
         {
             if (!Main.Settings.EnableSaveByLocation)
             {
-                if (Dropdown != null)
-                {
-                    Dropdown.SetActive(false);
-                }
+                Dropdown?.SetActive(false);
 
                 return true;
             }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/ActiveCharacterPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/ActiveCharacterPanelPatcher.cs
@@ -26,7 +26,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             var spell = __instance.GuiCharacter.RulesetCharacterHero?.ConcentratedSpell;
             if (spell == null)
             {
-                Main.Log($"ActiveCharacterPanel_OnStopConcentratingCb: No spell.");
+                Main.Log("ActiveCharacterPanel_OnStopConcentratingCb: No spell.");
                 return;
             }
 

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
@@ -15,8 +15,6 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
         }
         */
 
-    /// <summary>
-    /// </summary>
     [HarmonyPatch(typeof(EquipmentDefinitions), "ScaleAndRoundCosts")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class EquipmentDefinitions_ScaleAndRoundCosts
@@ -30,10 +28,10 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 
             // convert to copper
             int cp =
-                1000 * baseCosts[0] + // platinum
-                100 * baseCosts[1] + // gold
-                50 * baseCosts[2] + // electrum?
-                10 * baseCosts[3] + // silver
+                (1000 * baseCosts[0]) + // platinum
+                (100 * baseCosts[1]) + // gold
+                (50 * baseCosts[2]) + // electrum?
+                (10 * baseCosts[3]) + // silver
                 baseCosts[4]; // copper
 
             // scale
@@ -56,7 +54,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             else
             {
                 // else keep 2 sig fig
-                scaledGold = SignificantDigits.Round(scaledGold, 2);
+                scaledGold = scaledGold.Round(2);
             }
 
             // convert back to cp
@@ -66,8 +64,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             scaledCosts[4] = scaledAndRoundedCopper % 10;
             scaledCosts[3] = (scaledAndRoundedCopper - scaledCosts[4]) / 10 % 10;
             // scaledCosts[2] always zero?
-            scaledCosts[1] = (scaledAndRoundedCopper - scaledCosts[3] * 10 - scaledCosts[4]) / 100 % 10;
-            scaledCosts[0] = (scaledAndRoundedCopper - scaledCosts[1] * 100 - scaledCosts[3] * 10 - scaledCosts[4]) / 1000;
+            scaledCosts[1] = (scaledAndRoundedCopper - (scaledCosts[3] * 10) - scaledCosts[4]) / 100 % 10;
+            scaledCosts[0] = (scaledAndRoundedCopper - (scaledCosts[1] * 100) - (scaledCosts[3] * 10) - scaledCosts[4]) / 1000;
 
             // only show platinum if baseCosts had platinum
             if (baseCosts[0] == 0)
@@ -158,7 +156,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             }
 
             // The resulting rounding position will be negative for rounding at whole numbers, and positive for decimal places.
-            roundingPosition = significantDigits - 1 - (int)(Math.Floor(Math.Log10(Math.Abs(value))));
+            roundingPosition = significantDigits - 1 - (int)Math.Floor(Math.Log10(Math.Abs(value)));
 
             // try to use a rounding position directly, if no scale is needed.
             // this is because the scale mutliplication after the rounding can introduce error, although 

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RulesetCharacterPatcher.cs
@@ -9,7 +9,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
     /// <summary>
     /// Allow spells that require consumption of a material component (e.g. a gem of value >= 1000gp) use a stack
     /// of lesser value components (e.g. 4 x 300gp diamonds).
-    /// Note that this implementation will only work with identical components - e.g. 'all diamonds', it won't consider combining 
+    /// Note that this implementation will only work with identical components - e.g. 'all diamonds', it won't consider combining
     /// different types of items with the tag 'gem'.
     /// TODO: if anyone requests it we can improve with GroupBy etc...
     /// </summary>
@@ -106,7 +106,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 
             if (itemToUse == null)
             {
-                Main.Log($"Didn't find item.");
+                Main.Log("Didn't find item.");
 
                 return false;
             }
@@ -133,7 +133,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             }
             else
             {
-                Main.Log($"Destroy item");
+                Main.Log("Destroy item");
 
                 __instance.CharacterInventory.DestroyItem(rulesetItem);
             }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
@@ -43,7 +43,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             RulesetSpellRepertoire ___spellRepertoire, SpellsByLevelBox.SpellCastEngagedHandler ___spellCastEngaged)
         {
             if (!Main.Settings.EnableUpcastConjureElementalAndFey
-               || !SpellDefinition_SubspellsList.FilteredSubspells.Any())
+               || SpellDefinition_SubspellsList.FilteredSubspells.Count == 0)
             {
                 return true;
             }
@@ -112,8 +112,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
                     ChallengeRating = g.Key,
                     SpellDefinitions = g.Select(s => s.SpellDefinition).OrderBy(s => Gui.Format(s.GuiPresentation.Title))
                 })
-                .OrderByDescending(s => s.ChallengeRating)
                 .Where(s => s.ChallengeRating <= FilterBySlotLevel.Value)
+                .OrderByDescending(s => s.ChallengeRating)
                 .ToList();
 
             var allOrMostPowerful = Main.Settings.OnlyShowMostPowerfulUpcastConjuredElementalOrFey

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -9,7 +9,6 @@ namespace SolastaCommunityExpansion
 {
     public class Core
     {
-
     }
 
     [Serializable]
@@ -109,9 +108,9 @@ namespace SolastaCommunityExpansion
         public int OverrideRogueConArtistImprovedManipulationSpellDc { get; set; } = 3;
         public int OverrideWizardMasterManipulatorArcaneManipulationSpellDc { get; set; } = 2;
         public int ClassSliderPosition { get; set; } = 1;
-        public List<string> ClassEnabled { get; private set; } = new List<string>();
+        public List<string> ClassEnabled { get; } = new List<string>();
         public int SubclassSliderPosition { get; set; } = 1;
-        public List<string> SubclassEnabled { get; private set; } = new List<string>();
+        public List<string> SubclassEnabled { get; } = new List<string>();
 
         //
         // Characters - Feats
@@ -119,20 +118,20 @@ namespace SolastaCommunityExpansion
 
         public int FeatPowerAttackModifier { get; set; } = 3;
         public int FeatSliderPosition { get; set; } = 1;
-        public List<string> FeatEnabled { get; private set; } = new List<string>();
+        public List<string> FeatEnabled { get; } = new List<string>();
 
         //
         // Characters - Fighting Styles
         //
 
         public int FightingStyleSliderPosition { get; set; } = 1;
-        public List<string> FightingStyleEnabled { get; private set; } = new List<string>();
+        public List<string> FightingStyleEnabled { get; } = new List<string>();
 
         //
         // Characters - Powers
         //
 
-        public List<string> PowerEnabled { get; private set; } = new List<string>();
+        public List<string> PowerEnabled { get; } = new List<string>();
 
         //
         // Characters - Spells
@@ -164,7 +163,6 @@ namespace SolastaCommunityExpansion
         public bool FullyControlConjurations { get; set; }
         public bool DismissControlledConjurationsWhenDeliberatelyDropConcentration { get; set; }
         public bool OnlyShowMostPowerfulUpcastConjuredElementalOrFey { get; set; }
-
 
         // House
         public bool AllowAnyClassToWearSylvanArmor { get; set; }
@@ -203,9 +201,9 @@ namespace SolastaCommunityExpansion
         public int SetBeltOfDwarvenKindBeardChances { get; set; } = 50;
 
         // Crafting
-        public List<string> CraftingInStore { get; private set; } = new List<string>();
-        public List<string> CraftingItemsInDM { get; private set; } = new List<string>();
-        public List<string> CraftingRecipesInDM { get; private set; } = new List<string>();
+        public List<string> CraftingInStore { get; } = new List<string>();
+        public List<string> CraftingItemsInDM { get; } = new List<string>();
+        public List<string> CraftingRecipesInDM { get; } = new List<string>();
 
         // Merchants
         public bool StockGorimStoreWithAllNonMagicalClothing { get; set; }

--- a/SolastaCommunityExpansion/Spells/BazouSpells.cs
+++ b/SolastaCommunityExpansion/Spells/BazouSpells.cs
@@ -96,7 +96,6 @@ namespace SolastaCommunityExpansion.Spells
             //            spell.EffectDescription.EffectForms.Add(effectForm);
 
             return spell;
-
         }
 
         private static SpellDefinition BuildFindFamiliar()

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -10,7 +10,7 @@ using SolastaCommunityExpansion.Builders;
 
 namespace SolastaCommunityExpansion.Spells
 {
-    internal class SrdSpells
+    internal static class SrdSpells
     {
         private static readonly SpellDefinition DivineWord = BuildDivineWord();
         private static readonly SpellDefinition FingerOfDeath = BuildFingerOfDeath();
@@ -210,7 +210,7 @@ namespace SolastaCommunityExpansion.Spells
                     effectDefinitionName = formsParams.activeEffect.SourceDefinition.Name;
                 }
 
-                int sourceAbilityBonus = formsParams.activeEffect != null ? formsParams.activeEffect.ComputeSourceAbilityBonus(formsParams.sourceCharacter) : 0;
+                int sourceAbilityBonus = (formsParams.activeEffect?.ComputeSourceAbilityBonus(formsParams.sourceCharacter)) ?? 0;
 
                 formsParams.targetCharacter.InflictCondition(condition.Name, durationType, durationParam, RuleDefinitions.TurnOccurenceType.EndOfTurn, "11Effect", sourceGuid, sourceFaction, formsParams.effectLevel, effectDefinitionName, 0, sourceAbilityBonus);
             }
@@ -230,7 +230,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildFingerOfDeath()
         {
-            string text = "FingerOfDeathSpell";
+            const string text = "FingerOfDeathSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -366,7 +366,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildReverseGravity()
         {
-            string text = "ReverseGravitySpell";
+            const string text = "ReverseGravitySpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -530,36 +530,36 @@ namespace SolastaCommunityExpansion.Spells
                 new FeatureDefinitionCastSpell.SlotsByLevelDuplet() { Slots = new List<int> {13,6,1,1,1,0,0,0,0,0}, Level = 20 },
             });
 
-            string text = "ConjureCelestialSpell";
+            const string text = "ConjureCelestialSpell";
 
             MonsterDefinition BaseTemplateName = DatabaseHelper.MonsterDefinitions.KindredSpiritViper;
             MonsterDefinition MonsterShaderReference = DatabaseHelper.MonsterDefinitions.KindredSpiritViper;
 
-            string NewName = "CustomCouatl";
-            string NewTitle = "CustomCouatlTitle";
-            string NewDescription = "CustomCouatlDescription";
+            const string NewName = "CustomCouatl";
+            const string NewTitle = "CustomCouatlTitle";
+            const string NewDescription = "CustomCouatlDescription";
             CharacterSizeDefinition Size = DatabaseHelper.CharacterSizeDefinitions.Medium;
-            string Alignment = "LawfulGood";
-            int ArmorClass = 19;
-            int HitDice = 13;
-            RuleDefinitions.DieType HitDiceType = RuleDefinitions.DieType.D8;
-            int HitPointsBonus = 39;
-            int StandardHitPoints = 97;
-            int AttributeStrength = 16;
-            int AttributeDexterity = 20;
-            int AttributeConstitution = 17;
-            int AttributeIntelligence = 18;
-            int AttributeWisdom = 20;
-            int AttributeCharisma = 18;
-            int SavingThrowStrength = 0;
-            int SavingThrowDexterity = 0;
-            int SavingThrowConstitution = 5;
-            int SavingThrowIntelligence = 0;
-            int SavingThrowWisdom = 7;
-            int SavingThrowCharisma = 6;
-            int CR = 4;
-            bool LegendaryCreature = false;
-            string Type = "Celestial";
+            const string Alignment = "LawfulGood";
+            const int ArmorClass = 19;
+            const int HitDice = 13;
+            const RuleDefinitions.DieType HitDiceType = RuleDefinitions.DieType.D8;
+            const int HitPointsBonus = 39;
+            const int StandardHitPoints = 97;
+            const int AttributeStrength = 16;
+            const int AttributeDexterity = 20;
+            const int AttributeConstitution = 17;
+            const int AttributeIntelligence = 18;
+            const int AttributeWisdom = 20;
+            const int AttributeCharisma = 18;
+            const int SavingThrowStrength = 0;
+            const int SavingThrowDexterity = 0;
+            const int SavingThrowConstitution = 5;
+            const int SavingThrowIntelligence = 0;
+            const int SavingThrowWisdom = 7;
+            const int SavingThrowCharisma = 6;
+            const int CR = 4;
+            const bool LegendaryCreature = false;
+            const string Type = "Celestial";
 
             List<FeatureDefinition> Features = new List<FeatureDefinition>()
             {
@@ -650,9 +650,9 @@ namespace SolastaCommunityExpansion.Spells
 
             List<LegendaryActionDescription> LegendaryActionOptions = new List<LegendaryActionDescription>();
 
-            bool GroupAttacks = false;
+            const bool GroupAttacks = false;
 
-            bool PhantomDistortion = true;
+            const bool PhantomDistortion = true;
             // AttachedParticlesReference = "0286006526f6f9c4fa61ed8ead4f72cc"
             AssetReference AttachedParticlesReference = DatabaseHelper.MonsterDefinitions.FeyBear.MonsterPresentation.GetField<UnityEngine.AddressableAssets.AssetReference>("attachedParticlesReference");
             AssetReferenceSprite SpriteReference = DatabaseHelper.MonsterDefinitions.KindredSpiritViper.GuiPresentation.SpriteReference;
@@ -864,7 +864,7 @@ namespace SolastaCommunityExpansion.Spells
         */
         private static SpellDefinition BuildDominateMonster()
         {
-            string text = "DominateMonsterSpell";
+            const string text = "DominateMonsterSpell";
 
             EffectDescription effectDescription = new EffectDescription();
 
@@ -894,7 +894,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildFeeblemind()
         {
-            string text = "FeeblemindSpell";
+            const string text = "FeeblemindSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -918,7 +918,7 @@ namespace SolastaCommunityExpansion.Spells
                 DatabaseHelper.SmartAttributeDefinitions.Intelligence.name,
                 20,
                 false,
-                new List<SaveAffinityBySenseDescription> { }
+                new List<SaveAffinityBySenseDescription>()
                 )
             .AddEffectForm(new EffectFormBuilder()
                 .SetConditionForm(
@@ -1006,7 +1006,6 @@ namespace SolastaCommunityExpansion.Spells
                 Definition.SetModifierType2(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Force);
                 Definition.SetModifierValue(1);
                 Definition.SetSituationalContext(RuleDefinitions.SituationalContext.None);
-
             }
             private static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
                 => new FeeblemindIntAttributeModifierBuilder(name, guid).AddToDB();
@@ -1070,7 +1069,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildHolyAura()
         {
-            string text = "HolyAuraSpell";
+            const string text = "HolyAuraSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1117,7 +1116,6 @@ namespace SolastaCommunityExpansion.Spells
 
             return holyAuraSpell.AddToDB();
         }
-
 
         internal class HolyAuraConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
         {
@@ -1218,8 +1216,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildIncendiaryCloud()
         {
-
-            string text = "IncendiaryCloudSpell";
+            const string text = "IncendiaryCloudSpell";
 
             //
             // TODO: Why this effect description isn't used?
@@ -1323,7 +1320,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMaze()
         {
-            string text = "MazeSpell";
+            const string text = "MazeSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -1384,8 +1381,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMindBlank()
         {
-
-            string text = "MindBlankSpell";
+            const string text = "MindBlankSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder();
             effectDescription.SetDurationData(
@@ -1460,7 +1456,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordStun()
         {
-            string text = "PowerWordStunSpell";
+            const string text = "PowerWordStunSpell";
 
             ConditionForm conditionForm = new ConditionForm()
                 .SetApplyToSelf(false)
@@ -1529,10 +1525,9 @@ namespace SolastaCommunityExpansion.Spells
             return powerWordStunSpell.AddToDB();
         }
 
-
         private static SpellDefinition BuildSunBurst()
         {
-            string text = "SunBurstSpell";
+            const string text = "SunBurstSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1616,7 +1611,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildForesight()
         {
-            string text = "ForesightSpell";
+            const string text = "ForesightSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1692,7 +1687,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMassHeal()
         {
-            string text = "MassHealSpell";
+            const string text = "MassHealSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1739,7 +1734,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMeteorSwarmSingleTarget()
         {
-            string text = "MeteorSwarmSingleTargetSpell";
+            const string text = "MeteorSwarmSingleTargetSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1812,7 +1807,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordHeal()
         {
-            string text = "PowerWordHealSpell";
+            const string text = "PowerWordHealSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -1858,7 +1853,6 @@ namespace SolastaCommunityExpansion.Spells
                     })
                 .Build());
 
-
             GuiPresentation guiPresentationSpell = new GuiPresentation()
                 .SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f))
                 .SetDescription(GetSpellDescriptionTerm(text))
@@ -1881,7 +1875,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordKill()
         {
-            string text = "PowerWordKillSpell";
+            const string text = "PowerWordKillSpell";
 
             KillForm killForm = new KillForm()
                 .SetKillCondition(RuleDefinitions.KillCondition.UnderHitPoints)
@@ -1932,7 +1926,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildShapechange()
         {
-            string text = "ShapechangeSpell";
+            const string text = "ShapechangeSpell";
 
             ShapeChangeForm shapeChangeForm = new ShapeChangeForm()
                 .SetKeepMentalAbilityScores(true)
@@ -2001,7 +1995,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildTimeStop()
         {
-            string text = "TimeStopSpell";
+            const string text = "TimeStopSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -2072,7 +2066,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildWeird()
         {
-            string text = "WeirdSpell";
+            const string text = "WeirdSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -173,10 +173,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                         CreateNamespacedGuid("PathOfTheLightLightsProtectionOpportunityAttackImmunity"),
                         "Feature/&NoContentTitle",
                         "Feature/&NoContentTitle",
-                        definition =>
-                        {
-                            definition.ConditionName = IlluminatedConditionName;
-                        });
+                        definition => definition.ConditionName = IlluminatedConditionName);
 
                     featureSetDefinition.FeatureSet.Add(conditionalOpportunityAttackImmunity);
                 });
@@ -409,10 +406,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                 CreateNamespacedGuid("PathOfTheLightIlluminatedDisadvantage"),
                 "Subclass/&BarbarianPathOfTheLightIlluminatedDisadvantageDescription",
                 "Feature/&NoContentTitle",
-                definition =>
-                {
-                    definition.ConditionName = IlluminatedConditionName;
-                });
+                definition => definition.ConditionName = IlluminatedConditionName);
 
             return disadvantageAgainstNonSource;
         }
@@ -499,7 +493,6 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                 character.PersonalLightSource = null;
             }
         }
-
 
         // Helper classes
 

--- a/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
+++ b/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
@@ -19,11 +19,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass());
         }
 
         private const string DruidForestGuardianDruidSubclassName = "DruidForestGuardianDruidSubclass";
@@ -231,7 +227,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
                 true).AddToDB();
             superiorBarkWard.SetOverriddenPower(improvedBarkWard);
 
-
             return new Dictionary<int, FeatureDefinitionPowerSharedPool>{
                 {2, barkWard},
                 {10, improvedBarkWard},
@@ -316,8 +311,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             EffectDescriptionBuilder improvedBarkWardRetaliationEffect = new EffectDescriptionBuilder();
             improvedBarkWardRetaliationEffect.AddEffectForm(damageEffect.Build());
 
-
-
             return new FeatureDefinitionPowerBuilder("improvedBarkWardRetaliate",
                 GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "improvedBarkWardRetaliate").ToString(),
                 0,
@@ -362,7 +355,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             Definition.SetDurationParameter(10);
             Definition.SetDurationType(RuleDefinitions.DurationType.Minute);
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB()
@@ -438,7 +430,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             Definition.SetDurationParameter(10);
             Definition.SetDurationType(RuleDefinitions.DurationType.Minute);
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB()

--- a/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
@@ -94,15 +94,15 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 effectDescription.Copy(Definition.EffectDescription);
                 effectDescription.EffectForms[0].HealingForm.HealingCap = RuleDefinitions.HealingCap.MaximumHitPoints;
                 effectDescription.EffectForms[0].HealingForm.DiceNumber = 4;
-                FeatureDefinitionPowerExtensions.SetEffectDescription(Definition, effectDescription);
+                Definition.SetEffectDescription(effectDescription);
             }
 
             private void SetupGUI()
             {
                 Definition.GuiPresentation.Title = "Feature/&RallyingCryPowerTitle";
                 Definition.GuiPresentation.Description = "Feature/&RallyingCryPowerDescription";
-                FeatureDefinitionPowerExtensions.SetShortTitleOverride(Definition, "Feature/&RallyingCryPowerTitleShort");
-                GuiPresentationExtensions.SetSpriteReference(Definition.GuiPresentation, DatabaseHelper.SpellDefinitions.HealingWord.GuiPresentation.SpriteReference);
+                Definition.SetShortTitleOverride("Feature/&RallyingCryPowerTitleShort");
+                Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.HealingWord.GuiPresentation.SpriteReference);
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -145,15 +145,15 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                     effectDescription.EffectForms.Add(effectForm);
                 }
 
-                FeatureDefinitionPowerExtensions.SetEffectDescription(Definition, effectDescription);
+                Definition.SetEffectDescription(effectDescription);
             }
 
             private void SetupGUI()
             {
                 Definition.GuiPresentation.Title = "Feature/&InspiringSurgePowerTitle";
                 Definition.GuiPresentation.Description = "Feature/&InspiringSurgePowerDescription";
-                FeatureDefinitionPowerExtensions.SetShortTitleOverride(Definition, "Feature/&InspiringSurgePowerTitleShort");
-                GuiPresentationExtensions.SetSpriteReference(Definition.GuiPresentation, DatabaseHelper.SpellDefinitions.Heroism.GuiPresentation.SpriteReference);
+                Definition.SetShortTitleOverride("Feature/&InspiringSurgePowerTitleShort");
+                Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Heroism.GuiPresentation.SpriteReference);
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -14,11 +14,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = TacticianFighterSubclassBuilder.BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = TacticianFighterSubclassBuilder.BuildAndAddSubclass());
         }
     }
 
@@ -246,6 +242,5 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         public static readonly FeatureDefinitionPowerSharedPool KnockDownPower = KnockDownPowerBuilder.CreateAndAddToDB();
         public static readonly FeatureDefinitionPowerSharedPool InspirePower = InspirePowerBuilder.CreateAndAddToDB();
         public static readonly FeatureDefinitionPowerSharedPool CounterStrikePower = CounterStrikePowerBuilder.CreateAndAddToDB();
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -18,11 +18,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass());
         }
 
         private const string RangerArcanistRangerSubclassName = "RangerArcanistRangerSubclass";
@@ -305,7 +301,6 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
                 .AddToDB();
         }
     }
-
 
     // Creates a dedicated builder for the marked by arcanist condition. This helps with GUID wonkiness on the fact that separate features interact with it.
     internal class ConditionMarkedByArcanistBuilder : BaseDefinitionBuilder<ConditionDefinition>

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -121,9 +121,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             public AdvantageBuilder(string name, string guid, ConditionDefinition original, GuiPresentation guiPresentation) : base(original, name, guid)
             {
                 Definition.SetGuiPresentation(guiPresentation);
-                Definition.SetField("specialInterruptions", (new List<RuleDefinitions.ConditionInterruption>() {
+                Definition.SetField("specialInterruptions", new List<RuleDefinitions.ConditionInterruption>() {
                     RuleDefinitions.ConditionInterruption.Attacked,
-                }));
+                });
                 Definition.SetAdditionalDamageWhenHit(true);
                 Definition.SetAdditionalDamageDieType(RuleDefinitions.DieType.D8);
                 Definition.SetAdditionalDamageDieNumber(3);

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -43,7 +43,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 .SetGuiPresentation(guiPresentation)
                 .AddFeatureAtLevel(new RemoveGrantedFeatureBuilder(
                     featureName,
-                    GuidHelper.Create(Thug.SubclassNamespace, featureName).ToString(),
+                    GuidHelper.Create(SubclassNamespace, featureName).ToString(),
                     AdditionalDamageRogueSneakAttack,
                     1,
                     DatabaseHelper.CharacterClassDefinitions.Rogue).AddToDB(), 3)
@@ -63,7 +63,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             {
                 Definition.GuiPresentation.Title = "Feature/&KSRogueSubclassThugExploitVulnerabilitiesSneakAttackTitle";
                 Definition.GuiPresentation.Description = "Feature/&KSRogueSubclassThugExploitVulnerabilitiesSneakAttackDescription";
-                FeatureDefinitionAdditionalDamageExtensions.SetRequiredProperty(Definition, RuleDefinitions.AdditionalDamageRequiredProperty.None);
+                Definition.SetRequiredProperty(RuleDefinitions.AdditionalDamageRequiredProperty.None);
             }
 
             private static FeatureDefinitionAdditionalDamage CreateAndAddToDB(string name, string guid)
@@ -82,7 +82,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             {
                 Definition.GuiPresentation.Title = "Feature/&KSRogueSubclassThugProficienciesTitle";
                 Definition.GuiPresentation.Description = "Feature/&KSRogueSubclassThugProficienciesDescription";
-                FeatureDefinitionProficiencyExtensions.SetProficiencyType(Definition, RuleDefinitions.ProficiencyType.Armor);
+                Definition.SetProficiencyType(RuleDefinitions.ProficiencyType.Armor);
                 Definition.Proficiencies.Add("MediumArmorCategory");
                 Definition.Proficiencies.Add("ShieldCategory");
             }
@@ -121,7 +121,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
 
             private RogueSubclassThugBrutalMethodsActionBuilder(string name, string guid) : base(DatabaseHelper.ActionDefinitions.ShoveBonus, name, guid)
             {
-                ActionDefinitionExtensions.SetId(Definition, (ActionDefinitions.Id)THUG_BONUS_SHOVE_ACTION_ID);
+                Definition.SetId((ActionDefinitions.Id)THUG_BONUS_SHOVE_ACTION_ID);
             }
 
             private static ActionDefinition CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class BloodWitch
     {
-
         public static readonly Guid BLOODW_BASE_GUID = new Guid("c9f680ec-7c79-414f-b700-eebc11863105");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -16,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildBloodMagic()
@@ -89,7 +84,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +93,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +111,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class GreenWitch
     {
-
         public static readonly Guid GW_BASE_GUID = new Guid("5d595308-bcf8-4a9f-a9a0-d2ae85c243e7");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -16,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildGreenMagic()
@@ -89,7 +84,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +93,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +111,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class PurpleWitch
     {
-
         public static readonly Guid PW_BASE_GUID = new Guid("bb8a01e8-7997-4c44-8643-72ac15853b47");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -16,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildPurpleMagic()
@@ -89,7 +84,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +93,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +111,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class RedWitch
     {
-
         public static readonly Guid RW_BASE_GUID = new Guid("3cc83deb-e681-4670-9340-33d08b61f599");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -16,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildRedMagic()
@@ -89,7 +84,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +93,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +111,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class WhiteWitch
     {
-
         public static readonly Guid WW_BASE_GUID = new Guid("2d849694-5cc9-4333-944b-e40cc1e0d0fd");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -16,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildWhiteMagic()
@@ -89,7 +84,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +93,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         private static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +111,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Wizard/LifeTransmuter.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/LifeTransmuter.cs
@@ -186,7 +186,6 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
             RuleDefinitions.TurnOccurenceType endOfEffect, string abilityScore, ConditionDefinition condition,
             string name, GuiPresentation guiPresentation)
         {
-
             EffectDescriptionBuilder effectDescriptionBuilder = new EffectDescriptionBuilder();
             effectDescriptionBuilder.SetTargetingData(RuleDefinitions.Side.Ally, rangeType, rangeParameter, targetType, 1, 0, itemSelectionType);
             effectDescriptionBuilder.SetCreatedByCharacter();

--- a/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
@@ -6,8 +6,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class CharacterDisplay
     {
-
-
         internal static void DisplayCharacter()
         {
             int intValue;
@@ -142,7 +140,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (Main.Settings.DisplayProgressionToggle)
             {
                 UI.Label("");
-
 
                 toggle = Main.Settings.EnablesAsiAndFeat;
                 if (UI.Toggle("Enable both ASI and feat", ref toggle, UI.AutoWidth()))

--- a/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
@@ -4,7 +4,6 @@ using SolastaCommunityExpansion.Subclasses.Rogue;
 using SolastaCommunityExpansion.Subclasses.Wizard;
 using System.Linq;
 
-
 namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class ClassesAndSubclassesDisplay
@@ -233,5 +232,4 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("");
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
@@ -7,8 +7,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class ItemsAndCraftingDisplay
     {
-
-
         private static void AddUIForWeaponKey(string key)
         {
             bool toggle;

--- a/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
@@ -136,7 +136,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 var spellName = spellDefinition.Name;
                 var spellTitle = $"{spellDefinition.SpellLevel} - {spellDefinition.FormatTitle()}";
 
-                if (IsFromOtherModList.ElementAt(i))
+                if (IsFromOtherModList[i])
                 {
                     spellTitle = spellTitle.color(RGBA.brown);
                 }

--- a/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
@@ -20,11 +20,11 @@ namespace SolastaCommunityExpansion.Viewers
 
         private static bool showAttributes;
 
-        private static readonly Dictionary<MonsterDefinition, bool> currentFeaturesMonster = new Dictionary<MonsterDefinition, bool> { };
+        private static readonly Dictionary<MonsterDefinition, bool> currentFeaturesMonster = new Dictionary<MonsterDefinition, bool>();
 
-        private static readonly Dictionary<MonsterDefinition, bool> currentAttacksMonster = new Dictionary<MonsterDefinition, bool> { };
+        private static readonly Dictionary<MonsterDefinition, bool> currentAttacksMonster = new Dictionary<MonsterDefinition, bool>();
 
-        private static readonly Dictionary<RulesetCharacterHero, bool> currentItemsHeroes = new Dictionary<RulesetCharacterHero, bool> { };
+        private static readonly Dictionary<RulesetCharacterHero, bool> currentItemsHeroes = new Dictionary<RulesetCharacterHero, bool>();
 
         private static string SplitCamelCase(string str)
         {
@@ -70,7 +70,7 @@ namespace SolastaCommunityExpansion.Viewers
 
                 currentItemsHeroes.TryGetValue(hero, out flip);
 
-                if (UI.DisclosureToggle($"Inventory", ref flip, 132))
+                if (UI.DisclosureToggle("Inventory", ref flip, 132))
                 {
                     currentItemsHeroes.AddOrReplace<RulesetCharacterHero, bool>(hero, flip);
                 }
@@ -136,7 +136,6 @@ namespace SolastaCommunityExpansion.Viewers
                     UI.Label($"HD: {monsterDefinition.HitDice:0#}{monsterDefinition.HitDiceType}".yellow(), UI.Width(72));
                     UI.Label($"CR: {monsterDefinition.ChallengeRating}".yellow(), UI.Width(72));
                 }
-
 
                 currentAttacksMonster.TryGetValue(monsterDefinition, out flip);
 
@@ -209,7 +208,7 @@ namespace SolastaCommunityExpansion.Viewers
                             UI.Label($"hit bonus: {attackIteration.MonsterAttackDefinition.ToHitBonus}".green(), UI.Width(108));
                             if (attackIteration.MonsterAttackDefinition.MaxUses < 0)
                             {
-                                UI.Label($"max uses: inf".green(), UI.Width(108));
+                                UI.Label("max uses: inf".green(), UI.Width(108));
                             }
                             else
                             {
@@ -217,7 +216,7 @@ namespace SolastaCommunityExpansion.Viewers
                             }
                             if (attackIteration.MonsterAttackDefinition.Magical)
                             {
-                                UI.Label($"MAGICAL".green(), UI.Width(108));
+                                UI.Label("MAGICAL".green(), UI.Width(108));
                             }
                         }
                     }
@@ -297,11 +296,11 @@ namespace SolastaCommunityExpansion.Viewers
                 {
                     if (EncountersSpawnContext.EncounterCharacters[index] is RulesetCharacterMonster rulesetCharacterMonster)
                     {
-                        DisplayMonsterStats(rulesetCharacterMonster.MonsterDefinition, "-", () => { EncountersSpawnContext.RemoveFromEncounter(index); });
+                        DisplayMonsterStats(rulesetCharacterMonster.MonsterDefinition, "-", () => EncountersSpawnContext.RemoveFromEncounter(index));
                     }
                     else if (EncountersSpawnContext.EncounterCharacters[index] is RulesetCharacterHero rulesetCharacterHero)
                     {
-                        DisplayHeroStats(rulesetCharacterHero, "-", () => { EncountersSpawnContext.RemoveFromEncounter(index); });
+                        DisplayHeroStats(rulesetCharacterHero, "-", () => EncountersSpawnContext.RemoveFromEncounter(index));
                     }
                 }
             }
@@ -317,7 +316,7 @@ namespace SolastaCommunityExpansion.Viewers
 
             foreach (var monsterDefinition in EncountersSpawnContext.GetMonsters())
             {
-                DisplayMonsterStats(monsterDefinition, "+", () => { EncountersSpawnContext.AddToEncounter(monsterDefinition); });
+                DisplayMonsterStats(monsterDefinition, "+", () => EncountersSpawnContext.AddToEncounter(monsterDefinition));
             }
         }
 
@@ -331,7 +330,7 @@ namespace SolastaCommunityExpansion.Viewers
 
                 foreach (var hero in EncountersSpawnContext.GetHeroes())
                 {
-                    DisplayHeroStats(hero, "+", () => { EncountersSpawnContext.AddToEncounter(hero); });
+                    DisplayHeroStats(hero, "+", () => EncountersSpawnContext.AddToEncounter(hero));
                 }
             }
         }

--- a/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
@@ -153,9 +153,9 @@ namespace SolastaCommunityExpansion.Viewers
                 collectedString.Append("\n[line]\n");
                 collectedString.Append("[heading]Credits[/heading]\n[list]");
                 collectedString.Append("\n[*]Chris John Digital");
-                foreach (var kvp in Displays.CreditsDisplay.CreditsTable)
+                foreach (var kvp in CreditsTable)
                 {
-                    collectedString.Append("\n[*]" + kvp.Key + ": " + kvp.Value);
+                    collectedString.Append("\n[*]").Append(kvp.Key).Append(": ").Append(kvp.Value);
                 }
                 collectedString.Append("\n[/list]");
                 collectedString.Append("\nSource code on [url=https://github.com/ChrisPJohn/SolastaCommunityExpansion]GitHub[/url].");


### PR DESCRIPTION
And manually move some Tinkerer code around to allow use of static readonly.

Please note there are several of these 
#pragma warning disable S1481 // Unused local variables should be removed
that need sorting

Also there are few files I'm confused about.  For example GameUiContext is showing the addition of 
```
                   case Hotkeys.CTRL_SHIFT_H:
                        GameHud.ShowAll(gameLocationBaseScreen, GetInitiativeOrPartyPanel(), GetTimeAndNavigationPanel());
                        return;
```

which appears to have come from dev.  

The file ArtilleryConstruct_Force has changes I don't remember making.
