### PR TITLE
migrate dmpro

### DIFF
--- a/SolastaCommunityExpansion/Models/DmProEditorContext.cs
+++ b/SolastaCommunityExpansion/Models/DmProEditorContext.cs
@@ -8,7 +8,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class DmProEditorContext
     {
-        private const string GUID = "bff53ba4bb694bf5a69b3ae280eec118";
+        private static readonly System.Guid GUID = new System.Guid("bff53ba4bb694bf5a69b3ae280eec118");
 
         internal static readonly List<string> OutdoorRooms = new List<string>();
 
@@ -77,7 +77,7 @@ namespace SolastaCommunityExpansion.Models
             var flatRoomsCategory = Object.Instantiate(emptyRoomsCategory);
 
             flatRoomsCategory.name = "FlatRooms";
-            flatRoomsCategory.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoomsCategory.name).ToString());
+            flatRoomsCategory.SetGuid(SolastaModApi.GuidHelper.Create(GUID, flatRoomsCategory.name).ToString());
             flatRoomsCategory.GuiPresentation.Title = Gui.Format($"BlueprintCategory/&{flatRoomsCategory.name}Title").yellow();
             dbBlueprintCategory.Add(flatRoomsCategory);
 
@@ -90,7 +90,7 @@ namespace SolastaCommunityExpansion.Models
                     var categoryName = blueprintCategory.Name + "~" + environmentName + "~MOD";
 
                     newBlueprintCategory.name = categoryName;
-                    newBlueprintCategory.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newBlueprintCategory.name).ToString());
+                    newBlueprintCategory.SetGuid(SolastaModApi.GuidHelper.Create(GUID, newBlueprintCategory.name).ToString());
                     newBlueprintCategory.GuiPresentation.Title = Gui.Format(blueprintCategory.GuiPresentation.Title) + " " + Gui.Format(environmentDefinition.GuiPresentation.Title) + " [MODDED]".yellow();
                     categories.Add(newBlueprintCategory);
                 }
@@ -121,7 +121,7 @@ namespace SolastaCommunityExpansion.Models
                 var flatRoom = Object.Instantiate(dbRoomBlueprint.GetElement(template));
 
                 flatRoom.name = $"Flat{multiplier:D2}Room";
-                flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoom.name).ToString());
+                flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(GUID, flatRoom.name).ToString());
                 flatRoom.GuiPresentation.Title = "Flat".yellow() + " Room";
                 flatRoom.GuiPresentation.SetSortOrder(multiplier);
                 flatRoom.GuiPresentation.SetHidden(true);
@@ -146,7 +146,7 @@ namespace SolastaCommunityExpansion.Models
             var flatRoom = Object.Instantiate(dbRoomBlueprint.GetElement(template));
 
             flatRoom.name = "Flat" + template;
-            flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoom.name).ToString());
+            flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(GUID, flatRoom.name).ToString());
             flatRoom.GuiPresentation.Title = "Flat".yellow() + " " + Gui.Format(flatRoom.GuiPresentation.Title);
             flatRoom.GuiPresentation.SetSortOrder(sortOrder);
             flatRoom.GuiPresentation.SetHidden(true);
@@ -179,7 +179,7 @@ namespace SolastaCommunityExpansion.Models
                     var categoryName = gadgetBlueprint.Category + "~" + environmentName + "~MOD";
 
                     newGadgetBlueprint.name = gadgetBlueprint.Name + "~" + environmentName + "~MOD";
-                    newGadgetBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newGadgetBlueprint.name).ToString());
+                    newGadgetBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(GUID, newGadgetBlueprint.name).ToString());
                     newGadgetBlueprint.GuiPresentation.Title = Gui.Format(gadgetBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
                     newGadgetBlueprint.SetCategory(categoryName);
                     newGadgetBlueprint.PrefabsByEnvironment.Clear();
@@ -217,7 +217,7 @@ namespace SolastaCommunityExpansion.Models
                     var categoryName = propBlueprint.Category + "~" + environmentName + "~MOD";
 
                     newPropBlueprint.name = propBlueprint.Name + "~" + environmentName + "~MOD";
-                    newPropBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newPropBlueprint.name).ToString());
+                    newPropBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(GUID, newPropBlueprint.name).ToString());
                     newPropBlueprint.GuiPresentation.Title = Gui.Format(propBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
                     newPropBlueprint.SetCategory(categoryName);
                     newPropBlueprint.PrefabsByEnvironment.Clear();
@@ -245,46 +245,43 @@ namespace SolastaCommunityExpansion.Models
             var dbEnvironmentDefinition = DatabaseRepository.GetDatabase<EnvironmentDefinition>();
             var newRooms = new List<RoomBlueprint>();
 
-            foreach (var roomBlueprint in dbRoomBlueprint)
+            foreach (var roomBlueprint in dbRoomBlueprint
+                .Where(x => x.Category == "EmptyRooms" || x.Category == "FlatRooms"))
             {
-                if (roomBlueprint.Category == "EmptyRooms" || roomBlueprint.Category == "FlatRooms")
+                foreach (var prefabByEnvironment in roomBlueprint.PrefabsByEnvironment
+                    .Where(x => x.Environment != string.Empty))
                 {
-                    foreach (var prefabByEnvironment in roomBlueprint.PrefabsByEnvironment.Where(x => x.Environment != string.Empty))
-                    {
-                        var environmentName = prefabByEnvironment.Environment;
-                        var prefabEnvironmentDefinition = dbEnvironmentDefinition.GetElement(environmentName);
-                        var newRoomBlueprint = Object.Instantiate(roomBlueprint);
-                        var categoryName = roomBlueprint.Category + "~" + environmentName + "~MOD";
+                    var environmentName = prefabByEnvironment.Environment;
+                    var prefabEnvironmentDefinition = dbEnvironmentDefinition.GetElement(environmentName);
+                    var newRoomBlueprint = Object.Instantiate(roomBlueprint);
+                    var categoryName = roomBlueprint.Category + "~" + environmentName + "~MOD";
 
-                        if (prefabEnvironmentDefinition.Outdoor)
+                    newRoomBlueprint.name = roomBlueprint.Name + "~" + environmentName + "~MOD";
+                    newRoomBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(GUID, newRoomBlueprint.name).ToString());
+                    newRoomBlueprint.GuiPresentation.Title = Gui.Format(roomBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
+                    newRoomBlueprint.SetCategory(categoryName);
+                    newRoomBlueprint.GuiPresentation.SetHidden(false);
+                    newRoomBlueprint.PrefabsByEnvironment.Clear();
+
+                    foreach (var environmentDefinition in dbEnvironmentDefinition
+                        .Where(x => !prefabEnvironmentDefinition.Outdoor || x.Outdoor))
+                    {
+                        var myPrefabByEnvironment = new BaseBlueprint.PrefabByEnvironmentDescription();
+
+                        myPrefabByEnvironment.SetEnvironment(environmentDefinition.name);
+                        myPrefabByEnvironment.SetPrefabReference(prefabByEnvironment.PrefabReference);
+                        newRoomBlueprint.PrefabsByEnvironment.Add(myPrefabByEnvironment);
+                    }
+
+                    newRooms.Add(newRoomBlueprint);
+
+                    if (prefabEnvironmentDefinition.Outdoor)
+                    {
+                        OutdoorRooms.Add(newRoomBlueprint.Name);
+
+                        if (!OutdoorRooms.Contains(roomBlueprint.Name))
                         {
                             OutdoorRooms.Add(roomBlueprint.Name);
-                        }
-
-                        newRoomBlueprint.name = roomBlueprint.Name + "~" + environmentName + "~MOD";
-                        newRoomBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newRoomBlueprint.name).ToString());
-                        newRoomBlueprint.GuiPresentation.Title = Gui.Format(roomBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
-                        newRoomBlueprint.SetCategory(categoryName);
-                        newRoomBlueprint.GuiPresentation.SetHidden(false);
-                        newRoomBlueprint.PrefabsByEnvironment.Clear();
-
-                        foreach (var environmentDefinition in dbEnvironmentDefinition)
-                        {
-                            if (!prefabEnvironmentDefinition.Outdoor || environmentDefinition.Outdoor)
-                            {
-                                var myPrefabByEnvironment = new BaseBlueprint.PrefabByEnvironmentDescription();
-
-                                myPrefabByEnvironment.SetEnvironment(environmentDefinition.name);
-                                myPrefabByEnvironment.SetPrefabReference(prefabByEnvironment.PrefabReference);
-                                newRoomBlueprint.PrefabsByEnvironment.Add(myPrefabByEnvironment);
-                            }
-                        }
-
-                        newRooms.Add(newRoomBlueprint);
-
-                        if (prefabEnvironmentDefinition.Outdoor)
-                        {
-                            OutdoorRooms.Add(newRoomBlueprint.Name);
                         }
                     }
                 }
@@ -298,22 +295,31 @@ namespace SolastaCommunityExpansion.Models
         {
             var dbGadgetBlueprint = DatabaseRepository.GetDatabase<GadgetBlueprint>();
 
-            dbGadgetBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+            dbGadgetBlueprint
+                .Where(x => x.Name.EndsWith("MOD")).ToList()
+                .ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
         }
 
         private static void SetModdedPropsHiddenStatus()
         {
             var dbPropBlueprint = DatabaseRepository.GetDatabase<PropBlueprint>();
 
-            dbPropBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+            dbPropBlueprint
+                .Where(x => x.Name.EndsWith("MOD")).ToList()
+                .ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
         }
 
         private static void SetModdedRoomsHiddenStatus()
         {
             var dbRoomBlueprint = DatabaseRepository.GetDatabase<RoomBlueprint>();
 
-            dbRoomBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
-            dbRoomBlueprint.Where(x => x.Name.StartsWith("Flat")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+            dbRoomBlueprint
+                .Where(x => x.Name.EndsWith("MOD")).ToList()
+                .ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+
+            dbRoomBlueprint
+                .Where(x => x.Name.StartsWith("Flat")).ToList()
+                .ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
         }
     }
 }

--- a/SolastaCommunityExpansion/Models/DmProEditorContext.cs
+++ b/SolastaCommunityExpansion/Models/DmProEditorContext.cs
@@ -1,0 +1,319 @@
+﻿using ModKit;
+using SolastaModApi.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Models
+{
+    internal static class DmProEditorContext
+    {
+        private const string GUID = "bff53ba4bb694bf5a69b3ae280eec118";
+
+        internal static readonly List<string> OutdoorRooms = new List<string>();
+
+        internal enum ExtendedDungeonSize
+        {
+            Huge = UserLocationDefinitions.Size.Large + 1,
+            Gargantuan
+        }
+
+        internal static void Load()
+        {
+            if (!Main.Settings.EnableDungeonMakerPro)
+            {
+                return;
+            }
+
+            UpdateAvailableDungeonSizes();
+            UpdateCategories();
+            LoadFlatRooms();
+            UnleashGadgetsOnAllEnvironments();
+            UnleashPropsOnAllEnvironments();
+            UnleashRoomsOnAllEnvironments();
+        }
+
+        internal static int Compare(BaseBlueprint left, BaseBlueprint right)
+        {
+            var leftCategory = DatabaseRepository.GetDatabase<BlueprintCategory>().GetElement(left.Category);
+            var rightCategory = DatabaseRepository.GetDatabase<BlueprintCategory>().GetElement(right.Category);
+            var result = leftCategory.FormatTitle().CompareTo(rightCategory.FormatTitle());
+
+            if (result == 0)
+            {
+                result = left.FormatTitle().CompareTo(right.FormatTitle());
+
+                if (result == 0)
+                {
+                    result = left.GuiPresentation.SortOrder - right.GuiPresentation.SortOrder;
+                }
+            }
+
+            return result;
+        }
+
+        private static void UpdateAvailableDungeonSizes()
+        {
+            var customDungeonSizes = new Dictionary<UserLocationDefinitions.Size, int>
+            {
+                { (UserLocationDefinitions.Size) ExtendedDungeonSize.Huge, 150 },
+                { (UserLocationDefinitions.Size) ExtendedDungeonSize.Gargantuan, 200 }
+            };
+
+            UserLocationDefinitions.CellsBySize[UserLocationDefinitions.Size.Medium] = 75;
+
+            foreach (var kvp in customDungeonSizes)
+            {
+                UserLocationDefinitions.CellsBySize.Add(kvp.Key, kvp.Value);
+            }
+        }
+
+        private static void UpdateCategories()
+        {
+            var categories = new List<BlueprintCategory>();
+            var dbBlueprintCategory = DatabaseRepository.GetDatabase<BlueprintCategory>();
+            var dbEnvironmentDefinition = DatabaseRepository.GetDatabase<EnvironmentDefinition>();
+            var emptyRoomsCategory = dbBlueprintCategory.GetElement("EmptyRooms");
+            var flatRoomsCategory = Object.Instantiate(emptyRoomsCategory);
+
+            flatRoomsCategory.name = "FlatRooms";
+            flatRoomsCategory.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoomsCategory.name).ToString());
+            flatRoomsCategory.GuiPresentation.Title = Gui.Format($"BlueprintCategory/&{flatRoomsCategory.name}Title").yellow();
+            dbBlueprintCategory.Add(flatRoomsCategory);
+
+            foreach (var blueprintCategory in dbBlueprintCategory)
+            {
+                foreach (var environmentDefinition in dbEnvironmentDefinition)
+                {
+                    var newBlueprintCategory = Object.Instantiate(blueprintCategory);
+                    var environmentName = environmentDefinition.Name;
+                    var categoryName = blueprintCategory.Name + "~" + environmentName + "~MOD";
+
+                    newBlueprintCategory.name = categoryName;
+                    newBlueprintCategory.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newBlueprintCategory.name).ToString());
+                    newBlueprintCategory.GuiPresentation.Title = Gui.Format(blueprintCategory.GuiPresentation.Title) + " " + Gui.Format(environmentDefinition.GuiPresentation.Title) + " [MODDED]".yellow();
+                    categories.Add(newBlueprintCategory);
+                }
+            }
+
+            categories.ForEach(x => dbBlueprintCategory.Add(x));
+        }
+
+        private static void LoadFlatRooms()
+        {
+            if (!Main.Settings.EnableDungeonMakerModdedContent)
+            {
+                return;
+            }
+
+            CreateFlatRooms(12); // from 12x12 to 144x144
+            CreateSpecialFlatRoom("Drain_Big_24C_A", 12 + 1);
+            CreateSpecialFlatRoom("Drain_Big_24C_B", 12 + 2);
+        }
+
+        private static void CreateFlatRooms(int maxMultiplier)
+        {
+            var template = "Crossroad_12C";
+            var dbRoomBlueprint = DatabaseRepository.GetDatabase<RoomBlueprint>();
+
+            for (var multiplier = 1; multiplier <= maxMultiplier; multiplier++)
+            {
+                var flatRoom = Object.Instantiate(dbRoomBlueprint.GetElement(template));
+
+                flatRoom.name = $"Flat{multiplier:D2}Room";
+                flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoom.name).ToString());
+                flatRoom.GuiPresentation.Title = "Flat".yellow() + " Room";
+                flatRoom.GuiPresentation.SetSortOrder(multiplier);
+                flatRoom.GuiPresentation.SetHidden(true);
+                flatRoom.SetCategory("FlatRooms");
+                flatRoom.SetDimensions(new Vector2Int(flatRoom.Dimensions.x * multiplier, flatRoom.Dimensions.y * multiplier));
+                flatRoom.SetCellInfos(new int[flatRoom.Dimensions.x * flatRoom.Dimensions.y]);
+                flatRoom.SetWallSpriteReference(new UnityEngine.AddressableAssets.AssetReferenceSprite(""));
+                flatRoom.SetWallAndOpeningSpriteReference(new UnityEngine.AddressableAssets.AssetReferenceSprite(""));
+
+                for (var i = 0; i < flatRoom.CellInfos.Length; i++)
+                {
+                    flatRoom.CellInfos[i] = 1;
+                }
+
+                dbRoomBlueprint.Add(flatRoom);
+            }
+        }
+
+        private static void CreateSpecialFlatRoom(string template, int sortOrder)
+        {
+            var dbRoomBlueprint = DatabaseRepository.GetDatabase<RoomBlueprint>();
+            var flatRoom = Object.Instantiate(dbRoomBlueprint.GetElement(template));
+
+            flatRoom.name = "Flat" + template;
+            flatRoom.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), flatRoom.name).ToString());
+            flatRoom.GuiPresentation.Title = "Flat".yellow() + " " + Gui.Format(flatRoom.GuiPresentation.Title);
+            flatRoom.GuiPresentation.SetSortOrder(sortOrder);
+            flatRoom.GuiPresentation.SetHidden(true);
+            flatRoom.SetCategory("FlatRooms");
+
+            for (var i = 0; i < flatRoom.CellInfos.Length; i++)
+            {
+                if (flatRoom.CellInfos[i] == 2 || flatRoom.CellInfos[i] == 3)
+                {
+                    flatRoom.CellInfos[i] = 1;
+                }
+            }
+
+            dbRoomBlueprint.Add(flatRoom);
+        }
+
+        private static void UnleashGadgetsOnAllEnvironments()
+        {
+            var dbGadgetBlueprint = DatabaseRepository.GetDatabase<GadgetBlueprint>();
+            var dbEnvironmentDefinition = DatabaseRepository.GetDatabase<EnvironmentDefinition>();
+            var newGadgets = new List<GadgetBlueprint>();
+
+            foreach (var gadgetBlueprint in dbGadgetBlueprint)
+            {
+                foreach (var prefabByEnvironment in gadgetBlueprint.PrefabsByEnvironment.Where(x => x.Environment != string.Empty))
+                {
+                    var environmentName = prefabByEnvironment.Environment;
+                    var prefabEnvironmentDefinition = dbEnvironmentDefinition.GetElement(environmentName);
+                    var newGadgetBlueprint = Object.Instantiate(gadgetBlueprint);
+                    var categoryName = gadgetBlueprint.Category + "~" + environmentName + "~MOD";
+
+                    newGadgetBlueprint.name = gadgetBlueprint.Name + "~" + environmentName + "~MOD";
+                    newGadgetBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newGadgetBlueprint.name).ToString());
+                    newGadgetBlueprint.GuiPresentation.Title = Gui.Format(gadgetBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
+                    newGadgetBlueprint.SetCategory(categoryName);
+                    newGadgetBlueprint.PrefabsByEnvironment.Clear();
+
+                    foreach (var environmentDefinition in dbEnvironmentDefinition)
+                    {
+                        var myPrefabByEnvironment = new BaseBlueprint.PrefabByEnvironmentDescription();
+
+                        myPrefabByEnvironment.SetEnvironment(environmentDefinition.name);
+                        myPrefabByEnvironment.SetPrefabReference(prefabByEnvironment.PrefabReference);
+                        newGadgetBlueprint.PrefabsByEnvironment.Add(myPrefabByEnvironment);
+                    }
+
+                    newGadgets.Add(newGadgetBlueprint);
+                }
+            }
+
+            newGadgets.ForEach(x => dbGadgetBlueprint.Add(x));
+            SetModdedGadgetsHiddenStatus();
+        }
+
+        private static void UnleashPropsOnAllEnvironments()
+        {
+            var dbPropBlueprint = DatabaseRepository.GetDatabase<PropBlueprint>();
+            var dbEnvironmentDefinition = DatabaseRepository.GetDatabase<EnvironmentDefinition>();
+            var newProps = new List<PropBlueprint>();
+
+            foreach (var propBlueprint in dbPropBlueprint)
+            {
+                foreach (var prefabByEnvironment in propBlueprint.PrefabsByEnvironment.Where(x => x.Environment != string.Empty))
+                {
+                    var environmentName = prefabByEnvironment.Environment;
+                    var prefabEnvironmentDefinition = dbEnvironmentDefinition.GetElement(environmentName);
+                    var newPropBlueprint = Object.Instantiate(propBlueprint);
+                    var categoryName = propBlueprint.Category + "~" + environmentName + "~MOD";
+
+                    newPropBlueprint.name = propBlueprint.Name + "~" + environmentName + "~MOD";
+                    newPropBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newPropBlueprint.name).ToString());
+                    newPropBlueprint.GuiPresentation.Title = Gui.Format(propBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
+                    newPropBlueprint.SetCategory(categoryName);
+                    newPropBlueprint.PrefabsByEnvironment.Clear();
+
+                    foreach (EnvironmentDefinition environmentDefinition in dbEnvironmentDefinition)
+                    {
+                        var myPrefabByEnvironment = new BaseBlueprint.PrefabByEnvironmentDescription();
+
+                        myPrefabByEnvironment.SetEnvironment(environmentDefinition.name);
+                        myPrefabByEnvironment.SetPrefabReference(prefabByEnvironment.PrefabReference);
+                        newPropBlueprint.PrefabsByEnvironment.Add(myPrefabByEnvironment);
+                    }
+
+                    newProps.Add(newPropBlueprint);
+                }
+            }
+
+            newProps.ForEach(x => dbPropBlueprint.Add(x));
+            SetModdedPropsHiddenStatus();
+        }
+
+        private static void UnleashRoomsOnAllEnvironments()
+        {
+            var dbRoomBlueprint = DatabaseRepository.GetDatabase<RoomBlueprint>();
+            var dbEnvironmentDefinition = DatabaseRepository.GetDatabase<EnvironmentDefinition>();
+            var newRooms = new List<RoomBlueprint>();
+
+            foreach (var roomBlueprint in dbRoomBlueprint)
+            {
+                if (roomBlueprint.Category == "EmptyRooms" || roomBlueprint.Category == "FlatRooms")
+                {
+                    foreach (var prefabByEnvironment in roomBlueprint.PrefabsByEnvironment.Where(x => x.Environment != string.Empty))
+                    {
+                        var environmentName = prefabByEnvironment.Environment;
+                        var prefabEnvironmentDefinition = dbEnvironmentDefinition.GetElement(environmentName);
+                        var newRoomBlueprint = Object.Instantiate(roomBlueprint);
+                        var categoryName = roomBlueprint.Category + "~" + environmentName + "~MOD";
+
+                        if (prefabEnvironmentDefinition.Outdoor)
+                        {
+                            OutdoorRooms.Add(roomBlueprint.Name);
+                        }
+
+                        newRoomBlueprint.name = roomBlueprint.Name + "~" + environmentName + "~MOD";
+                        newRoomBlueprint.SetGuid(SolastaModApi.GuidHelper.Create(new System.Guid(GUID), newRoomBlueprint.name).ToString());
+                        newRoomBlueprint.GuiPresentation.Title = Gui.Format(roomBlueprint.GuiPresentation.Title) + " " + Gui.Format(prefabEnvironmentDefinition.GuiPresentation.Title).yellow();
+                        newRoomBlueprint.SetCategory(categoryName);
+                        newRoomBlueprint.GuiPresentation.SetHidden(false);
+                        newRoomBlueprint.PrefabsByEnvironment.Clear();
+
+                        foreach (var environmentDefinition in dbEnvironmentDefinition)
+                        {
+                            if (!prefabEnvironmentDefinition.Outdoor || environmentDefinition.Outdoor)
+                            {
+                                var myPrefabByEnvironment = new BaseBlueprint.PrefabByEnvironmentDescription();
+
+                                myPrefabByEnvironment.SetEnvironment(environmentDefinition.name);
+                                myPrefabByEnvironment.SetPrefabReference(prefabByEnvironment.PrefabReference);
+                                newRoomBlueprint.PrefabsByEnvironment.Add(myPrefabByEnvironment);
+                            }
+                        }
+
+                        newRooms.Add(newRoomBlueprint);
+
+                        if (prefabEnvironmentDefinition.Outdoor)
+                        {
+                            OutdoorRooms.Add(newRoomBlueprint.Name);
+                        }
+                    }
+                }
+            }
+
+            newRooms.ForEach(x => dbRoomBlueprint.Add(x));
+            SetModdedRoomsHiddenStatus();
+        }
+
+        private static void SetModdedGadgetsHiddenStatus()
+        {
+            var dbGadgetBlueprint = DatabaseRepository.GetDatabase<GadgetBlueprint>();
+
+            dbGadgetBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+        }
+
+        private static void SetModdedPropsHiddenStatus()
+        {
+            var dbPropBlueprint = DatabaseRepository.GetDatabase<PropBlueprint>();
+
+            dbPropBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+        }
+
+        private static void SetModdedRoomsHiddenStatus()
+        {
+            var dbRoomBlueprint = DatabaseRepository.GetDatabase<RoomBlueprint>();
+
+            dbRoomBlueprint.Where(x => x.Name.EndsWith("MOD")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+            dbRoomBlueprint.Where(x => x.Name.StartsWith("Flat")).ToList().ForEach(y => y.GuiPresentation.SetHidden(!Main.Settings.EnableDungeonMakerModdedContent));
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Models/DmProRendererContext.cs
+++ b/SolastaCommunityExpansion/Models/DmProRendererContext.cs
@@ -1,0 +1,217 @@
+﻿using AwesomeTechnologies;
+using AwesomeTechnologies.VegetationSystem;
+using AwesomeTechnologies.VegetationSystem.Biomes;
+using SolastaModApi.Infrastructure;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace SolastaCommunityExpansion.Models
+{
+    internal static class DmProRendererContext
+    {
+        //
+        // all public methods on this class are referenced from WorldLocationPatcher transpiler. keep them public
+        //
+
+        private const int MARGIN = 25;
+        private const int FLAT_ROOM_SIZE = 12;
+        private const string FLAT_ROOM_TAG = "Flat";
+
+        private static VegetationMaskArea TemplateVegetationMaskArea { get; set; }
+
+        private static bool IsFlatRoom(UserRoom userRoom) => userRoom.RoomBlueprint.name.StartsWith(FLAT_ROOM_TAG);
+
+        private static bool IsDynamicFlatRoom(UserRoom userRoom) => IsFlatRoom(userRoom) && int.TryParse(userRoom.RoomBlueprint.name.Substring(FLAT_ROOM_TAG.Length, 2), out int _);
+
+        public static void GetTemplateVegetationMaskArea(WorldLocation worldLocation)
+        {
+            var prefabByReference = worldLocation.GetField<WorldLocation, Dictionary<AssetReference, GameObject>>("prefabByReference");
+
+            foreach (var prefab in prefabByReference.Values)
+            {
+                TemplateVegetationMaskArea = prefab.GetComponentInChildren<VegetationMaskArea>();
+
+                if (TemplateVegetationMaskArea != null)
+                {
+                    break;
+                }
+            }
+        }
+
+        public static void SetupLocationTerrain(WorldLocation worldLocation, UserLocation userLocation)
+        {
+            var masterTerrain = worldLocation.gameObject.GetComponentInChildren<Terrain>();
+
+            if (masterTerrain == null)
+            {
+                return;
+            }
+
+            // calculates inverted heights in map coordinates
+            var locationSize = UserLocationDefinitions.CellsBySize[userLocation.Size];
+            var mapHeights = new int[locationSize + MARGIN * 2, locationSize + MARGIN * 2];
+
+            foreach (var userRoom in userLocation.UserRooms)
+            {
+                var isIndoor = !DmProEditorContext.OutdoorRooms.Contains(userRoom.RoomBlueprint.name);
+                var border = 2;
+                var px = userRoom.Position.x;
+                var py = userRoom.Position.y;
+                var oh = userRoom.OrientedHeight;
+                var ow = userRoom.OrientedWidth;
+
+                for (var x = 0; x < ow; x++)
+                {
+                    for (var y = 0; y < oh; y++)
+                    {
+                        var lowGround = isIndoor && (x >= border && x <= ow - border && y >= border && y <= oh - border || userRoom.GetCellType(x, y) == RoomBlueprint.CellType.GroundLow);
+
+                        mapHeights[MARGIN + px + x, MARGIN + py + y] = lowGround ? 1 : 0;
+                    }
+                }
+            }
+
+            // calculates heights in terrain data coordinates
+            var resolution = masterTerrain.terrainData.heightmapResolution;
+            var heights = new float[resolution, resolution];
+
+            for (var y = 0; y < resolution; y++)
+            {
+                for (var x = 0; x < resolution; x++)
+                {
+                    var sx = (int)System.Math.Round(x * (locationSize + MARGIN * 2f - 1f) / (resolution - 1f));
+                    var sy = (int)System.Math.Round(y * (locationSize + MARGIN * 2f - 1f) / (resolution - 1f));
+
+                    heights[y, x] = 1 - mapHeights[sx, sy];
+                }
+            }
+
+            // adjusts terrain to new settings
+            masterTerrain.terrainData = TerrainDataCloner.Clone(masterTerrain.terrainData);
+            masterTerrain.terrainData.size = new Vector3(locationSize + MARGIN * 2f, 5f, locationSize + MARGIN * 2f);
+            masterTerrain.terrainData.SetHeights(0, 0, heights);
+            masterTerrain.transform.position = new Vector3(masterTerrain.transform.position.x, -5.01f, masterTerrain.transform.position.z);
+
+            worldLocation.GetField<WorldLocation, List<TerrainData>>("duplicatedTerrainData").Add(masterTerrain.terrainData);
+
+            // updates the biome to cover the entire location
+            var biomeMaskArea = worldLocation.gameObject.GetComponentInChildren<BiomeMaskArea>();
+
+            if (biomeMaskArea == null)
+            {
+                return;
+            }
+
+            biomeMaskArea.ClearNodes();
+            biomeMaskArea.AddNode(biomeMaskArea.transform.InverseTransformDirection(new Vector3(-MARGIN, 0, locationSize + MARGIN)));
+            biomeMaskArea.AddNode(biomeMaskArea.transform.InverseTransformDirection(new Vector3(-MARGIN, 0, -MARGIN)));
+            biomeMaskArea.AddNode(biomeMaskArea.transform.InverseTransformDirection(new Vector3(locationSize + MARGIN, 0, -MARGIN)));
+            biomeMaskArea.AddNode(biomeMaskArea.transform.InverseTransformDirection(new Vector3(locationSize + MARGIN, 0, locationSize + MARGIN)));
+            biomeMaskArea.UpdateBiomeMask();
+            worldLocation.gameObject.GetComponentInChildren<VegetationSystemPro>()?.CalculateVegetationSystemBounds();
+        }
+
+        public static void SetupFlatRooms(Transform roomTransform, UserRoom userRoom)
+        {
+            void DisableWalls(Transform transform)
+            {
+                for (int i = 0; i < transform.childCount; i++)
+                {
+                    DisableWalls(transform.GetChild(i));
+                }
+
+                var name = transform.gameObject.name;
+
+                if ((name.Contains("Wall") && !name.Contains("Drain")) || name.Contains("Column") || name.Contains("DM_Dirt_Pack"))
+                {
+                    // need to keep parents around otherwise pure flat locations don't render correctly
+                    if (transform.childCount > 0)
+                    {
+                        transform.position = new Vector3(-1f, 0f, -1f);
+                    }
+                    else
+                    {
+                        transform.gameObject.SetActive(false);
+                    }
+                }
+            }
+
+            if (!IsFlatRoom(userRoom))
+            {
+                return;
+            }
+
+            DisableWalls(roomTransform);
+
+            if (int.TryParse(userRoom.RoomBlueprint.name.Substring(FLAT_ROOM_TAG.Length, 2), out int multiplier))
+            {
+                var rnd = new System.Random();
+
+                roomTransform.position = new Vector3(roomTransform.position.x - (multiplier - 1) * FLAT_ROOM_SIZE / 2, 0, roomTransform.position.z - (multiplier - 1) * FLAT_ROOM_SIZE / 2);
+
+                for (var x = 0; x < multiplier; x++)
+                {
+                    for (var z = 0; z < multiplier; z++)
+                    {
+                        if (x > 0 || z > 0)
+                        {
+                            // placing textures using a random angle to remove the repetition feeling a bit
+                            var angle = LocationDefinitions.OrientationToAngle((LocationDefinitions.Orientation)rnd.Next(0, 3));
+                            var newRoom = Object.Instantiate(roomTransform.gameObject, new Vector3(roomTransform.position.x + FLAT_ROOM_SIZE * x, 0, roomTransform.position.z + FLAT_ROOM_SIZE * z), Quaternion.identity, roomTransform.parent);
+
+                            newRoom.transform.rotation = Quaternion.Euler(0, angle, 0);
+                        }
+                    }
+                }
+
+                // adds a hint to fix the reflection probe later on
+                roomTransform.name = FLAT_ROOM_TAG + roomTransform.name;
+            }
+        }
+
+        public static void AddVegetationMaskArea(Transform roomTransform, UserRoom userRoom)
+        {
+            if (TemplateVegetationMaskArea == null || DmProEditorContext.OutdoorRooms.Contains(userRoom.RoomBlueprint.name))
+            {
+                return;
+            }
+
+            var vegetationMaskArea = Object.Instantiate(TemplateVegetationMaskArea, roomTransform);
+            var sizex = userRoom.OrientedWidth;
+            var sizey = userRoom.OrientedHeight;
+
+            // exceptional case here as the mask must be a constant size in this case as the vegetation mask object will get re-instantiated later
+            if (IsDynamicFlatRoom(userRoom))
+            {
+                sizex = FLAT_ROOM_SIZE;
+                sizey = FLAT_ROOM_SIZE;
+            }
+
+            vegetationMaskArea.transform.position = new Vector3(userRoom.Position.x + sizex / 2f, 0, userRoom.Position.y + sizey / 2f);
+            vegetationMaskArea.AdditionalGrassPerimiter = 0;
+            vegetationMaskArea.RemoveGrass = true;
+            vegetationMaskArea.RemoveLargeObjects = true;
+            vegetationMaskArea.RemoveObjects = true;
+            vegetationMaskArea.RemovePlants = true;
+            vegetationMaskArea.RemoveTrees = true;
+            vegetationMaskArea.ClearNodes();
+            vegetationMaskArea.AddNode(new Vector3(-sizex / 2f, 0, -sizey / 2f));
+            vegetationMaskArea.AddNode(new Vector3(-sizex / 2f, 0, +sizey / 2f));
+            vegetationMaskArea.AddNode(new Vector3(+sizex / 2f, 0, +sizey / 2f));
+            vegetationMaskArea.AddNode(new Vector3(+sizex / 2f, 0, -sizey / 2f));
+            vegetationMaskArea.UpdateVegetationMask();
+        }
+
+        public static void FixFlatRoomReflectionProbe(WorldLocation worldLocation)
+        {
+            var reflectionProbes = worldLocation.GetComponentsInChildren<ReflectionProbe>();
+
+            foreach (var reflectionProbe in reflectionProbes.Where(x => x.transform.parent.name.StartsWith(FLAT_ROOM_TAG)))
+            {
+                reflectionProbe.transform.position = new Vector3(reflectionProbe.size.x / 2f, reflectionProbe.size.y, reflectionProbe.size.z / 2f);
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/GadgetBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/GadgetBlueprintSelectionPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {
     // better gadget sorting
     [HarmonyPatch(typeof(GadgetBlueprintSelectionPanel), "Compare")]
-    internal static class GadgetBlueprintSelectionPanelCompare
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class GadgetBlueprintSelectionPanel_Compare
     {
         internal static bool Prefix(GadgetBlueprint left, GadgetBlueprint right, ref int __result)
         {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/GadgetBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/GadgetBlueprintSelectionPanelPatcher.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker
+{
+    // better gadget sorting
+    [HarmonyPatch(typeof(GadgetBlueprintSelectionPanel), "Compare")]
+    internal static class GadgetBlueprintSelectionPanelCompare
+    {
+        internal static bool Prefix(GadgetBlueprint left, GadgetBlueprint right, ref int __result)
+        {
+            if (!Main.Settings.EnableSortingDungeonMakerAssets)
+            {
+                return true;
+            }
+
+            __result = Models.DmProEditorContext.Compare(left, right);
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintPatcher.cs
@@ -1,51 +1,50 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
 {
-    internal static class BaseBlueprintPatcher
+    // ensures custom props display the proper icon
+    [HarmonyPatch(typeof(BaseBlueprint), "GetAssetKey")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class BaseBlueprint_GetAssetKey
     {
-        // ensures custom props display the proper icon
-        [HarmonyPatch(typeof(BaseBlueprint), "GetAssetKey")]
-        internal static class BaseBlueprintGetAssetKey
+        internal static bool Prefix(
+            BaseBlueprint __instance,
+            ref string __result,
+            BaseBlueprint.PrefabByEnvironmentDescription prefabByEnvironmentDescription,
+            EnvironmentDefinition environmentDefinition,
+            bool perspective)
         {
-            internal static bool Prefix(
-                BaseBlueprint __instance,
-                ref string __result,
-                BaseBlueprint.PrefabByEnvironmentDescription prefabByEnvironmentDescription,
-                EnvironmentDefinition environmentDefinition,
-                bool perspective)
+            if (!Main.Settings.EnableDungeonMakerPro
+                || !Main.Settings.EnableDungeonMakerModdedContent
+                || !(__instance is PropBlueprint propBlueprint)
+                || !propBlueprint.Name.EndsWith("MOD"))
             {
-                if (!Main.Settings.EnableDungeonMakerPro
-                    || !Main.Settings.EnableDungeonMakerModdedContent
-                    || !(__instance is PropBlueprint propBlueprint)
-                    || !propBlueprint.Name.EndsWith("MOD"))
-                {
-                    return true;
-                }
-
-                var a = propBlueprint.Name.Split(new[] { '~' }, 3);
-
-                if (a.Length != 3)
-                {
-                    return true;
-                }
-
-                var propName = a[0];
-                var environmentName = a[1];
-                var str1 = "Gui/Bitmaps/Blueprints/Props/";
-                var str2 = "User_Props_" + propName;
-                var postfix = (perspective ? "_Pers" : "_Top");
-
-                if (environmentDefinition != null && prefabByEnvironmentDescription.Environment == environmentDefinition.Name)
-                {
-                    str1 += environmentName + "/";
-                    str2 += "_" + environmentName;
-                }
-
-                __result = str1 + str2 + postfix;
-
-                return false;
+                return true;
             }
+
+            var a = propBlueprint.Name.Split(new[] { '~' }, 3);
+
+            if (a.Length != 3)
+            {
+                return true;
+            }
+
+            var propName = a[0];
+            var environmentName = a[1];
+            var str1 = "Gui/Bitmaps/Blueprints/Props/";
+            var str2 = "User_Props_" + propName;
+            var postfix = (perspective ? "_Pers" : "_Top");
+
+            if (environmentDefinition != null && prefabByEnvironmentDescription.Environment == environmentDefinition.Name)
+            {
+                str1 += environmentName + "/";
+                str2 += "_" + environmentName;
+            }
+
+            __result = str1 + str2 + postfix;
+
+            return false;
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintPatcher.cs
@@ -1,0 +1,51 @@
+﻿using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
+{
+    internal static class BaseBlueprintPatcher
+    {
+        // ensures custom props display the proper icon
+        [HarmonyPatch(typeof(BaseBlueprint), "GetAssetKey")]
+        internal static class BaseBlueprintGetAssetKey
+        {
+            internal static bool Prefix(
+                BaseBlueprint __instance,
+                ref string __result,
+                BaseBlueprint.PrefabByEnvironmentDescription prefabByEnvironmentDescription,
+                EnvironmentDefinition environmentDefinition,
+                bool perspective)
+            {
+                if (!Main.Settings.EnableDungeonMakerPro
+                    || !Main.Settings.EnableDungeonMakerModdedContent
+                    || !(__instance is PropBlueprint propBlueprint)
+                    || !propBlueprint.Name.EndsWith("MOD"))
+                {
+                    return true;
+                }
+
+                var a = propBlueprint.Name.Split(new[] { '~' }, 3);
+
+                if (a.Length != 3)
+                {
+                    return true;
+                }
+
+                var propName = a[0];
+                var environmentName = a[1];
+                var str1 = "Gui/Bitmaps/Blueprints/Props/";
+                var str2 = "User_Props_" + propName;
+                var postfix = (perspective ? "_Pers" : "_Top");
+
+                if (environmentDefinition != null && prefabByEnvironmentDescription.Environment == environmentDefinition.Name)
+                {
+                    str1 += environmentName + "/";
+                    str2 += "_" + environmentName;
+                }
+
+                __result = str1 + str2 + postfix;
+
+                return false;
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintSelectionPanelPatcher.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
+{
+    // open DM content folded
+    [HarmonyPatch(typeof(BaseBlueprintSelectionPanel), "Bind")]
+    internal static class BaseBlueprintSelectionPanelBind
+    {
+        internal static void Postfix(BaseBlueprintSelectionPanel __instance)
+        {
+            if (!Main.Settings.EnableDungeonMakerPro || !Main.Settings.EnableDungeonMakerModdedContent)
+            {
+                return;
+            }
+
+            __instance.FoldAll();
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/BaseBlueprintSelectionPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
 {
     // open DM content folded
     [HarmonyPatch(typeof(BaseBlueprintSelectionPanel), "Bind")]
-    internal static class BaseBlueprintSelectionPanelBind
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class BaseBlueprintSelectionPanel_Bind
     {
         internal static void Postfix(BaseBlueprintSelectionPanel __instance)
         {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/UserLocationSettingsModalPatcher.cs
@@ -1,61 +1,61 @@
 ﻿using HarmonyLib;
 using ModKit;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using TMPro;
 using static SolastaCommunityExpansion.Models.DmProEditorContext;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
 {
-    internal static class UserLocationSettingsModalPatcher
+    // unlocks visual moods across all environments
+    [HarmonyPatch(typeof(UserLocationSettingsModal), "RefreshVisualMoods")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class UserLocationSettingsModal_RefreshVisualMoods
     {
-        // unlocks visual moods across all environments
-        [HarmonyPatch(typeof(UserLocationSettingsModal), "RefreshVisualMoods")]
-        internal static class UserLocationSettingsModalRefreshVisualMoods
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-            {
-                int found = 0;
+            int found = 0;
 
-                foreach (CodeInstruction instruction in instructions)
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (!Main.Settings.EnableDungeonMakerPro)
                 {
-                    if (!Main.Settings.EnableDungeonMakerPro)
-                    {
-                        yield return instruction;
-                    }
-                    else if (Main.Settings.EnableDungeonMakerModdedContent && instruction.opcode == OpCodes.Brfalse_S && ++found == 1)
-                    {
-                        yield return new CodeInstruction(OpCodes.Pop);
-                    }
-                    else
-                    {
-                        yield return instruction;
-                    }
+                    yield return instruction;
+                }
+                else if (Main.Settings.EnableDungeonMakerModdedContent && instruction.opcode == OpCodes.Brfalse_S && ++found == 1)
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                }
+                else
+                {
+                    yield return instruction;
                 }
             }
         }
+    }
 
-        // adds custom dungeons sizes
-        [HarmonyPatch(typeof(UserLocationSettingsModal), "RuntimeLoaded")]
-        internal static class UserLocationSettingsModalRuntimeLoaded
+    // adds custom dungeons sizes
+    [HarmonyPatch(typeof(UserLocationSettingsModal), "RuntimeLoaded")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class UserLocationSettingsModal_RuntimeLoaded
+    {
+        internal static void Postfix(UserLocationSettingsModal __instance, List<TMP_Dropdown.OptionData> ___optionsListSize)
         {
-            internal static void Postfix(UserLocationSettingsModal __instance, List<TMP_Dropdown.OptionData> ___optionsListSize)
+            if (!Main.Settings.EnableDungeonMakerPro || !Main.Settings.EnableDungeonMakerModdedContent)
             {
-                if (!Main.Settings.EnableDungeonMakerPro || !Main.Settings.EnableDungeonMakerModdedContent)
-                {
-                    return;
-                }
+                return;
+            }
 
-                for (var size = ExtendedDungeonSize.Huge; size <= ExtendedDungeonSize.Gargantuan; size++)
-                {
-                    var sizeString = UserLocationDefinitions.CellsBySize[(UserLocationDefinitions.Size)size].ToString();
+            for (var size = ExtendedDungeonSize.Huge; size <= ExtendedDungeonSize.Gargantuan; size++)
+            {
+                var sizeString = UserLocationDefinitions.CellsBySize[(UserLocationDefinitions.Size)size].ToString();
 
-                    ___optionsListSize.Add(new GuiDropdown.OptionDataAdvanced
-                    {
-                        text = Gui.FormatLocationSize((UserLocationDefinitions.Size)size).yellow() + " " + Gui.Format("{0} x {1}", sizeString, sizeString),
-                        TooltipContent = string.Empty
-                    });
-                }
+                ___optionsListSize.Add(new GuiDropdown.OptionDataAdvanced
+                {
+                    text = Gui.FormatLocationSize((UserLocationDefinitions.Size)size).yellow() + " " + Gui.Format("{0} x {1}", sizeString, sizeString),
+                    TooltipContent = string.Empty
+                });
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/UserLocationSettingsModalPatcher.cs
@@ -1,0 +1,62 @@
+﻿using HarmonyLib;
+using ModKit;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using TMPro;
+using static SolastaCommunityExpansion.Models.DmProEditorContext;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
+{
+    internal static class UserLocationSettingsModalPatcher
+    {
+        // unlocks visual moods across all environments
+        [HarmonyPatch(typeof(UserLocationSettingsModal), "RefreshVisualMoods")]
+        internal static class UserLocationSettingsModalRefreshVisualMoods
+        {
+            internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                int found = 0;
+
+                foreach (CodeInstruction instruction in instructions)
+                {
+                    if (!Main.Settings.EnableDungeonMakerPro)
+                    {
+                        yield return instruction;
+                    }
+                    else if (Main.Settings.EnableDungeonMakerModdedContent && instruction.opcode == OpCodes.Brfalse_S && ++found == 1)
+                    {
+                        yield return new CodeInstruction(OpCodes.Pop);
+                    }
+                    else
+                    {
+                        yield return instruction;
+                    }
+                }
+            }
+        }
+
+        // adds custom dungeons sizes
+        [HarmonyPatch(typeof(UserLocationSettingsModal), "RuntimeLoaded")]
+        internal static class UserLocationSettingsModalRuntimeLoaded
+        {
+            internal static void Postfix(UserLocationSettingsModal __instance, List<TMP_Dropdown.OptionData> ___optionsListSize)
+            {
+                if (!Main.Settings.EnableDungeonMakerPro || !Main.Settings.EnableDungeonMakerModdedContent)
+                {
+                    return;
+                }
+
+                for (var size = ExtendedDungeonSize.Huge; size <= ExtendedDungeonSize.Gargantuan; size++)
+                {
+                    var sizeString = UserLocationDefinitions.CellsBySize[(UserLocationDefinitions.Size)size].ToString();
+
+                    ___optionsListSize.Add(new GuiDropdown.OptionDataAdvanced
+                    {
+                        text = Gui.FormatLocationSize((UserLocationDefinitions.Size)size).yellow() + " " + Gui.Format("{0} x {1}", sizeString, sizeString),
+                        TooltipContent = string.Empty
+                    });
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/WorldLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/WorldLocationPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using UnityEngine;
 
@@ -7,7 +8,8 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
 {
     // changes how the location / rooms are instantiated
     [HarmonyPatch(typeof(WorldLocation), "BuildFromUserLocation")]
-    internal static class WorldLocationBuildFromUserLocation
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class WorldLocation_BuildFromUserLocation
     {
         //
         // IMPORTANT: this transpiler only works in BETA. we need to change lines 38-39 and 44-45 from 8,4 to 4,2 in PRODUCTION RELEASE

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/WorldLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/Pro/WorldLocationPatcher.cs
@@ -1,0 +1,64 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker.Pro
+{
+    // changes how the location / rooms are instantiated
+    [HarmonyPatch(typeof(WorldLocation), "BuildFromUserLocation")]
+    internal static class WorldLocationBuildFromUserLocation
+    {
+        //
+        // IMPORTANT: this transpiler only works in BETA. we need to change lines 38-39 and 44-45 from 8,4 to 4,2 in PRODUCTION RELEASE
+        //
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var found = 0;
+            var setLocalPositionMethod = typeof(Transform).GetMethod("set_localPosition");
+            var getTemplateVegetationMaskAreaMethod = typeof(Models.DmProRendererContext).GetMethod("GetTemplateVegetationMaskArea");
+            var setupLocationTerrainMethod = typeof(Models.DmProRendererContext).GetMethod("SetupLocationTerrain");
+            var setupFlatRoomsMethod = typeof(Models.DmProRendererContext).GetMethod("SetupFlatRooms");
+            var addVegetationMaskAreaMethod = typeof(Models.DmProRendererContext).GetMethod("AddVegetationMaskArea");
+            var fixFlatRoomReflectionProbeMethod = typeof(Models.DmProRendererContext).GetMethod("FixFlatRoomReflectionProbe");
+
+            yield return new CodeInstruction(OpCodes.Ldarg_0);
+            yield return new CodeInstruction(OpCodes.Call, getTemplateVegetationMaskAreaMethod);
+
+            yield return new CodeInstruction(OpCodes.Ldarg_0);
+            yield return new CodeInstruction(OpCodes.Ldarg_1);
+            yield return new CodeInstruction(OpCodes.Call, setupLocationTerrainMethod);
+
+            foreach (var instruction in instructions)
+            {
+                if (!Main.Settings.EnableDungeonMakerPro)
+                {
+                    yield return instruction;
+                }
+                else if (instruction.Calls(setLocalPositionMethod) && ++found == 1)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 8); // roomTransform 4
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 4); // userRoom 2
+                    yield return new CodeInstruction(OpCodes.Call, addVegetationMaskAreaMethod);
+
+                    yield return instruction;
+
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 8); // roomTransform 4
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 4); // userRoom 2
+                    yield return new CodeInstruction(OpCodes.Call, setupFlatRoomsMethod);
+                }
+                else if (instruction.opcode == OpCodes.Ret)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Call, fixFlatRoomReflectionProbeMethod);
+
+                    yield return instruction;
+                }
+                else
+                {
+                    yield return instruction;
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/PropBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/PropBlueprintSelectionPanelPatcher.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker
+{
+    // better props sorting
+    [HarmonyPatch(typeof(PropBlueprintSelectionPanel), "Compare")]
+    internal static class PropBlueprintSelectionPanelCompare
+    {
+        internal static bool Prefix(PropBlueprint left, PropBlueprint right, ref int __result)
+        {
+            if (!Main.Settings.EnableSortingDungeonMakerAssets)
+            {
+                return true;
+            }
+
+            __result = Models.DmProEditorContext.Compare(left, right);
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/PropBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/PropBlueprintSelectionPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {
     // better props sorting
     [HarmonyPatch(typeof(PropBlueprintSelectionPanel), "Compare")]
-    internal static class PropBlueprintSelectionPanelCompare
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class PropBlueprintSelectionPanel_Compare
     {
         internal static bool Prefix(PropBlueprint left, PropBlueprint right, ref int __result)
         {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/RoomBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/RoomBlueprintSelectionPanelPatcher.cs
@@ -1,10 +1,12 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {
     // better rooms sorting
     [HarmonyPatch(typeof(RoomBlueprintSelectionPanel), "Compare")]
-    internal static class RoomBlueprintSelectionPanelCompare
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class RoomBlueprintSelectionPanel_Compare
     {
         internal static bool Prefix(RoomBlueprint left, RoomBlueprint right, ref int __result)
         {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/RoomBlueprintSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/RoomBlueprintSelectionPanelPatcher.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.DungeonMaker
+{
+    // better rooms sorting
+    [HarmonyPatch(typeof(RoomBlueprintSelectionPanel), "Compare")]
+    internal static class RoomBlueprintSelectionPanelCompare
+    {
+        internal static bool Prefix(RoomBlueprint left, RoomBlueprint right, ref int __result)
+        {
+            if (!Main.Settings.EnableSortingDungeonMakerAssets)
+            {
+                return true;
+            }
+
+            __result = Models.DmProEditorContext.Compare(left, right);
+
+            return false;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -17,6 +17,7 @@ namespace SolastaCommunityExpansion.Patches
             ConjurationsContext.Load();
             DruidArmorContext.Load();
             DungeonMakerContext.Load();
+            DmProEditorContext.Load();
             EpicArrayContext.Load();
             FaceUnlockContext.Load();
             // Fighting Styles must be loaded before feats to allow feats to generate corresponding fighting style ones.

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -53,12 +53,14 @@ namespace SolastaCommunityExpansion
         public bool BugFixItemFiltering { get; set; } = true;
         public bool BugFixNullRecipesOnGameSerialization { get; set; } = true;
         public bool EnableCancelEditOnRightMouseClick { get; set; } = true;
+        public bool EnableDungeonMakerPro { get; set; } = true;
         public bool EnableDungeonMakerRotationHotkeys { get; set; } = true;
         public bool EnableFirstLevelCasterFeats { get; set; } = true;
         public bool EnableMultiLinePowerPanel { get; set; } = true;
         public bool EnableMultiLineSpellPanel { get; set; } = true;
         public bool EnableSortingClasses { get; set; } = true;
         public bool EnableSortingDeities { get; set; } = true;
+        public bool EnableSortingDungeonMakerAssets { get; set; } = true;
         public bool EnableSortingFeats { get; set; } = true;
         public bool EnableSortingFutureFeatures { get; set; } = true;
         public bool EnableSortingRaces { get; set; } = true;
@@ -234,6 +236,7 @@ namespace SolastaCommunityExpansion
         public bool AllowPropsToBePlacedAnywhere { get; set; }
         public bool UnleashNpcAsEnemy { get; set; }
         public bool UnleashEnemyAsNpc { get; set; }
+        public bool EnableDungeonMakerModdedContent { get; set; }
 
         //
         // Interface - Game UI

--- a/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
+++ b/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
@@ -396,6 +396,10 @@
 			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Solasta_Data\Managed\UnityEngine.XRModule.dll'))</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="AwesomeTechnologies.VegetationStudioPro.Runtime">
+			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Solasta_Data\Managed\AwesomeTechnologies.VegetationStudioPro.Runtime.dll'))</HintPath>
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="UnityModManager">
 			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Solasta_Data\Managed\UnityModManager\UnityModManager.dll'))</HintPath>
 			<Private>false</Private>

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -1170,3 +1170,6 @@ Subclass/&WitchSubclassPathDescription	Your knowledge of magic has culminated in
 Subclass/&WitchSubclassPathTitle	Witch Covens
 Tooltip/&Tag9000Title	Custom Effect
 Tooltip/&TagScoutSentinelWeaponTitle	Uses Int for attack & damage
+Screen/&EditorLocationSize3Title	Huge [MODDED]
+Screen/&EditorLocationSize4Title	Gargantuan [MODDED]
+BlueprintCategory/&FlatRoomsTitle	Flat Rooms

--- a/SolastaCommunityExpansion/Viewers/Displays/DungeonMakerDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/DungeonMakerDisplay.cs
@@ -11,6 +11,8 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 
             #region DungeonMaker
             UI.Label("");
+            UI.Label(". These 4 settings are safe to use as they don't require a player to have this mod installed");
+            UI.Label("");
 
             toggle = Main.Settings.AllowGadgetsToBePlacedAnywhere;
             if (UI.Toggle("Allow gadgets to be placed anywhere on the map " + RequiresRestart, ref toggle))
@@ -38,6 +40,20 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 Main.Settings.UnleashEnemyAsNpc = toggle;
             }
             #endregion
+
+            UI.Label("");
+            UI.Label("ATTENTION:".bold().yellow());
+            UI.Label(". Any modded content used on a location will force the player to install this mod");
+            UI.Label(". Can be easily identified in the editor as asset labels are " + "yellow".yellow());
+            UI.Label(". Include flat rooms, 150x150 & 200x200 dungeon sizes and no frills mixing assets from all environments");
+            UI.Label(". You must have at least one outdoor room if you pick an outdoor environment");
+            UI.Label("");
+
+            toggle = Main.Settings.EnableDungeonMakerModdedContent;
+            if (UI.Toggle("Enable Dungeon Maker Pro " + "[MODDED CONTENT] ".italic().yellow() + RequiresRestart, ref toggle))
+            {
+                Main.Settings.EnableDungeonMakerModdedContent = toggle;
+            }
 
             UI.Label("");
         }

--- a/SolastaCommunityExpansion/Viewers/Displays/DungeonMakerDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/DungeonMakerDisplay.cs
@@ -42,6 +42,12 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             #endregion
 
             UI.Label("");
+
+            if (!Main.Settings.EnableDungeonMakerPro)
+            {
+                return;
+            }
+
             UI.Label("ATTENTION:".bold().yellow());
             UI.Label(". Any modded content used on a location will force the player to install this mod");
             UI.Label(". Can be easily identified in the editor as asset labels are " + "yellow".yellow());


### PR DESCRIPTION
- migrates all DMPRO features except for custom monsters and multiplayer
- **EnableDungeonMakerPro** is a master hidden switch in the rare case we wanna fully disable this from CE
- **EnableDungeonMakerModdedContent** controls if authors will have access to additional assets in the editor
- **WorldLocationPatcher** is only controlled by the master switch to keep the experience as bug free as possible to players (no need to toggle any switch. all a player requires is install CE to play modded dungeon content)
- custom content in the editor is yellow and tagged as [modded]
- added proper text explaining the consequences of using modded assets in dungeons
- plan is to get support from @DubhHerder to migrate custom monsters from DMPRO
