### PR TITLE
Beta cleanup

### DIFF
--- a/SolastaCommunityExpansion/.editorconfig
+++ b/SolastaCommunityExpansion/.editorconfig
@@ -143,6 +143,12 @@ dotnet_diagnostic.S125.severity = silent
 # S3267: Loops should be simplified with "LINQ" expressions
 dotnet_diagnostic.S3267.severity = silent
 
+# RCS1146: Use conditional access.
+dotnet_diagnostic.RCS1146.severity = silent
+
+# RCS1112: Combine 'Enumerable.Where' method chain.
+dotnet_diagnostic.RCS1112.severity = silent
+
 [*.vb]
 # Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
@@ -381,7 +381,7 @@ namespace SolastaCommunityExpansion.Builders
                         FeatureDefinitionCastSpell.SlotsByLevelDuplet slotsForLevel = new FeatureDefinitionCastSpell.SlotsByLevelDuplet
                         {
                             Level = level,
-                            Slots = SlotsByCasterLevel[(level - startingLevel) / 2 + 1]
+                            Slots = SlotsByCasterLevel[((level - startingLevel) / 2) + 1]
                         };
                         Definition.SlotsPerLevels.Add(slotsForLevel);
                     }
@@ -392,7 +392,7 @@ namespace SolastaCommunityExpansion.Builders
                         FeatureDefinitionCastSpell.SlotsByLevelDuplet slotsForLevel = new FeatureDefinitionCastSpell.SlotsByLevelDuplet
                         {
                             Level = level,
-                            Slots = SlotsByCasterLevel[(level - startingLevel + 2) / 3 + 1]
+                            Slots = SlotsByCasterLevel[((level - startingLevel + 2) / 3) + 1]
                         };
                         Definition.SlotsPerLevels.Add(slotsForLevel);
                     }

--- a/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CastSpellBuilder.cs
@@ -269,7 +269,6 @@ namespace SolastaCommunityExpansion.Builders
                 case CasterProgression.THIRD_CASTER:
                     for (; level < 21; level++)
                     {
-
                         Definition.KnownSpells.Add(startingAmount +
                             // +2 here because third casters effectively "round up" for spells known
                             BonusSpellsKnownByCasterLevel[(level + 2) / 3] +

--- a/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
@@ -8,8 +8,6 @@ using static CharacterClassDefinition;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    /// <summary>
-    /// </summary>
     public class CharacterClassDefinitionBuilder : BaseDefinitionBuilder<CharacterClassDefinition>
     {
         public CharacterClassDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
@@ -3,8 +3,6 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    /// <summary>
-    /// </summary>
     public class CharacterSubclassDefinitionBuilder : BaseDefinitionBuilder<CharacterSubclassDefinition>
     {
         public CharacterSubclassDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/EffectDescriptionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/EffectDescriptionBuilder.cs
@@ -87,7 +87,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public EffectDescriptionBuilder NoVisibilityRequiredToTarget()
         {
-
             effect.SetRequiresVisibilityForPosition(false);
             return this;
         }

--- a/SolastaCommunityExpansion/Builders/EffectFormBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/EffectFormBuilder.cs
@@ -120,7 +120,7 @@ namespace SolastaCommunityExpansion.Builders
             RuleDefinitions.DieType dieType, int diceNumber, RuleDefinitions.HealFromInflictedDamage healFromInflictedDamage,
             params RuleDefinitions.TrendInfo[] damageBonusTrends)
         {
-            return SetDamageForm(versatile, versatileDieType, damageType, bonusDamage, dieType, 
+            return SetDamageForm(versatile, versatileDieType, damageType, bonusDamage, dieType,
                 diceNumber, healFromInflictedDamage, damageBonusTrends.AsEnumerable());
         }
 

--- a/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
@@ -30,7 +30,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatDefinitionBuilder(FeatDefinition original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatDefinitionBuilder SetFeatures(params FeatureDefinition[] features)

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionAdditionalActionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionAdditionalActionBuilder.cs
@@ -24,12 +24,10 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAdditionalActionBuilder(FeatureDefinitionAdditionalAction original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatureDefinitionAdditionalActionBuilder(string name, string guid) : base(name, guid)
         {
-
         }
 
         public FeatureDefinitionAdditionalActionBuilder SetGuiPresentation(GuiPresentation guiPresentation)

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using SolastaModApi;
 using SolastaModApi.Extensions;

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionAutoPreparedSpellsBuilder.cs
@@ -23,7 +23,7 @@ namespace SolastaCommunityExpansion.Builders
         public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid, List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists,
             GuiPresentation guiPresentation) : base(name, guid)
         {
-            Definition.SetField("autoPreparedSpellsGroups", 
+            Definition.SetField("autoPreparedSpellsGroups",
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>(autospelllists));
 
             Definition.SetGuiPresentation(guiPresentation);
@@ -31,12 +31,10 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid) : base(name, guid)
         {
-
         }
 
         public FeatureDefinitionAutoPreparedSpellsBuilder(FeatureDefinitionAutoPreparedSpells original, string name, string guid) : base(original, name, guid)
         {
-
         }
 
         public FeatureDefinitionAutoPreparedSpellsBuilder SetPreparedSpellGroups(params FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup[] autospelllists)
@@ -46,7 +44,7 @@ namespace SolastaCommunityExpansion.Builders
 
         public FeatureDefinitionAutoPreparedSpellsBuilder SetPreparedSpellGroups(IEnumerable<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists)
         {
-            Definition.SetField("autoPreparedSpellsGroups", 
+            Definition.SetField("autoPreparedSpellsGroups",
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>(autospelllists));
 
             return this;

--- a/SolastaCommunityExpansion/Builders/FeatureDefinitionPointPoolBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatureDefinitionPointPoolBuilder.cs
@@ -15,7 +15,7 @@ namespace SolastaCommunityExpansion.Builders
             Definition.SetPoolAmount(poolAmount);
         }
 
-        public FeatureDefinitionPointPoolBuilder(string name, Guid baseGuid, 
+        public FeatureDefinitionPointPoolBuilder(string name, Guid baseGuid,
             HeroDefinitions.PointsPoolType poolType, int poolAmount, string keyPrefix = null) : base(name, baseGuid, keyPrefix)
         {
             Definition.SetPoolType(poolType);

--- a/SolastaCommunityExpansion/Builders/MonsterBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/MonsterBuilder.cs
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion.Builders
 {
     public class MonsterBuilder : BaseDefinitionBuilder<MonsterDefinition>
     {
-        public MonsterBuilder(string name, string guid, string title, string description, MonsterDefinition baseMonster) 
+        public MonsterBuilder(string name, string guid, string title, string description, MonsterDefinition baseMonster)
             : base(baseMonster, name, guid, title, description)
         {
         }
@@ -290,7 +290,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public MonsterBuilder ClearSkillScores()
         {
-
             Definition.SkillScores.Clear();
             return this;
         }
@@ -308,7 +307,6 @@ namespace SolastaCommunityExpansion.Builders
 
         public MonsterBuilder ClearAttackIterations()
         {
-
             Definition.AttackIterations.Clear();
             return this;
         }

--- a/SolastaCommunityExpansion/Builders/SpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/SpellBuilder.cs
@@ -123,6 +123,5 @@ namespace SolastaCommunityExpansion.Builders
             Definition.SetGuiPresentation(gui);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
@@ -6,7 +6,7 @@ using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class AlchemistBuilder
+    public static class AlchemistBuilder
     {
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer)
         {
@@ -265,7 +265,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 DatabaseHelper.SpellDefinitions.GreaterRestoration.EffectDescription,
                 greaterRestorativeElixirsGui.Build()).AddToDB();
             alchemist.AddFeatureAtLevel(greaterRestorativeElixirs, 15);
-
 
             GuiPresentationBuilder healElixirsGui = new GuiPresentationBuilder(
                 "Feat/&PowerAlchemistHealElixirsDescription",

--- a/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
@@ -1,7 +1,7 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer

--- a/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/AlchemistBuilder.cs
@@ -46,21 +46,21 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&MagicAffinityAlchemistSpellRecoveryDescription",
                 "Subclass/&MagicAffinityAlchemistSpellRecoveryTitle");
             spellRecoveryGui.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerWizardArcaneRecovery.GuiPresentation.SpriteReference);
-            FeatureDefinitionPower bonusRecovery = FeatureHelpers.BuildSpellFormPower(2 /* usePerRecharge */, RuleDefinitions.UsesDetermination.Fixed, RuleDefinitions.ActivationTime.Rest,
-                1 /* cost */, RuleDefinitions.RechargeRate.LongRest, "PowerAlchemistSpellBonusRecovery", spellRecoveryGui.Build());
+            FeatureDefinitionPower bonusRecovery = FeatureHelpers.BuildSpellFormPower(2 /* usePerRecharge */, UsesDetermination.Fixed, ActivationTime.Rest,
+                1 /* cost */, RechargeRate.LongRest, "PowerAlchemistSpellBonusRecovery", spellRecoveryGui.Build());
             alchemist.AddFeatureAtLevel(bonusRecovery, 3);
 
-            FeatureHelpers.BuildRestActivity(RestDefinitions.RestStage.AfterRest, RuleDefinitions.RestType.ShortRest,
+            FeatureHelpers.BuildRestActivity(RestDefinitions.RestStage.AfterRest, RestType.ShortRest,
                 RestActivityDefinition.ActivityCondition.CanUsePower, "UsePower", bonusRecovery.Name, "AlcemicalPreparationRestAction", spellRecoveryGui.Build());
 
             // Healing 2d4+int
             EffectDescriptionBuilder healEffect = new EffectDescriptionBuilder();
             healEffect.AddEffectForm(new EffectFormBuilder()
-                .SetHealingForm(RuleDefinitions.HealingComputation.Dice, 0, RuleDefinitions.DieType.D4, 2, false, RuleDefinitions.HealingCap.MaximumHitPoints)
-                .SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus)
+                .SetHealingForm(HealingComputation.Dice, 0, DieType.D4, 2, false, HealingCap.MaximumHitPoints)
+                .SetBonusMode(AddBonusMode.AbilityBonus)
                 .Build());
-            healEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            healEffect.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            healEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            healEffect.SetDurationData(DurationType.Hour, 1, TurnOccurenceType.EndOfTurn);
             healEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.CureWounds.EffectDescription.EffectParticleParameters);
             GuiPresentationBuilder healingElixirGui = new GuiPresentationBuilder(
                 "Feat/&ArtificerAlchemistHealElixirDescription",
@@ -69,9 +69,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             SpellDefinition healElixirSpell = new SpellBuilder("AlchemistHealElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistHealElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(healEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(healingElixirGui.Build())
                 .AddToDB();
 
@@ -83,7 +83,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ConditionDefinition swiftness = FeatureHelpers.BuildCondition(new List<FeatureDefinition>()
             {
                 FeatureHelpers.BuildMovementAffinity(true, 2, 1, "AlchemistSwiftnessMovementAffinity", swiftnessGui.Build())
-            }, RuleDefinitions.DurationType.Hour, 1, false, "AlchemistSwiftnessElixirCondition", swiftnessGui.Build());
+            }, DurationType.Hour, 1, false, "AlchemistSwiftnessElixirCondition", swiftnessGui.Build());
             FeatureDefinitionPower cancelSwiftness = new CancelConditionPowerBuilder("CancelElixirSwiftness", "86888f66-c8b2-49db-910a-bde389dd69df",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirSwiftnessDescription", "Subclass/&CancelCancelElixirSwiftnessTitle")
                 .SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionExpeditiousRetreat.GuiPresentation.SpriteReference).Build(),
@@ -93,16 +93,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectFormBuilder swiftnessForm = new EffectFormBuilder();
             swiftnessForm.SetConditionForm(swiftness, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>());
             swiftnessEffect.AddEffectForm(swiftnessForm.Build());
-            swiftnessEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, RuleDefinitions.DieType.D1, 0).Build());
-            swiftnessEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            swiftnessEffect.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            swiftnessEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D1, 0).Build());
+            swiftnessEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            swiftnessEffect.SetDurationData(DurationType.Hour, 1, TurnOccurenceType.EndOfTurn);
             swiftnessEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Longstrider.EffectDescription.EffectParticleParameters);
             SpellDefinition swiftnessElixirSpell = new SpellBuilder("AlchemistSwiftnessElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistSwiftnessElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(swiftnessEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(swiftnessGui.Build())
                 .AddToDB();
 
@@ -115,7 +115,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             {
                 FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
                 "AlchemistResilienceMovementAffinity", resilienceGui.Build())
-            }, RuleDefinitions.DurationType.Minute, 10, false, "AlchemistResilienceElixirCondition", resilienceGui.Build());
+            }, DurationType.Minute, 10, false, "AlchemistResilienceElixirCondition", resilienceGui.Build());
             FeatureDefinitionPower cancelResilience = new CancelConditionPowerBuilder("CancelElixirResilience", "4de693d2-f193-4434-8741-57335d7cefdc",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirResilienceDescription", "Subclass/&CancelCancelElixirResilienceTitle")
                 .SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference).Build(),
@@ -123,15 +123,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             resilience.Features.Add(cancelResilience);
             EffectDescriptionBuilder resilienceEffect = new EffectDescriptionBuilder();
             resilienceEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(resilience, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            resilienceEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            resilienceEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 10, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            resilienceEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            resilienceEffect.SetDurationData(DurationType.Minute, 10, TurnOccurenceType.EndOfTurn);
             resilienceEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Blur.EffectDescription.EffectParticleParameters);
             SpellDefinition resilienceElixirSpell = new SpellBuilder("AlchemistResilienceElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistResilienceElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(resilienceEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(resilienceGui.Build())
                 .AddToDB();
 
@@ -143,16 +143,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             EffectDescriptionBuilder boldnessEffect = new EffectDescriptionBuilder();
             boldnessEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.ConditionBlessed, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            boldnessEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            boldnessEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            boldnessEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            boldnessEffect.SetDurationData(DurationType.Minute, 1, TurnOccurenceType.EndOfTurn);
             boldnessEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Bless.EffectDescription.EffectParticleParameters);
 
             SpellDefinition boldnessElixirSpell = new SpellBuilder("AlchemistBoldnessElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistBoldnessElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(boldnessEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(boldnessElixirGui.Build())
                 .AddToDB();
 
@@ -164,7 +164,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ConditionDefinition fly = FeatureHelpers.BuildCondition(new List<FeatureDefinition>()
             {
                 DatabaseHelper.FeatureDefinitionMoveModes.MoveModeFly2,
-            }, RuleDefinitions.DurationType.Minute, 10, false, "AlchemistFlyElixirCondition", flyElixirGui.Build());
+            }, DurationType.Minute, 10, false, "AlchemistFlyElixirCondition", flyElixirGui.Build());
 
             FeatureDefinitionPower cancelFly = new CancelConditionPowerBuilder("CancelElixirFly", "64385214-7b0f-4372-a12f-8346b2b33884",
                 new GuiPresentationBuilder("Subclass/&CancelCancelElixirFlyDescription", "Subclass/&CancelCancelElixirFlyTitle")
@@ -174,15 +174,15 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             EffectDescriptionBuilder flyEffect = new EffectDescriptionBuilder();
             flyEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(fly, ConditionForm.ConditionOperation.Add, false, false, new List<ConditionDefinition>()).Build());
-            flyEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Touch, 1, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            flyEffect.SetDurationData(RuleDefinitions.DurationType.Minute, 10, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            flyEffect.SetTargetingData(Side.Ally, RangeType.Touch, 1, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            flyEffect.SetDurationData(DurationType.Minute, 10, TurnOccurenceType.EndOfTurn);
             flyEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Fly.EffectDescription.EffectParticleParameters);
             SpellDefinition flyElixirSpell = new SpellBuilder("AlchemistFlyElixir", GuidHelper.Create(TinkererClass.GuidNamespace, "AlchemistFlyElixir").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolTransmutation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(flyEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(flyElixirGui.Build())
                 .AddToDB();
 
@@ -203,7 +203,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder alchemicalSavantGui = new GuiPresentationBuilder(
                 "Feat/&ArtificerAlchemistAlchemicalSavantDescription",
                 "Feat/&ArtificerAlchemistAlchemicalSavantTitle");
-            FeatureDefinitionHealingModifier improvedHealing = FeatureHelpers.BuildHealingModifier(1, RuleDefinitions.DieType.D4, RuleDefinitions.LevelSourceType.CharacterLevel,
+            FeatureDefinitionHealingModifier improvedHealing = FeatureHelpers.BuildHealingModifier(1, DieType.D4, LevelSourceType.CharacterLevel,
                 "ArtificerAlchemistAlchemicalSavantHealing", alchemicalSavantGui.Build());
             alchemist.AddFeatureAtLevel(improvedHealing, 5);
 
@@ -223,8 +223,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistRestorativeElixirsTitle");
             restorativeElixirs.SetSpriteReference(DatabaseHelper.SpellDefinitions.LesserRestoration.GuiPresentation.SpriteReference);
             FeatureDefinitionPower restorativeElixisrPower = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistRestorativeElixirs", GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistRestorativeElixirs").ToString(),
-                0, RuleDefinitions.UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                0, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 DatabaseHelper.SpellDefinitions.LesserRestoration.EffectDescription,
                 restorativeElixirs.Build()).AddToDB();
@@ -234,17 +234,17 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistEmboldeningShotsDescription",
                 "Feat/&PowerAlchemistEmboldeningShotsTitle");
             EffectDescriptionBuilder emboldeningShotsEffect = new EffectDescriptionBuilder();
-            emboldeningShotsEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D6, 4).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            emboldeningShotsEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 6, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            emboldeningShotsEffect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            emboldeningShotsEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D6, 4).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            emboldeningShotsEffect.SetTargetingData(Side.Ally, RangeType.Distance, 6, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            emboldeningShotsEffect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             emboldeningShotsEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             SpellDefinition emboldeningShots = new SpellBuilder("CantripAlchemistEmboldeningShots", GuidHelper.Create(TinkererClass.GuidNamespace, "CantripAlchemistEmboldeningShots").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSpellLevel(0)
-                .SetCastingTime(RuleDefinitions.ActivationTime.BonusAction)
+                .SetCastingTime(ActivationTime.BonusAction)
                 .SetEffectDescription(emboldeningShotsEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(emboldeningShotsGui.Build())
                 .AddToDB();
 
@@ -259,8 +259,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistGreaterRestorativeElixirsTitle");
             restorativeElixirs.SetSpriteReference(DatabaseHelper.SpellDefinitions.GreaterRestoration.GuiPresentation.SpriteReference);
             FeatureDefinitionPower greaterRestorativeElixirs = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistGreaterRestorativeElixirs", GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistGreaterRestorativeElixirs").ToString(),
-                1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                1, UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 DatabaseHelper.SpellDefinitions.GreaterRestoration.EffectDescription,
                 greaterRestorativeElixirsGui.Build()).AddToDB();
@@ -271,8 +271,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&PowerAlchemistHealElixirsTitle");
             EffectDescriptionBuilder healSpellEffect = new EffectDescriptionBuilder();
             healSpellEffect.AddEffectForm(new EffectFormBuilder()
-                .SetHealingForm(RuleDefinitions.HealingComputation.Dice, 0, RuleDefinitions.DieType.D1, 70, false, RuleDefinitions.HealingCap.MaximumHitPoints)
-                .SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus)
+                .SetHealingForm(HealingComputation.Dice, 0, DieType.D1, 70, false, HealingCap.MaximumHitPoints)
+                .SetBonusMode(AddBonusMode.AbilityBonus)
                 .Build());
             healSpellEffect.AddEffectForm(new EffectFormBuilder().SetConditionForm(DatabaseHelper.ConditionDefinitions.ConditionParalyzed, ConditionForm.ConditionOperation.RemoveDetrimentalAll,
                 false, false, new List<ConditionDefinition>() {
@@ -286,14 +286,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                     DatabaseHelper.ConditionDefinitions.ConditionContagionSeizure,
                     DatabaseHelper.ConditionDefinitions.ConditionContagionSlimyDoom,
                 }).Build());
-            healSpellEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 12, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
-            healSpellEffect.SetDurationData(RuleDefinitions.DurationType.Instantaneous, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            healSpellEffect.SetTargetingData(Side.Ally, RangeType.Distance, 12, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            healSpellEffect.SetDurationData(DurationType.Instantaneous, 1, TurnOccurenceType.EndOfTurn);
             healSpellEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             FeatureDefinitionPower greatHealElixirs = new FeatureHelpers.FeatureDefinitionPowerBuilder("PowerAlchemistHealElixirs",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "PowerAlchemistHealElixirs").ToString(),
-                1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
-                RuleDefinitions.ActivationTime.Action, 1, RuleDefinitions.RechargeRate.LongRest,
+                1, UsesDetermination.Fixed, AttributeDefinitions.Intelligence,
+                ActivationTime.Action, 1, RechargeRate.LongRest,
                 false, false, AttributeDefinitions.Intelligence,
                 healSpellEffect.Build(),
                 healElixirsGui.Build()).AddToDB();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
@@ -21,25 +21,25 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             meleePresentation.SetSpriteReference(DatabaseHelper.CharacterSubclassDefinitions.TraditionShockArcanist.GuiPresentation.SpriteReference);
             artillerist.SetGuiPresentation(meleePresentation.Build());
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells1 = FeatureHelpers.BuildAutoPreparedSpellGroup(3,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells1 = BuildAutoPreparedSpellGroup(3,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.Shield, DatabaseHelper.SpellDefinitions.Thunderwave });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells2 = FeatureHelpers.BuildAutoPreparedSpellGroup(5,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells2 = BuildAutoPreparedSpellGroup(5,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.ScorchingRay, DatabaseHelper.SpellDefinitions.Shatter });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells3 = FeatureHelpers.BuildAutoPreparedSpellGroup(9,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells3 = BuildAutoPreparedSpellGroup(9,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.Fireball, DatabaseHelper.SpellDefinitions.WindWall });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells4 = FeatureHelpers.BuildAutoPreparedSpellGroup(13,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells4 = BuildAutoPreparedSpellGroup(13,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.IceStorm, DatabaseHelper.SpellDefinitions.WallOfFire });
 
-            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells5 = FeatureHelpers.BuildAutoPreparedSpellGroup(17,
+            FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup artilleristSpells5 = BuildAutoPreparedSpellGroup(17,
                 new List<SpellDefinition>() { DatabaseHelper.SpellDefinitions.ConeOfCold, DatabaseHelper.SpellDefinitions.WallOfForce });
 
             GuiPresentationBuilder artilleristSpellsPresentation = new GuiPresentationBuilder(
                 "Feat/&ArtilleristSubclassSpellsDescription",
                 "Feat/&ArtilleristSubclassSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleristPrepSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleristPrepSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     artilleristSpells1, artilleristSpells2, artilleristSpells3, artilleristSpells4, artilleristSpells5 },
                 artificer, "ArtificerArtilleristAutoPrepSpells", artilleristSpellsPresentation.Build());
@@ -55,9 +55,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fireEffect = new EffectDescriptionBuilder();
             fireEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 2, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fireEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fireEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fireEffect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fireEffect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fireEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -75,7 +75,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             forceEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 2, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             forceEffect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            forceEffect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            forceEffect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
             forceEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -91,9 +91,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             protectorGui.SetSpriteReference(DatabaseHelper.SpellDefinitions.FalseLife.GuiPresentation.SpriteReference);
 
             EffectDescriptionBuilder protectorEffect = new EffectDescriptionBuilder();
-            protectorEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 1).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            protectorEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 2, RuleDefinitions.TargetType.Sphere, 2, 2, ActionDefinitions.ItemSelectionType.None);
-            protectorEffect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            protectorEffect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 1).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            protectorEffect.SetTargetingData(Side.Ally, RangeType.Self, 2, TargetType.Sphere, 2, 2, ActionDefinitions.ItemSelectionType.None);
+            protectorEffect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             protectorEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -107,7 +107,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder ArtilleryConstructLevel03AutopreparedSpellsPresentation = new GuiPresentationBuilder(
                  "Feat/&ArtilleryConstructLevel03AutopreparedSpellsDescription",
                  "Feat/&ArtilleryConstructLevel03AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel03AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel03AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,
@@ -124,8 +124,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&ArtificerArtilleristArcaneFirearmTitle");
             FeatureDefinitionAdditionalDamage arcaneFirearm = new FeatureDefinitionAdditionalDamageBuilder("ArtificerArtilleristArcaneFirearm",
                  GuidHelper.Create(TinkererClass.GuidNamespace, "ArtificerArtilleristArcaneFirearm").ToString(), "ArcaneFirearm",
-                RuleDefinitions.FeatureLimitedUsage.OncePerTurn, RuleDefinitions.AdditionalDamageValueDetermination.Die, RuleDefinitions.AdditionalDamageTriggerCondition.EvocationSpellDamage, RuleDefinitions.AdditionalDamageRequiredProperty.None,
-                false /* attack only */, RuleDefinitions.DieType.D8, 1 /* dice number */, RuleDefinitions.AdditionalDamageType.SameAsBaseDamage, "", RuleDefinitions.AdditionalDamageAdvancement.None,
+                FeatureLimitedUsage.OncePerTurn, AdditionalDamageValueDetermination.Die, AdditionalDamageTriggerCondition.EvocationSpellDamage, AdditionalDamageRequiredProperty.None,
+                false /* attack only */, DieType.D8, 1 /* dice number */, AdditionalDamageType.SameAsBaseDamage, "", AdditionalDamageAdvancement.None,
                 new List<DiceByRank>(), false, AttributeDefinitions.Wisdom, 0, EffectSavingThrowType.None, new List<ConditionOperationDescription>(),
                 arcaneFirearmGui.Build()).AddToDB();
             artillerist.AddFeatureAtLevel(arcaneFirearm, 5);
@@ -138,17 +138,17 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             detonationEffect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage)
                 .Build());
-            detonationEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            detonationEffect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            detonationEffect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Distance, 12, RuleDefinitions.TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
+            detonationEffect.SetTargetingData(Side.All, RangeType.Distance, 12, TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
             detonationEffect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             SpellDefinition detonation = new SpellBuilder("ArtilleristCannonDetonation", GuidHelper.Create(TinkererClass.GuidNamespace, "ArtilleristCannonDetonation").ToString())
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSpellLevel(1)
-                .SetCastingTime(RuleDefinitions.ActivationTime.Action)
+                .SetCastingTime(ActivationTime.Action)
                 .SetEffectDescription(detonationEffect.Build())
-                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Mundane)
+                .SetMaterialComponent(MaterialComponentType.Mundane)
                 .SetGuiPresentation(detonationGui.Build())
                 .AddToDB();
 
@@ -159,9 +159,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             // TODO: unused
 #pragma warning disable IDE0059, S1481 // Unused local variables should be removed
-            FeatureDefinitionAutoPreparedSpells artilleristDetonationSpell = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells artilleristDetonationSpell = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
-                    FeatureHelpers.BuildAutoPreparedSpellGroup(9, new List<SpellDefinition>() { detonation })
+                    BuildAutoPreparedSpellGroup(9, new List<SpellDefinition>() { detonation })
                 },
                 artificer, "ArtificerArtillerstDetonationSpellPrepared", artilleristDetonationPreparedPresentation.Build());
             //    artillerist.AddFeatureAtLevel(artilleristDetonationSpell, 9);
@@ -176,9 +176,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fire9Effect = new EffectDescriptionBuilder();
             fire9Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fire9Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fire9Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fire9Effect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fire9Effect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fire9Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -197,7 +197,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             force9Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             force9Effect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            force9Effect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
+            force9Effect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 1, 1, ActionDefinitions.ItemSelectionType.None);
             force9Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -211,7 +211,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder ArtilleryConstructLevel09AutopreparedSpellsPresentation = new GuiPresentationBuilder(
                  "Feat/&ArtilleryConstructLevel09AutopreparedSpellsDescription",
                  "Feat/&ArtilleryConstructLevel09AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel09AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel09AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,
@@ -231,9 +231,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectDescriptionBuilder fire15Effect = new EffectDescriptionBuilder();
             fire15Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeFire, 0, DieType.D8, 6, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .HasSavingThrow(EffectSavingThrowType.HalfDamage).Build());
-            fire15Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, RuleDefinitions.EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
+            fire15Effect.SetSavingThrowData(true, false, AttributeDefinitions.Dexterity, false, EffectDifficultyClassComputation.SpellCastingFeature, AttributeDefinitions.Intelligence,
                 15, false, new List<SaveAffinityBySenseDescription>());
-            fire15Effect.SetTargetingData(RuleDefinitions.Side.All, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
+            fire15Effect.SetTargetingData(Side.All, RangeType.Self, 1, TargetType.Cone, 3, 2, ActionDefinitions.ItemSelectionType.None);
             fire15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -252,7 +252,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             force15Effect.AddEffectForm(new EffectFormBuilder().SetDamageForm(false, DieType.D8, DamageTypeForce, 0, DieType.D8, 3, HealFromInflictedDamage.Never, new List<TrendInfo>())
                 .Build());
             force15Effect.AddEffectForm(new EffectFormBuilder().SetMotionForm(MotionForm.MotionType.PushFromOrigin, 1).Build());
-            force15Effect.SetTargetingData(RuleDefinitions.Side.Enemy, RuleDefinitions.RangeType.RangeHit, 24, RuleDefinitions.TargetType.Individuals, 2, 2, ActionDefinitions.ItemSelectionType.None);
+            force15Effect.SetTargetingData(Side.Enemy, RangeType.RangeHit, 24, TargetType.Individuals, 2, 2, ActionDefinitions.ItemSelectionType.None);
             force15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -267,9 +267,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             protectorGui.SetSpriteReference(DatabaseHelper.SpellDefinitions.FalseLife.GuiPresentation.SpriteReference);
 
             EffectDescriptionBuilder protector15Effect = new EffectDescriptionBuilder();
-            protector15Effect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 2).SetBonusMode(RuleDefinitions.AddBonusMode.AbilityBonus).Build());
-            protector15Effect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 2, RuleDefinitions.TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
-            protector15Effect.SetDurationData(RuleDefinitions.DurationType.Permanent, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
+            protector15Effect.AddEffectForm(new EffectFormBuilder().SetTempHPForm(0, DieType.D8, 2).SetBonusMode(AddBonusMode.AbilityBonus).Build());
+            protector15Effect.SetTargetingData(Side.Ally, RangeType.Self, 2, TargetType.Sphere, 4, 4, ActionDefinitions.ItemSelectionType.None);
+            protector15Effect.SetDurationData(DurationType.Permanent, 1, TurnOccurenceType.EndOfTurn);
             protector15Effect.SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.FalseLife.EffectDescription.EffectParticleParameters);
 
             // TODO- add an option to enable the power version of the Blaster (there have been some requests for this) instead of the summons
@@ -283,7 +283,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder ArtilleryConstructLevel15AutopreparedSpellsPresentation = new GuiPresentationBuilder(
     "Feat/&ArtilleryConstructLevel15AutopreparedSpellsDescription",
     "Feat/&ArtilleryConstructLevel15AutopreparedSpellsTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel15AutopreparedSpells = FeatureHelpers.BuildAutoPreparedSpells(
+            FeatureDefinitionAutoPreparedSpells ArtilleryConstructLevel15AutopreparedSpells = BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup() {
                         ClassLevel=1,

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
@@ -8,7 +8,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     public static class ArtilleristBuilder
     {
+        // TODO: unused parameter FeatureDefinitionCastSpell
+#pragma warning disable RCS1163 // Unused parameter.
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer, FeatureDefinitionCastSpell spellCasting)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             // Make Artillerist subclass
             CharacterSubclassDefinitionBuilder artillerist = new CharacterSubclassDefinitionBuilder("Artillerist", GuidHelper.Create(TinkererClass.GuidNamespace, "Artillerist").ToString());
@@ -153,12 +156,16 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder artilleristDetonationPreparedPresentation = new GuiPresentationBuilder(
                 "Feat/&ArtificerArtillerstDetonationSpellPreparedDescription",
                 "Feat/&ArtificerArtillerstDetonationSpellPreparedTitle");
-            FeatureDefinitionAutoPreparedSpells ArtilleristDetonationSpell = FeatureHelpers.BuildAutoPreparedSpells(
+
+            // TODO: unused
+#pragma warning disable IDE0059, S1481 // Unused local variables should be removed
+            FeatureDefinitionAutoPreparedSpells artilleristDetonationSpell = FeatureHelpers.BuildAutoPreparedSpells(
                 new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>() {
                     FeatureHelpers.BuildAutoPreparedSpellGroup(9, new List<SpellDefinition>() { detonation })
                 },
                 artificer, "ArtificerArtillerstDetonationSpellPrepared", artilleristDetonationPreparedPresentation.Build());
-            //    artillerist.AddFeatureAtLevel(ArtilleristDetonationSpell, 9);
+            //    artillerist.AddFeatureAtLevel(artilleristDetonationSpell, 9);
+#pragma warning restore IDE0059, S1481 // Unused local variables should be removed
 
             // cannons with boosted damage
             GuiPresentationBuilder flame9Gui = new GuiPresentationBuilder(

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
-using System.Collections.Generic;
 using static RuleDefinitions;
 using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleristBuilder.cs
@@ -6,7 +6,7 @@ using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class ArtilleristBuilder
+    public static class ArtilleristBuilder
     {
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer, FeatureDefinitionCastSpell spellCasting)
         {
@@ -62,7 +62,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 1, UsesDetermination.AbilityBonusPlusFixed, AttributeDefinitions.Intelligence, ActivationTime.BonusAction, 0, RechargeRate.AtWill, false, false, AttributeDefinitions.Intelligence, fireEffect.Build(),
                 flameGui.Build()).AddToDB();
             //    artillerist.AddFeatureAtLevel(flameAttack, 3);
-
 
             GuiPresentationBuilder forceGui = new GuiPresentationBuilder(
                 "Feat/&ArtilleristForceCannonDescription",

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
@@ -16,14 +16,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected FlameArtilleryBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDragonBreath_Fire, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&FlameArtilleryTitle";
             Definition.GuiPresentation.Description = "Feat/&FlameArtilleryDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
 
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
-
 
             DamageForm FlameArtillery = new DamageForm
             {
@@ -35,7 +33,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             // AlterationForm alterationForm = new AlterationForm();
             //alterationForm.SetAlterationType (AlterationForm.Type.LightUp);
-
 
             EffectForm effect = new EffectForm
             {
@@ -49,7 +46,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effect.SetLevelMultiplier(1);
             effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
@@ -66,7 +62,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.EffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.BurningHands.EffectDescription.EffectParticleParameters);
             Definition.EffectDescription.SetRangeType(RuleDefinitions.RangeType.Distance);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -75,11 +70,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower FlameArtillery = CreateAndAddToDB(FlameArtilleryName, FlameArtilleryGuid);
-
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		FlameArtillery_2Builder		*******************************************************************
@@ -92,11 +83,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected FlameArtillery_2Builder(string name, string guid) : base(FlameArtilleryBuilder.FlameArtillery, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&FlameArtillery_2Title";
             Definition.GuiPresentation.Description = "Feat/&FlameArtillery_2Description";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
-
 
             Definition.EffectDescription.EffectForms[0].DamageForm.DiceNumber = 3;
             Definition.SetOverriddenPower(FlameArtilleryBuilder.FlameArtillery);
@@ -108,8 +97,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower FlameArtillery_2 = CreateAndAddToDB(FlameArtillery_2Name, FlameArtillery_2Guid);
-
-
     }
 
     //*****************************************************************************************************************************************
@@ -123,7 +110,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected FlameArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // can use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -147,10 +133,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
-
-
-
-
 
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
@@ -179,12 +161,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Add(FlameArtilleryBuilder.FlameArtillery);
 
-
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -193,8 +170,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
-
-
     }
 
     internal class FlameArtilleryConstruct_9Builder : BaseDefinitionBuilder<MonsterDefinition>
@@ -208,7 +183,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Add(FlameArtillery_2Builder.FlameArtillery_2);
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -217,11 +191,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition FlameArtilleryConstruct_9 = CreateAndAddToDB(FlameArtilleryConstruct_9Name, FlameArtilleryConstruct_9Guid);
-
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		FlameArtilleryConstruct_15Builder		*******************************************************************
@@ -237,7 +207,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&FlameArtilleryConstructTitle_5";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -246,10 +215,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition FlameArtilleryConstruct_15 = CreateAndAddToDB(FlameArtilleryConstruct_15Name, FlameArtilleryConstruct_15Guid);
-
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstructBuilder		*******************************************************************
@@ -262,7 +228,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonFlameArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtilleryModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtilleryModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.BurningHands.GuiPresentation.SpriteReference);
@@ -272,12 +237,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.FlameArtillery_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -286,11 +246,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonFlameArtilleryConstruct = CreateAndAddToDB(SummonFlameArtilleryConstructName, SummonFlameArtilleryConstructGuid);
-
     }
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstruct_9Builder		*******************************************************************
@@ -303,13 +259,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonFlameArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtillery_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtillery_09ModePowerDescription";
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct_9Builder.FlameArtilleryConstruct_9.Name);
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -318,10 +270,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonFlameArtilleryConstruct_9 = CreateAndAddToDB(SummonFlameArtilleryConstruct_9Name, SummonFlameArtilleryConstruct_9Guid);
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonFlameArtillerySpellConstruct_15Builder		*******************************************************************
@@ -334,12 +283,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonFlameArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonFlameArtillerySpellConstructBuilder.SummonFlameArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&FlameArtillery_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&FlameArtillery_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(FlameArtilleryConstruct_15Builder.FlameArtilleryConstruct_15.Name);
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -348,8 +295,5 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonFlameArtilleryConstruct_15 = CreateAndAddToDB(SummonFlameArtilleryConstruct_15Name, SummonFlameArtilleryConstruct_15Guid);
-
     }
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Flame.cs
@@ -23,7 +23,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
 
-            DamageForm FlameArtillery = new DamageForm
+            DamageForm flameArtillery = new DamageForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 2,
@@ -37,7 +37,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectForm effect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (FlameArtillery)
+                DamageForm = flameArtillery
             };
             effect.SetCreatedByCharacter(true);
             effect.SavingThrowAffinity = RuleDefinitions.EffectSavingThrowType.HalfDamage;
@@ -69,7 +69,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower FlameArtillery = CreateAndAddToDB(FlameArtilleryName, FlameArtilleryGuid);
+        public static readonly FeatureDefinitionPower FlameArtillery = CreateAndAddToDB(FlameArtilleryName, FlameArtilleryGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -96,7 +96,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtillery_2Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower FlameArtillery_2 = CreateAndAddToDB(FlameArtillery_2Name, FlameArtillery_2Guid);
+        public static readonly FeatureDefinitionPower FlameArtillery_2 = CreateAndAddToDB(FlameArtillery_2Name, FlameArtillery_2Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -169,7 +169,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
+        public static readonly MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
     }
 
     internal class FlameArtilleryConstruct_9Builder : BaseDefinitionBuilder<MonsterDefinition>
@@ -190,7 +190,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct_9 = CreateAndAddToDB(FlameArtilleryConstruct_9Name, FlameArtilleryConstruct_9Guid);
+        public static readonly MonsterDefinition FlameArtilleryConstruct_9 = CreateAndAddToDB(FlameArtilleryConstruct_9Name, FlameArtilleryConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -214,7 +214,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new FlameArtilleryConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition FlameArtilleryConstruct_15 = CreateAndAddToDB(FlameArtilleryConstruct_15Name, FlameArtilleryConstruct_15Guid);
+        public static readonly MonsterDefinition FlameArtilleryConstruct_15 = CreateAndAddToDB(FlameArtilleryConstruct_15Name, FlameArtilleryConstruct_15Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -245,7 +245,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonFlameArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct = CreateAndAddToDB(SummonFlameArtilleryConstructName, SummonFlameArtilleryConstructGuid);
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct = CreateAndAddToDB(SummonFlameArtilleryConstructName, SummonFlameArtilleryConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -269,7 +269,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonFlameArtillerySpellConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct_9 = CreateAndAddToDB(SummonFlameArtilleryConstruct_9Name, SummonFlameArtilleryConstruct_9Guid);
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct_9 = CreateAndAddToDB(SummonFlameArtilleryConstruct_9Name, SummonFlameArtilleryConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -294,6 +294,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonFlameArtillerySpellConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonFlameArtilleryConstruct_15 = CreateAndAddToDB(SummonFlameArtilleryConstruct_15Name, SummonFlameArtilleryConstruct_15Guid);
+        public static readonly SpellDefinition SummonFlameArtilleryConstruct_15 = CreateAndAddToDB(SummonFlameArtilleryConstruct_15Name, SummonFlameArtilleryConstruct_15Guid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
@@ -17,7 +17,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ForceArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // can use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -46,10 +45,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
 
-
-
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(15);
@@ -77,10 +72,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             // Definition.Features.Add(ForceArtilleryBuilder.ForceArtillery);
 
-
-
             Definition.AttackIterations.Clear();
-
 
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
 
@@ -90,11 +82,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.AttackIterations.AddRange(new List<MonsterAttackIteration> { monsterAttackIteration });
 
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -103,10 +91,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition ForceArtilleryConstruct = CreateAndAddToDB(ForceArtilleryConstructName, ForceArtilleryConstructGuid);
-
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ForceArtilleryConstruct_9Builder		*******************************************************************
@@ -126,7 +111,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(ForceArtilleryAdditionalDamageBuilder.ForceArtilleryAdditionalDamage);
 
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -135,11 +119,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition ForceArtilleryConstruct_9 = CreateAndAddToDB(ForceArtilleryConstruct_9Name, ForceArtilleryConstruct_9Guid);
-
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		ForceArtilleryConstruct_15Builder		*******************************************************************
@@ -156,7 +136,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryConstructDescription_3";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -165,10 +144,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition ForceArtilleryConstruct_15 = CreateAndAddToDB(ForceArtilleryConstruct_15Name, ForceArtilleryConstruct_15Guid);
-
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstructBuilder		*******************************************************************
@@ -181,7 +157,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonForceArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtilleryModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -191,11 +166,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.ForceArtillery_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -204,10 +175,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonForceArtilleryConstruct = CreateAndAddToDB(SummonForceArtilleryConstructName, SummonForceArtilleryConstructGuid);
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstruct_9Builder		*******************************************************************
@@ -220,14 +188,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonForceArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtillery_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtillery_09ModePowerDescription";
 
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct_9Builder.ForceArtilleryConstruct_9.Name);
             //
-
-
 
         }
 
@@ -237,10 +202,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonForceArtilleryConstruct_9 = CreateAndAddToDB(SummonForceArtilleryConstruct_9Name, SummonForceArtilleryConstruct_9Guid);
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonForceArtillerySpellConstruct_15Builder		*******************************************************************
@@ -253,17 +215,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonForceArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonForceArtillerySpellConstructBuilder.SummonForceArtilleryConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtillery_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&ForceArtillery_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
 
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(ForceArtilleryConstruct_15Builder.ForceArtilleryConstruct_15.Name);
-
-
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -272,10 +228,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonForceArtilleryConstruct_15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
-
     }
-
-
 
     internal class ForceArtilleryAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
     {
@@ -284,7 +237,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ForceArtilleryAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Orc_Grimblade_IceDagger, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryTitle";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -369,7 +321,6 @@ Web
             EffectParticleParameters effectParticleParameters = new EffectParticleParameters();
             effectParticleParameters.Copy(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
             Definition.EffectDescription.SetEffectParticleParameters(effectParticleParameters);
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -378,8 +329,6 @@ Web
         }
 
         public static MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
-
-
     }
 
     internal class ForceArtilleryAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
@@ -389,7 +338,6 @@ Web
 
         protected ForceArtilleryAdditionalDamageBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamageDomainLifeDivineStrike, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&ForceArtilleryAdditionalDamageTitle";
             Definition.GuiPresentation.Description = "Feat/&ForceArtilleryAdditionalDamageDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -400,7 +348,6 @@ Web
             Definition.SetDamageDieType(RuleDefinitions.DieType.D8);
             Definition.SetNotificationTag("UpgradedConstruct");
             Definition.SetLimitedUsage(RuleDefinitions.FeatureLimitedUsage.None);
-
         }
 
         public static FeatureDefinitionAdditionalDamage CreateAndAddToDB(string name, string guid)
@@ -409,12 +356,7 @@ Web
         }
 
         public static FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
-
-
     }
-
-
-
 
     internal class ForceArtilleryProjectileBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
@@ -423,7 +365,6 @@ Web
 
         protected ForceArtilleryProjectileBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.OrcGrimblade_IceDagger, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Item/&ForceArtilleryProjectileTitle";
             Definition.GuiPresentation.Description = "Item/&ForceArtilleryProjectileDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.MagicMissile.GuiPresentation.SpriteReference);
@@ -431,7 +372,6 @@ Web
             EffectParticleParameters effectParticleParameters = new EffectParticleParameters();
             effectParticleParameters.Copy(DatabaseHelper.SpellDefinitions.MagicMissile.EffectDescription.EffectParticleParameters);
             Definition.AmmunitionDescription.EffectDescription.SetEffectParticleParameters(effectParticleParameters);
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -440,8 +380,5 @@ Web
         }
 
         public static ItemDefinition ForceArtilleryProjectile = CreateAndAddToDB(ForceArtilleryProjectileName, ForceArtilleryProjectileGuid);
-
-
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
@@ -90,7 +90,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ForceArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct = CreateAndAddToDB(ForceArtilleryConstructName, ForceArtilleryConstructGuid);
+        public static readonly MonsterDefinition ForceArtilleryConstruct = CreateAndAddToDB(ForceArtilleryConstructName, ForceArtilleryConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -118,7 +118,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ForceArtilleryConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct_9 = CreateAndAddToDB(ForceArtilleryConstruct_9Name, ForceArtilleryConstruct_9Guid);
+        public static readonly MonsterDefinition ForceArtilleryConstruct_9 = CreateAndAddToDB(ForceArtilleryConstruct_9Name, ForceArtilleryConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -143,7 +143,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ForceArtilleryConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ForceArtilleryConstruct_15 = CreateAndAddToDB(ForceArtilleryConstruct_15Name, ForceArtilleryConstruct_15Guid);
+        public static readonly MonsterDefinition ForceArtilleryConstruct_15 = CreateAndAddToDB(ForceArtilleryConstruct_15Name, ForceArtilleryConstruct_15Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -174,7 +174,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonForceArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct = CreateAndAddToDB(SummonForceArtilleryConstructName, SummonForceArtilleryConstructGuid);
+        public static readonly SpellDefinition SummonForceArtilleryConstruct = CreateAndAddToDB(SummonForceArtilleryConstructName, SummonForceArtilleryConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -201,7 +201,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonForceArtillerySpellConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct_9 = CreateAndAddToDB(SummonForceArtilleryConstruct_9Name, SummonForceArtilleryConstruct_9Guid);
+        public static readonly SpellDefinition SummonForceArtilleryConstruct_9 = CreateAndAddToDB(SummonForceArtilleryConstruct_9Name, SummonForceArtilleryConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -227,7 +227,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonForceArtillerySpellConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonForceArtilleryConstruct_15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
+        public static readonly SpellDefinition SummonForceArtilleryConstruct_15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
     }
 
     internal class ForceArtilleryAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
@@ -284,7 +284,7 @@ Web
             effectmotion.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effectmotion.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
-            DamageForm ForceArtilleryAttack = new DamageForm
+            DamageForm forceArtilleryAttack = new DamageForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 2,
@@ -295,7 +295,7 @@ Web
             EffectForm effect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (ForceArtilleryAttack)
+                DamageForm = forceArtilleryAttack
             };
             effect.SetCreatedByCharacter(true);
             effect.HasSavingThrow = false;
@@ -328,7 +328,7 @@ Web
             return new ForceArtilleryAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
+        public static readonly MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
     }
 
     internal class ForceArtilleryAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
@@ -355,7 +355,7 @@ Web
             return new ForceArtilleryAdditionalDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
+        public static readonly FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
     }
 
     internal class ForceArtilleryProjectileBuilder : BaseDefinitionBuilder<ItemDefinition>
@@ -379,6 +379,6 @@ Web
             return new ForceArtilleryProjectileBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ForceArtilleryProjectile = CreateAndAddToDB(ForceArtilleryProjectileName, ForceArtilleryProjectileGuid);
+        public static readonly ItemDefinition ForceArtilleryProjectile = CreateAndAddToDB(ForceArtilleryProjectileName, ForceArtilleryProjectileGuid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Force.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using UnityEngine.AddressableAssets;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
@@ -137,7 +137,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel03FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel03FeatureSet = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel03FeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -250,7 +250,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel09FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel09FeatureSet = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel09FeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -378,7 +378,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtilleryConstructlevel15FeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ArtilleryConstructlevel15FeatureSet = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionFeatureSet ArtilleryConstructlevel15FeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -427,7 +427,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             EffectForm ExplosionEffect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Damage,
-                DamageForm = (ExplosionDamage)
+                DamageForm = ExplosionDamage
             };
             ExplosionEffect.SetCreatedByCharacter(true);
             ExplosionEffect.HasSavingThrow = true;
@@ -470,7 +470,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfDestructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SelfDestruct = CreateAndAddToDB(SelfDestructName, SelfDestructGuid);
+        public static readonly FeatureDefinitionPower SelfDestruct = CreateAndAddToDB(SelfDestructName, SelfDestructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -520,7 +520,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfDestructionConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition SelfDestructionCondition = CreateAndAddToDB(SelfDestructionConditionName, SelfDestructionConditionGuid);
+        public static readonly ConditionDefinition SelfDestructionCondition = CreateAndAddToDB(SelfDestructionConditionName, SelfDestructionConditionGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -538,25 +538,25 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Description = "Feat/&HalfCoverShieldDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Shield.GuiPresentation.SpriteReference);
 
-            EffectForm HalfCoverShield = new EffectForm
+            EffectForm halfCoverShield = new EffectForm
             {
                 ConditionForm = new ConditionForm(),
                 FormType = EffectForm.EffectFormType.Condition
             };
-            HalfCoverShield.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
-            HalfCoverShield.ConditionForm.SetConditionDefinitionName(HalfCoverShieldConditionBuilder.HalfCoverShieldCondition.Name);
-            HalfCoverShield.ConditionForm.ConditionDefinition = HalfCoverShieldConditionBuilder.HalfCoverShieldCondition;// DistractingPulseBuilder.DistractingPulse;
+            halfCoverShield.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
+            halfCoverShield.ConditionForm.SetConditionDefinitionName(HalfCoverShieldConditionBuilder.HalfCoverShieldCondition.Name);
+            halfCoverShield.ConditionForm.ConditionDefinition = HalfCoverShieldConditionBuilder.HalfCoverShieldCondition;// DistractingPulseBuilder.DistractingPulse;
 
-            HalfCoverShield.SetCreatedByCharacter(true);
+            halfCoverShield.SetCreatedByCharacter(true);
 
-            HalfCoverShield.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
-            HalfCoverShield.SetLevelMultiplier(1);
-            HalfCoverShield.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
-            HalfCoverShield.SetApplyLevel(EffectForm.LevelApplianceType.No);
+            halfCoverShield.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
+            halfCoverShield.SetLevelMultiplier(1);
+            halfCoverShield.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
+            halfCoverShield.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
-            Definition.EffectDescription.EffectForms.Add(HalfCoverShield);
+            Definition.EffectDescription.EffectForms.Add(halfCoverShield);
             Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.Sphere);
             Definition.EffectDescription.SetTargetParameter(2);
             Definition.EffectDescription.SetTargetSide(RuleDefinitions.Side.Ally);
@@ -575,7 +575,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower HalfCoverShield = CreateAndAddToDB(HalfCoverShieldName, HalfCoverShieldGuid);
+        public static readonly FeatureDefinitionPower HalfCoverShield = CreateAndAddToDB(HalfCoverShieldName, HalfCoverShieldGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -601,7 +601,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition HalfCoverShieldCondition = CreateAndAddToDB(HalfCoverShieldConditionName, HalfCoverShieldConditionGuid);
+        public static readonly ConditionDefinition HalfCoverShieldCondition = CreateAndAddToDB(HalfCoverShieldConditionName, HalfCoverShieldConditionGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -628,7 +628,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new HalfCoverShieldAttributeBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAttributeModifier HalfCoverShieldAttribute = CreateAndAddToDB(HalfCoverShieldAttributeName, HalfCoverShieldAttributeGuid);
+        public static readonly FeatureDefinitionAttributeModifier HalfCoverShieldAttribute = CreateAndAddToDB(HalfCoverShieldAttributeName, HalfCoverShieldAttributeGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -667,7 +667,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonArtillerySpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct = CreateAndAddToDB(SummonArtillerySpellConstructName, SummonArtillerySpellConstructGuid);
+        public static readonly SpellDefinition SummonArtillerySpellConstruct = CreateAndAddToDB(SummonArtillerySpellConstructName, SummonArtillerySpellConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -698,7 +698,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonArtillerySpellConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct_9 = CreateAndAddToDB(SummonArtillerySpellConstruct_9Name, SummonArtillerySpellConstruct_9Guid);
+        public static readonly SpellDefinition SummonArtillerySpellConstruct_9 = CreateAndAddToDB(SummonArtillerySpellConstruct_9Name, SummonArtillerySpellConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -729,7 +729,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonArtillerySpellConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonArtillerySpellConstruct_15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
+        public static readonly SpellDefinition SummonArtillerySpellConstruct_15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
     }
 
     internal class SummoningAffinityTinkererArtilleryConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
@@ -782,6 +782,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummoningAffinityTinkererArtilleryConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererArtilleryConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionSummoningAffinity SummoningAffinityTinkererArtilleryConstruct = CreateAndAddToDB(Name, Guid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_Shared.cs
@@ -7,8 +7,6 @@ using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
-
     //*****************************************************************************************************************************************
     //***********************************		ArtilleryConstructlevel03FeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
@@ -23,10 +21,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionPowerSharedPool ForceArtillery_03modepower;
         public static FeatureDefinitionPowerSharedPool TempHPShield_03modepower;
 
-
         protected ArtilleryConstructlevel03FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructDescription";
 
@@ -47,8 +43,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                    RuleDefinitions.RechargeRate.ShortRest,
                    guiPresentationArtilleryMode
                ).AddToDB();
-
-
 
             GuiPresentationBuilder guiPresentationFlameArtillery03 = new GuiPresentationBuilder(
                 "Feature/&FlameArtilleryModePowerDescription",
@@ -75,8 +69,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , guiPresentationFlameArtillery03.Build()                     // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
-
-
 
             GuiPresentationBuilder guiPresentationForceArtillery03 = new GuiPresentationBuilder(
                 "Feature/&ForceArtilleryModePowerDescription",
@@ -114,7 +106,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectTempHPShieldmode03.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectTempHPShieldmode03.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstructBuilder.TempHPShieldConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-
             TempHPShield_03modepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
                  "TempHPShieldModePower"                                         // string name
@@ -131,7 +122,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
 
-
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ArtilleryModePool);
             Definition.FeatureSet.Add(TempHPShield_03modepower);
@@ -140,7 +130,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.FeatureSet.Add(AddConstructCantripsBuilder.AddConstructCantrips);
             //Definition.FeatureSet.Add(SummoningAffinityTinkererConstructBuilder.SummoningAffinityTinkererConstruct);
             Definition.FeatureSet.Add(SummoningAffinityTinkererArtilleryConstructBuilder.SummoningAffinityTinkererArtilleryConstruct);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -149,7 +138,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionFeatureSet ArtilleryConstructlevel03FeatureSet = CreateAndAddToDB(Name, Guid);
-
     }
 
     //*****************************************************************************************************************************************
@@ -167,12 +155,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtilleryConstructlevel09FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructlevel09Title";
             Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructlevel09Description";
-
-
-
 
             GuiPresentationBuilder guiPresentationFlameArtillery09 = new GuiPresentationBuilder(
                 "Feature/&FlameArtillery_09ModePowerDescription",
@@ -183,7 +167,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectFlameArtillerymode09.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectFlameArtillerymode09.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectFlameArtillerymode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct_9Builder.FlameArtilleryConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
 
             FlameArtillery_09modepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
@@ -201,7 +184,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
             FlameArtillery_09modepower.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.FlameArtillery_03modepower);
-
 
             GuiPresentationBuilder guiPresentationForceArtillery09 = new GuiPresentationBuilder(
                 "Feature/&ForceArtillery_09ModePowerDescription",
@@ -230,8 +212,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ).AddToDB();
             ForceArtillery_09modepower.SetOverriddenPower(ArtilleryConstructlevel03FeatureSetBuilder.ForceArtillery_03modepower);
 
-
-
             GuiPresentationBuilder guiPresentationTempHPShield09 = new GuiPresentationBuilder(
                 "Feature/&TempHPShield_09ModePowerDescription",
                 "Feature/&TempHPShield_09ModePowerTitle");
@@ -241,7 +221,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectTempHPShieldmode09.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectTempHPShieldmode09.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectTempHPShieldmode09.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct_9Builder.TempHPShieldConstruct_9.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
 
             TempHPShield_09modepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
@@ -264,8 +243,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.FeatureSet.Add(TempHPShield_09modepower);
             Definition.FeatureSet.Add(FlameArtillery_09modepower);
             Definition.FeatureSet.Add(ForceArtillery_09modepower);
-
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -274,7 +251,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionFeatureSet ArtilleryConstructlevel09FeatureSet = CreateAndAddToDB(Name, Guid);
-
     }
 
     //*****************************************************************************************************************************************
@@ -292,7 +268,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtilleryConstructlevel15FeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonArtilleryConstructlevel15Title";
             Definition.GuiPresentation.Description = "Feat/&SummonArtilleryConstructlevel15Description";
 
@@ -320,7 +295,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectFlameArtillerymode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectFlameArtillerymode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, FlameArtilleryConstruct_15Builder.FlameArtilleryConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-
             FlameArtillery_15modepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
                  "FlameArtillery_15ModePower"                                   // string name
@@ -337,7 +311,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
             FlameArtillery_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.FlameArtillery_09modepower);
-
 
             GuiPresentationBuilder guiPresentationForceArtillery15 = new GuiPresentationBuilder(
                 "Feature/&ForceArtillery_15ModePowerDescription",
@@ -366,8 +339,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ).AddToDB();
             ForceArtillery_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.ForceArtillery_09modepower);
 
-
-
             GuiPresentationBuilder guiPresentationTempHPShield15 = new GuiPresentationBuilder(
                 "Feature/&TempHPShield_15ModePowerDescription",
                 "Feature/&TempHPShield_15ModePowerTitle");
@@ -377,7 +348,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectTempHPShieldmode15.SetDurationData(RuleDefinitions.DurationType.Hour, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             effectTempHPShieldmode15.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             effectTempHPShieldmode15.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, TempHPShieldConstruct_15Builder.TempHPShieldConstruct_15.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
-
 
             TempHPShield_15modepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
@@ -396,19 +366,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ).AddToDB();
             TempHPShield_15modepower.SetOverriddenPower(ArtilleryConstructlevel09FeatureSetBuilder.TempHPShield_09modepower);
 
-
-
-
-
-
-
-
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ArtilleryPoolIncrease);
             Definition.FeatureSet.Add(TempHPShield_15modepower);
             Definition.FeatureSet.Add(FlameArtillery_15modepower);
             Definition.FeatureSet.Add(ForceArtillery_15modepower);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -417,9 +379,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionFeatureSet ArtilleryConstructlevel15FeatureSet = CreateAndAddToDB(Name, Guid);
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SelfDestructBuilder		*******************************************************************
@@ -432,7 +392,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SelfDestructBuilder(string name, string guid) : base(ThunderShieldBuilder.ThunderShield, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SelfDestructTitle";
             Definition.GuiPresentation.Description = "Feat/&SelfDestructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.FlamingSphere.GuiPresentation.SpriteReference);
@@ -440,9 +399,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
-
-
-
 
             // SelfDestructionConditionBuilder.SelfDestructionCondition
 
@@ -459,8 +415,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // CounterForm SelfDestruct = new CounterForm();
             //
             // SelfDestruct.SetType (CounterForm.CounterType.DismissCreature);
-
-
 
             DamageForm ExplosionDamage = new DamageForm
             {
@@ -517,8 +471,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower SelfDestruct = CreateAndAddToDB(SelfDestructName, SelfDestructGuid);
-
-
     }
 
     //*****************************************************************************************************************************************
@@ -554,7 +506,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             KillEffect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             KillEffect.SetApplyLevel(EffectForm.LevelApplianceType.No);
 
-
             Definition.RecurrentEffectForms.Add(KillEffect);
 
             Definition.SetDurationType(RuleDefinitions.DurationType.Permanent);
@@ -562,8 +513,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetSpecialDuration(true);
             Definition.SetDurationParameter(1);
             Definition.SetConditionType(RuleDefinitions.ConditionType.Detrimental);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -585,7 +534,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected HalfCoverShieldBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDomainBattleHeraldOfBattle, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&HalfCoverShieldTitle";
             Definition.GuiPresentation.Description = "Feat/&HalfCoverShieldDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Shield.GuiPresentation.SpriteReference);
@@ -599,14 +547,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             HalfCoverShield.ConditionForm.SetConditionDefinitionName(HalfCoverShieldConditionBuilder.HalfCoverShieldCondition.Name);
             HalfCoverShield.ConditionForm.ConditionDefinition = HalfCoverShieldConditionBuilder.HalfCoverShieldCondition;// DistractingPulseBuilder.DistractingPulse;
 
-
             HalfCoverShield.SetCreatedByCharacter(true);
 
             HalfCoverShield.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
             HalfCoverShield.SetLevelMultiplier(1);
             HalfCoverShield.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             HalfCoverShield.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
@@ -630,8 +576,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower HalfCoverShield = CreateAndAddToDB(HalfCoverShieldName, HalfCoverShieldGuid);
-
-
     }
 
     //*****************************************************************************************************************************************
@@ -650,10 +594,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Clear();
             Definition.Features.Add(HalfCoverShieldAttributeBuilder.HalfCoverShieldAttribute);
-
-
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -675,17 +615,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected HalfCoverShieldAttributeBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAttributeModifiers.AttributeModifierHeraldOfBattle, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Rules/&HalfCoverShieldAttributeTitle";
             Definition.GuiPresentation.Description = "Rules/&HalfCoverShieldAttributeDescription";
 
             Definition.SetModifiedAttribute(DatabaseHelper.SmartAttributeDefinitions.ArmorClass.Name);
             Definition.SetModifierType2(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive);
             Definition.SetModifierValue(2);
-
-
-
         }
 
         public static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
@@ -695,8 +630,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionAttributeModifier HalfCoverShieldAttribute = CreateAndAddToDB(HalfCoverShieldAttributeName, HalfCoverShieldAttributeGuid);
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonArtillerySpellConstructBuilder		*******************************************************************
@@ -709,7 +642,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonArtillerySpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_03Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.FaerieFire.GuiPresentation.SpriteReference);
@@ -718,7 +650,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetRequiresConcentration(false);
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
-
 
             Definition.SetSpellsBundle(true);
             Definition.SubspellsList.AddRange(new List<SpellDefinition>
@@ -729,8 +660,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             });
 
             Definition.EffectDescription.Clear();
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -739,7 +668,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonArtillerySpellConstruct = CreateAndAddToDB(SummonArtillerySpellConstructName, SummonArtillerySpellConstructGuid);
-
     }
 
     //*****************************************************************************************************************************************
@@ -753,7 +681,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonArtillerySpellConstruct_9Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_09Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
 
@@ -772,9 +699,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonArtillerySpellConstruct_9 = CreateAndAddToDB(SummonArtillerySpellConstruct_9Name, SummonArtillerySpellConstruct_9Guid);
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonArtillerySpellConstruct_15Builder		*******************************************************************
@@ -787,10 +712,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonArtillerySpellConstruct_15Builder(string name, string guid) : base(SummonArtillerySpellConstructBuilder.SummonArtillerySpellConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ResummonArtilleryConstruct_15Title";
             Definition.GuiPresentation.Description = "Feat/&ResummonArtilleryConstructDescription";
-
 
             Definition.SubspellsList.Clear();
             Definition.SubspellsList.AddRange(new List<SpellDefinition>
@@ -799,9 +722,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                SummonForceArtillerySpellConstruct_15Builder.SummonForceArtilleryConstruct_15,
                 SummonTempHPShieldSpellConstruct_15Builder.SummonTempHPShieldConstruct_15
             });
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -812,7 +732,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static SpellDefinition SummonArtillerySpellConstruct_15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
     }
 
-
     internal class SummoningAffinityTinkererArtilleryConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
     {
         private const string Name = "SummoningAffinityTinkererArtilleryConstruct";
@@ -820,7 +739,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummoningAffinityTinkererArtilleryConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionSummoningAffinitys.SummoningAffinityKindredSpiritBond, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&NoContentTitle";
             Definition.GuiPresentation.Description = "Feature/&NoContentTitle";
             Definition.GuiPresentation.SetSpriteReference(null);
@@ -865,7 +783,5 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererArtilleryConstruct = CreateAndAddToDB(Name, Guid);
-
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
@@ -23,7 +23,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
 
-            TemporaryHitPointsForm TempHPShield = new TemporaryHitPointsForm
+            TemporaryHitPointsForm tempHPShield = new TemporaryHitPointsForm
             {
                 DieType = RuleDefinitions.DieType.D8,
                 DiceNumber = 1,
@@ -35,7 +35,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             {
                 FormType = EffectForm.EffectFormType.TemporaryHitPoints
             };
-            effect.SetTemporaryHitPointsForm(TempHPShield);
+            effect.SetTemporaryHitPointsForm(tempHPShield);
             effect.SetCreatedByCharacter(true);
 
             effect.AddBonusMode = RuleDefinitions.AddBonusMode.AbilityBonus;
@@ -64,7 +64,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower TempHPShield = CreateAndAddToDB(TempHPShieldName, TempHPShieldGuid);
+        public static readonly FeatureDefinitionPower TempHPShield = CreateAndAddToDB(TempHPShieldName, TempHPShieldGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstructBuilder		*******************************************************************
@@ -139,7 +139,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct = CreateAndAddToDB(TempHPShieldConstructName, TempHPShieldConstructGuid);
+        public static readonly MonsterDefinition TempHPShieldConstruct = CreateAndAddToDB(TempHPShieldConstructName, TempHPShieldConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -163,7 +163,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct_9 = CreateAndAddToDB(TempHPShieldConstruct_9Name, TempHPShieldConstruct_9Guid);
+        public static readonly MonsterDefinition TempHPShieldConstruct_9 = CreateAndAddToDB(TempHPShieldConstruct_9Name, TempHPShieldConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -187,7 +187,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TempHPShieldConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition TempHPShieldConstruct_15 = CreateAndAddToDB(TempHPShieldConstruct_15Name, TempHPShieldConstruct_15Guid);
+        public static readonly MonsterDefinition TempHPShieldConstruct_15 = CreateAndAddToDB(TempHPShieldConstruct_15Name, TempHPShieldConstruct_15Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -218,7 +218,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonTempHPShieldSpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct = CreateAndAddToDB(SummonTempHPShieldConstructName, SummonTempHPShieldConstructGuid);
+        public static readonly SpellDefinition SummonTempHPShieldConstruct = CreateAndAddToDB(SummonTempHPShieldConstructName, SummonTempHPShieldConstructGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -243,7 +243,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonTempHPShieldSpellConstruct_9Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct_9 = CreateAndAddToDB(SummonTempHPShieldConstruct_9Name, SummonTempHPShieldConstruct_9Guid);
+        public static readonly SpellDefinition SummonTempHPShieldConstruct_9 = CreateAndAddToDB(SummonTempHPShieldConstruct_9Name, SummonTempHPShieldConstruct_9Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -268,6 +268,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonTempHPShieldSpellConstruct_15Builder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonTempHPShieldConstruct_15 = CreateAndAddToDB(SummonTempHPShieldConstruct_15Name, SummonTempHPShieldConstruct_15Guid);
+        public static readonly SpellDefinition SummonTempHPShieldConstruct_15 = CreateAndAddToDB(SummonTempHPShieldConstruct_15Name, SummonTempHPShieldConstruct_15Guid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ArtilleryConstruct_TempHP.cs
@@ -4,7 +4,6 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldBuilder		*******************************************************************
     //*****************************************************************************************************************************************
@@ -16,7 +15,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TempHPShieldBuilder(string name, string guid) : base(ThunderShieldBuilder.ThunderShield, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShieldTitle";
             Definition.SetShortTitleOverride("Feature/&TempHPShieldTitle");
             Definition.GuiPresentation.Description = "Feat/&TempHPShieldDescription";
@@ -24,7 +22,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.Action);
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.AtWill);
-
 
             TemporaryHitPointsForm TempHPShield = new TemporaryHitPointsForm
             {
@@ -45,7 +42,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effect.SetLevelMultiplier(1);
             effect.SetLevelType(RuleDefinitions.LevelSourceType.EffectLevel);
             effect.SetApplyLevel(EffectForm.LevelApplianceType.No);
-
 
             Definition.EffectDescription.EffectAdvancement.Clear();
             Definition.EffectDescription.EffectForms.Clear();
@@ -69,8 +65,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower TempHPShield = CreateAndAddToDB(TempHPShieldName, TempHPShieldGuid);
-
-
     }
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstructBuilder		*******************************************************************
@@ -83,7 +77,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TempHPShieldConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Magic_Mouth, name, guid)
         {
-
             // cant use set, need to copy individual parts of presentation
             //Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.CubeOfLight.MonsterPresentation);
 
@@ -110,10 +103,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(10);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(10);     // CHA
-
-
-
-
 
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
@@ -142,12 +131,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.Features.Add(TempHPShieldBuilder.TempHPShield);
 
-
-
-
             Definition.CreatureTags.Add("ScalingTinkererArtilleryConstruct");
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -156,10 +140,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition TempHPShieldConstruct = CreateAndAddToDB(TempHPShieldConstructName, TempHPShieldConstructGuid);
-
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstruct_9Builder		*******************************************************************
@@ -175,7 +156,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&TempHPShieldConstructTitle_3";
 
             Definition.Features.Add(SelfDestructBuilder.SelfDestruct);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -184,11 +164,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition TempHPShieldConstruct_9 = CreateAndAddToDB(TempHPShieldConstruct_9Name, TempHPShieldConstruct_9Guid);
-
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		TempHPShieldConstruct_15Builder		*******************************************************************
@@ -204,7 +180,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&TempHPShieldConstructTitle_5";
 
             Definition.Features.Add(HalfCoverShieldBuilder.HalfCoverShield);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -213,11 +188,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition TempHPShieldConstruct_15 = CreateAndAddToDB(TempHPShieldConstruct_15Name, TempHPShieldConstruct_15Guid);
-
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstructBuilder		*******************************************************************
@@ -230,7 +201,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonTempHPShieldSpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShieldModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShieldModePowerDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Aid.GuiPresentation.SpriteReference);
@@ -240,12 +210,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetUniqueInstance(true);
             Definition.SetCastingTime(RuleDefinitions.ActivationTime.Action);
 
-
-
-
             Definition.SetEffectDescription(ArtilleryConstructlevel03FeatureSetBuilder.TempHPShield_03modepower.EffectDescription);
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -254,13 +219,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonTempHPShieldConstruct = CreateAndAddToDB(SummonTempHPShieldConstructName, SummonTempHPShieldConstructGuid);
-
     }
-
-
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstruct_9Builder		*******************************************************************
@@ -273,15 +232,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonTempHPShieldSpellConstruct_9Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShield_09ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShield_09ModePowerDescription";
 
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct_9Builder.TempHPShieldConstruct_9.Name);
-
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -290,10 +244,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonTempHPShieldConstruct_9 = CreateAndAddToDB(SummonTempHPShieldConstruct_9Name, SummonTempHPShieldConstruct_9Guid);
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonTempHPShieldSpellConstruct_15Builder		*******************************************************************
@@ -306,15 +257,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonTempHPShieldSpellConstruct_15Builder(string name, string guid) : base(SummonTempHPShieldSpellConstructBuilder.SummonTempHPShieldConstruct, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&TempHPShield_15ModePowerTitle";
             Definition.GuiPresentation.Description = "Feature/&TempHPShield_15ModePowerDescription";
             Definition.SetUniqueInstance(false);
             Definition.EffectDescription.EffectForms[0].SummonForm.SetMonsterDefinitionName(TempHPShieldConstruct_15Builder.TempHPShieldConstruct_15.Name);
-
-
-
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -323,11 +269,5 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonTempHPShieldConstruct_15 = CreateAndAddToDB(SummonTempHPShieldConstruct_15Name, SummonTempHPShieldConstruct_15Guid);
-
     }
-
-
-
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
@@ -7,7 +7,7 @@ using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    public class BattleSmithBuilder
+    public static class BattleSmithBuilder
     {
         public static CharacterSubclassDefinition Build(CharacterClassDefinition artificer)
         {
@@ -123,7 +123,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return battleSmith.AddToDB();
         }
 
-        private class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        private sealed class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             public FeatureDefinitionAttackModifierBuilder(string name, string guid,
             RuleDefinitions.AbilityScoreReplacement abilityReplacement, string additionalAttackTag,

--- a/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
@@ -46,7 +46,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             GuiPresentationBuilder weaponProfPresentation = new GuiPresentationBuilder(
                 "Subclass/&WeaponProfArtificerBattleSmithDescription",
                 "Subclass/&WeaponProfArtificerBattleSmithTitle");
-            FeatureDefinitionProficiency weaponProf = FeatureHelpers.BuildProficiency(RuleDefinitions.ProficiencyType.Weapon,
+            FeatureDefinitionProficiency weaponProf = FeatureHelpers.BuildProficiency(ProficiencyType.Weapon,
                 new List<string>() { EquipmentDefinitions.MartialWeaponCategory },
                 "ProficiencyWeaponArtificerBattleSmith", weaponProfPresentation.Build());
             battleSmith.AddFeatureAtLevel(weaponProf, 3);
@@ -56,7 +56,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&HealingPoolArtificerBattleSmithInfusionsIncreaseTitle");
             FeatureDefinitionPowerPoolModifier InfusionPoolIncrease = new FeatureDefinitionPowerPoolModifierBuilder("AttributeModiferArtificerBattleSmithInfusionHealingPool",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "AttributeModiferArtificerBattleSmithInfusionHealingPool").ToString(),
-                2, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Intelligence, TinkererClass.InfusionPool, InfusionPoolIncreaseGui.Build()).AddToDB();
+                2, UsesDetermination.Fixed, AttributeDefinitions.Intelligence, TinkererClass.InfusionPool, InfusionPoolIncreaseGui.Build()).AddToDB();
             battleSmith.AddFeatureAtLevel(InfusionPoolIncrease, 3);
 
             GuiPresentationBuilder attackModGui = new GuiPresentationBuilder(
@@ -93,8 +93,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&AttackModifierArtificerBattleSmithJoltTitle");
             FeatureDefinitionAttackModifier joltAttack = FeatureHelpers.BuildAttackModifier(
                 // Note ability score bonus only works if it's applied to a weapon, not a character.
-                RuleDefinitions.AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
-                RuleDefinitions.AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
+                AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
+                AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
                 "AttackModifierArtificerBattleSmithJolt", joltAttackGui.Build());
             battleSmith.AddFeatureAtLevel(joltAttack, 9);
 
@@ -113,8 +113,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Feat/&AttackModifierArtificerBattleSmithJolt2Title");
             FeatureDefinitionAttackModifier jolt2Attack = FeatureHelpers.BuildAttackModifier(
                 // Note ability score bonus only works if it's applied to a weapon, not a character.
-                RuleDefinitions.AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
-                RuleDefinitions.AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
+                AttackModifierMethod.None, 0, AttributeDefinitions.Intelligence,
+                AttackModifierMethod.FlatValue, 3, AttributeDefinitions.Intelligence, false, "Magical",
                 "AttackModifierArtificerBattleSmithJolt2", jolt2AttackGui.Build());
             battleSmith.AddFeatureAtLevel(jolt2Attack, 15);
             battleSmith.AddFeatureAtLevel(ProtectorConstructUpgradeFeatureSetBuilder.ProtectorConstructUpgradeFeatureSet, 15);

--- a/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/BattleSmithBuilder.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new TinkererConstructFamilyBuilder(name, guid).AddToDB();
         }
 
-        public static CharacterFamilyDefinition TinkererConstructFamily = CreateAndAddToDB(TinkererConstructFamilyName, TinkererConstructFamilyGuid);
+        public static readonly CharacterFamilyDefinition TinkererConstructFamily = CreateAndAddToDB(TinkererConstructFamilyName, TinkererConstructFamilyGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -52,7 +52,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new AddConstructCantripsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionBonusCantrips AddConstructCantrips = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionBonusCantrips AddConstructCantrips = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -102,7 +102,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new MendingConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition MendingConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition MendingConstruct = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -127,14 +127,14 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetMaterialComponentType(RuleDefinitions.MaterialComponentType.None);
             Definition.SetVerboseComponent(false);
 
-            CounterForm DismissConstruct = new CounterForm();
-            DismissConstruct.SetType(CounterForm.CounterType.DismissCreature);
+            CounterForm dismissConstruct = new CounterForm();
+            dismissConstruct.SetType(CounterForm.CounterType.DismissCreature);
 
             EffectForm effect = new EffectForm
             {
                 FormType = EffectForm.EffectFormType.Counter
             };
-            effect.SetCounterForm(DismissConstruct);
+            effect.SetCounterForm(dismissConstruct);
             effect.HasSavingThrow = false;
             effect.SetCreatedByCharacter(true);
 
@@ -175,7 +175,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new DismissConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition DismissConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition DismissConstruct = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -268,7 +268,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtificialServantBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ArtificialServant = CreateAndAddToDB(ArtificialServantName, ArtificialServantGuid);
+        public static readonly MonsterDefinition ArtificialServant = CreateAndAddToDB(ArtificialServantName, ArtificialServantGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -326,7 +326,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ArtificialServantAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
+        public static readonly MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
     }
     internal class CancelFlyingConditionBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -374,6 +374,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new CancelFlyingConditionBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower CancelFlyingCondition = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionPower CancelFlyingCondition = CreateAndAddToDB(Name, Guid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ConstructCantripsAndArtificialServant.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
     ////*****************************************************************************************************************************************
     ////***********************************		TinkererConstructFamilyBuilder		*************************************************************
     ////*****************************************************************************************************************************************
@@ -18,9 +17,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected TinkererConstructFamilyBuilder(string name, string guid) : base(DatabaseHelper.CharacterFamilyDefinitions.Construct, name, guid)
         {
-
             Definition.SetExtraplanar(true);
-
         }
 
         public static CharacterFamilyDefinition CreateAndAddToDB(string name, string guid)
@@ -42,14 +39,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected AddConstructCantripsBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionBonusCantripss.BonusCantripsDomainOblivion, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&AddConstructCantripsTitle";
             Definition.GuiPresentation.Description = "Feat/&AddConstructCantripsDescription";
 
             Definition.BonusCantrips.Clear();
             Definition.BonusCantrips.Add(MendingConstructBuilder.MendingConstruct);
             Definition.BonusCantrips.Add(DismissConstructBuilder.DismissConstruct);
-
         }
 
         public static FeatureDefinitionBonusCantrips CreateAndAddToDB(string name, string guid)
@@ -71,7 +66,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected MendingConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.PrayerOfHealing, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&MendingConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&MendingConstructDescription";
 
@@ -101,7 +95,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.EffectDescription.EffectForms.Add(effect);
             Definition.EffectDescription.RestrictedCreatureFamilies.Add(TinkererConstructFamilyBuilder.TinkererConstructFamily.Name);
             Definition.EffectDescription.ImmuneCreatureFamilies.Clear();
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -123,7 +116,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected DismissConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.Banishment, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&DismissConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&DismissConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.AnimalFriendship.GuiPresentation.SpriteReference);
@@ -176,7 +168,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             });
 
             Definition.SetEffectDescription(effectDescription);
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -186,7 +177,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static SpellDefinition DismissConstruct = CreateAndAddToDB(Name, Guid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ArtificialServantBuilder		*******************************************************************
@@ -199,8 +189,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtificialServantBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.Fire_Jester, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Feat/&ArtificialServantTitle";
             Definition.GuiPresentation.Description = "Feat/&ArtificialServantDescription";
             Definition.MonsterPresentation.SetUniqueNameTitle("Feat/&ArtificialServantTitle");
@@ -242,8 +230,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SkillScores.Add(Stealth);
             Definition.SkillScores.Add(Perception);
 
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(10);
@@ -265,7 +251,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityPoisonImmunity);
             // Definition.Features.Add(DatabaseHelper.);
 
-
             Definition.AttackIterations.Clear();
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
             monsterAttackIteration.SetField("monsterAttackDefinition", ArtificialServantAttackBuilder.ArtificialServantAttack);
@@ -276,7 +261,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.MonsterPresentation.SetFemalePrefabReference(new UnityEngine.AddressableAssets.AssetReference("ab0501343e8629149ae0aa4dace755f5"));
             Definition.MonsterPresentation.SetMaleModelScale(0.2f);
             Definition.MonsterPresentation.SetFemaleModelScale(0.2f);
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -285,8 +269,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition ArtificialServant = CreateAndAddToDB(ArtificialServantName, ArtificialServantGuid);
-
-
     }
 
     //*****************************************************************************************************************************************
@@ -300,7 +282,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ArtificialServantAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Goblin_PebbleThrow, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ArtificialServantAttackTitle";
             Definition.GuiPresentation.Description = "Feat/&ArtificialServantAttackDescription";
 
@@ -314,12 +295,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 }
             };
 
-            int assumedIntModifier = 3;
-            int assumedProficiencyBonus = 2;
+            const int assumedIntModifier = 3;
+            const int assumedProficiencyBonus = 2;
             damageEffect.DamageForm.BonusDamage = assumedProficiencyBonus;
             damageEffect.DamageForm.DamageType = "DamageForce";
-
-
 
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
@@ -337,15 +316,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // newEffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.ShadowDagger.EffectDescription.EffectParticleParameters);
             newEffectDescription.SetEffectParticleParameters(DatabaseHelper.MonsterAttackDefinitions.Attack_Goblin_PebbleThrow.EffectDescription.EffectParticleParameters);
 
-
             Definition.SetEffectDescription(newEffectDescription);
 
             Definition.SetToHitBonus(assumedIntModifier + assumedProficiencyBonus);
-
-
-
-
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -354,8 +327,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
-
-
     }
     internal class CancelFlyingConditionBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -364,7 +335,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected CancelFlyingConditionBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionBootsWinged, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&CancelFlyingConditionTitle";
             Definition.GuiPresentation.Description = "Feat/&CancelFlyingConditionDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ExpeditiousRetreat.GuiPresentation.SpriteReference);
@@ -397,7 +367,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectDescription.EffectForms.Add(effect);
 
             Definition.SetEffectDescription(effectDescription);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -408,4 +377,3 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionPower CancelFlyingCondition = CreateAndAddToDB(Name, Guid);
     }
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
@@ -9,9 +9,8 @@ using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class FeatureHelpers
+    internal static class FeatureHelpers
     {
-
         // TODO Most of theese builders should likely get moved/merged with the CE builders.
         public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
         {
@@ -92,7 +91,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public class FeatureDefinitionMagicAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionMagicAffinity>
         {
-
             public FeatureDefinitionMagicAffinityBuilder(string name, string guid, RuleDefinitions.ConcentrationAffinity concentrationAffinity,
                 int threshold, GuiPresentation guiPresentation) : base(name, guid)
             {
@@ -311,7 +309,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             public FeatureDefinitionBonusCantripsBuilder(string name, string guid, List<SpellDefinition> cantrips, GuiPresentation guiPresentation) : base(name, guid)
             {
-
                 foreach (SpellDefinition cantrip in cantrips)
                 {
                     Definition.BonusCantrips.Add(cantrip);
@@ -372,7 +369,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 autospelllists, characterclass, guiPresentation);
             return builder.AddToDB();
         }
-
 
         public static FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup BuildAutoPreparedSpellGroup(int classLevel, List<SpellDefinition> spellnames)
         {
@@ -441,7 +437,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             particleParams.Copy(DatabaseHelper.FeatureDefinitionPowers.PowerWizardArcaneRecovery.EffectDescription.EffectParticleParameters);
             effectDescriptionBuilder.SetParticleEffectParameters(particleParams);
 
-
             FeatureDefinitionPowerBuilder builder = new FeatureDefinitionPowerBuilder(name, GuidHelper.Create(TinkererClass.GuidNamespace, name).ToString(),
                 usesPerRecharge, usesDetermination, AttributeDefinitions.Intelligence, activationTime, costPerUse, recharge, false, false, AttributeDefinitions.Intelligence,
                 effectDescriptionBuilder.Build(), guiPresentation);
@@ -477,7 +472,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionHealingModifier BuildHealingModifier(int healingBonusDiceNumber, RuleDefinitions.DieType healingBonusDiceType,
             RuleDefinitions.LevelSourceType addLevel, string name, GuiPresentation guiPresentation)
         {
-
             FeatureDefinitionHealingModifierBuilder healingModifier = new FeatureDefinitionHealingModifierBuilder(name, GuidHelper.Create(TinkererClass.GuidNamespace, name).ToString(),
                 healingBonusDiceNumber, healingBonusDiceType, addLevel, guiPresentation);
             return healingModifier.AddToDB();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
@@ -1,10 +1,10 @@
-﻿using HarmonyLib;
-using SolastaModApi;
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
 using SolastaCommunityExpansion.Builders;
+using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System;
-using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
@@ -219,7 +219,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                     {
                         abilityScoreName = abilityProficiency.Item1
                     };
-                    if (!String.IsNullOrEmpty(abilityProficiency.Item2))
+                    if (!string.IsNullOrEmpty(abilityProficiency.Item2))
                     {
                         group.proficiencyName = abilityProficiency.Item2;
                     }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -1,5 +1,4 @@
-﻿
-using HarmonyLib;
+﻿using HarmonyLib;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
@@ -10,7 +9,7 @@ using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class InfusionHelpers
+    internal static class InfusionHelpers
     {
         private static FeatureDefinitionPower artificialServant;
         private static FeatureDefinitionPower enhancedFocus;
@@ -271,7 +270,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&EquipmentModifierArtificerBagOfHolderDescription",
                 "Subclass/&EquipmentModifierArtificerBagOfHolderTitle");
             bagOfHoldingGui.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionPotionOfGiantStrengthCloud.GuiPresentation.SpriteReference);
-            return BuildItemConditionInfusion(bagOfHoldingCondition, "ArtificerInfusionBagOfHolding", bagOfHoldingGui.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(bagOfHoldingCondition, "ArtificerInfusionBagOfHolding", bagOfHoldingGui.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower GogglesOfNight
@@ -301,7 +300,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseDarkvisionTitle");
             InfuseDarkvision.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerDomainBattleDivineWrath.GuiPresentation.SpriteReference);
 
-            return BuildItemConditionInfusion(darkvisionCondition, "PowerInfuseDarkvision", InfuseDarkvision.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(darkvisionCondition, "PowerInfuseDarkvision", InfuseDarkvision.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower MindSharpener
@@ -331,7 +330,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseMindSharpenerTitle");
             InfuseMindSharpener.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionTomeOfQuickThought.GuiPresentation.SpriteReference);
 
-            return BuildItemConditionInfusion(infusedMindSharpenerCondition, "ArtificerInfusionMindSharpener", InfuseMindSharpener.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(infusedMindSharpenerCondition, "ArtificerInfusionMindSharpener", InfuseMindSharpener.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower ArmorOfMagicalStrength
@@ -368,7 +367,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseArmorMagicalStrengthDescription",
                 "Subclass/&PowerInfuseArmorMagicalStrengthTitle");
             InfuseArmorMagicalStrength.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerFunctionManualGainfulExercise.GuiPresentation.SpriteReference);
-            return BuildItemConditionInfusion(armorMagicalStrengthCondition, "ArtificerInfusionArmorMagicalStrength", InfuseArmorMagicalStrength.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(armorMagicalStrengthCondition, "ArtificerInfusionArmorMagicalStrength", InfuseArmorMagicalStrength.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower ResistantArmor
@@ -382,7 +381,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 return resistantArmor;
             }
         }
-
 
         private static FeatureDefinitionPower BuildResistantArmor()
         {
@@ -405,10 +403,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityPsychicResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityRadiantResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityThunderResistance,
-
             },
                 RuleDefinitions.DurationType.UntilLongRest, 1, false, "ConditionPowerArtificerResistantArmor", ConditionArmorResistance.Build());
-            return BuildItemConditionInfusion(ArmorResistance, "ArtificerInfusionResistantArmor", InfuseResistantArmor.Build()).AddToDB(); ;
+            return BuildItemConditionInfusion(ArmorResistance, "ArtificerInfusionResistantArmor", InfuseResistantArmor.Build()).AddToDB();
         }
 
         public static FeatureDefinitionPower SpellRefuelingRing
@@ -422,7 +419,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 return spellRefuelingRing;
             }
         }
-
 
         private static FeatureDefinitionPower BuildSpellRefuelingRing()
         {
@@ -701,7 +697,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         private static FeatureDefinitionPower PowerMimicsItem(ItemDefinition item, string name)
         {
-
             List<FeatureDefinition> features = new List<FeatureDefinition>();
             foreach (ItemPropertyDescription property in item.StaticProperties)
             {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -431,11 +431,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             spellEffect.SetDurationData(RuleDefinitions.DurationType.UntilLongRest, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn);
             spellEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Self, 1, RuleDefinitions.TargetType.Self, 1, 1, ActionDefinitions.ItemSelectionType.None);
             spellEffect.AddEffectForm(new EffectFormBuilder().SetSpellForm(9).Build());
-            FeatureDefinitionPowerSharedPool spellRefuelingRing = new FeatureDefinitionPowerSharedPoolBuilder("ArtificerInfusionSpellRefuelingRing",
+
+            return new FeatureDefinitionPowerSharedPoolBuilder("ArtificerInfusionSpellRefuelingRing",
                 GuidHelper.Create(TinkererClass.GuidNamespace, "ArtificerInfusionSpellRefuelingRing").ToString(),
                 TinkererClass.InfusionPool, RuleDefinitions.RechargeRate.LongRest, RuleDefinitions.ActivationTime.NoCost, 1, false, false, AttributeDefinitions.Intelligence,
                 spellEffect.Build(), InfuseSpellRefuelingRing.Build(), true /* unique instance */).AddToDB();
-            return spellRefuelingRing;
         }
 
         public static FeatureDefinitionPower BlindingWeapon

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -65,7 +65,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             artificialServantEffect.SetTargetingData(RuleDefinitions.Side.Ally, RuleDefinitions.RangeType.Distance, 1, RuleDefinitions.TargetType.Position, 1, 1, ActionDefinitions.ItemSelectionType.Equiped);
             artificialServantEffect.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ArtificialServantBuilder.ArtificialServant.name, DatabaseHelper.ConditionDefinitions.ConditionFlyingBootsWinged, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
-            FeatureDefinitionPowerSharedPool summonArtificialServantPower = InfusionHelpers.BuildBasicInfusionPower("summonArtificialServantPower",
+            FeatureDefinitionPowerSharedPool summonArtificialServantPower = BuildBasicInfusionPower("summonArtificialServantPower",
                 artificialServantEffect.Build(), summonArtificialServantGui.Build()).AddToDB();
             return summonArtificialServantPower;
         }
@@ -78,8 +78,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerEnhancedFocusDescription",
                 "Subclass/&AttackModifierArtificerEnhancedFocusTitle");
             focusPlus1Gui.SetSpriteReference(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierMagicWeapon.GuiPresentation.SpriteReference);
-            FeatureDefinitionMagicAffinity focusPlus1 = FeatureHelpers.BuildMagicAffinityModifiers(1, 1, "Enhanced Focus", focusPlus1Gui.Build());
-            ConditionDefinition infusedFocusCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() { focusPlus1 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedFocus", focusPlus1Gui.Build());
+            FeatureDefinitionMagicAffinity focusPlus1 = BuildMagicAffinityModifiers(1, 1, "Enhanced Focus", focusPlus1Gui.Build());
+            ConditionDefinition infusedFocusCondition = BuildCondition(new List<FeatureDefinition>() { focusPlus1 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedFocus", focusPlus1Gui.Build());
 
             GuiPresentationBuilder enhanceFocusGui = new GuiPresentationBuilder(
                 "Subclass/&AttackModifierArtificerEnhancedFocusDescription",
@@ -96,8 +96,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerImprovedEnhancedFocusDescription",
                 "Subclass/&AttackModifierArtificerImprovedEnhancedFocusTitle");
             focusPlus2Gui.SetSpriteReference(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierMagicWeapon.GuiPresentation.SpriteReference);
-            FeatureDefinitionMagicAffinity focusPlus2 = FeatureHelpers.BuildMagicAffinityModifiers(2, 2, "ImprovedEnhancedFocus", focusPlus2Gui.Build());
-            ConditionDefinition infusedFocusCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() { focusPlus2 }, RuleDefinitions.DurationType.UntilLongRest, 1, false,
+            FeatureDefinitionMagicAffinity focusPlus2 = BuildMagicAffinityModifiers(2, 2, "ImprovedEnhancedFocus", focusPlus2Gui.Build());
+            ConditionDefinition infusedFocusCondition = BuildCondition(new List<FeatureDefinition>() { focusPlus2 }, RuleDefinitions.DurationType.UntilLongRest, 1, false,
                 "ArtificerImprovedInfusedFocus", focusPlus2Gui.Build());
 
             GuiPresentationBuilder enhanceFocusGui = new GuiPresentationBuilder(
@@ -116,7 +116,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerEnhancedArmorDescription",
                 "Subclass/&AttackModifierArtificerEnhancedArmorTitle");
             enhanceArmorConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            FeatureDefinitionAttributeModifier armorModifier = FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
+            FeatureDefinitionAttributeModifier armorModifier = BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 1,
                 "AttributeModifierArmorInfusion", enhanceArmorConditionGui.Build());
 
             GuiPresentationBuilder enhanceArmorGui = new GuiPresentationBuilder(
@@ -135,7 +135,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&AttackModifierArtificerImprovedEnhancedArmorDescription",
                 "Subclass/&AttackModifierArtificerImprovedEnhancedArmorTitle");
             enhanceArmorConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            FeatureDefinitionAttributeModifier armorModifier = FeatureHelpers.BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 2,
+            FeatureDefinitionAttributeModifier armorModifier = BuildAttributeModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive, AttributeDefinitions.ArmorClass, 2,
                 "AttributeModifierImprovedArmorInfusion", enhanceArmorConditionGui.Build());
 
             GuiPresentationBuilder enhanceArmorGui = new GuiPresentationBuilder(
@@ -182,8 +182,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&EquipmentModifierArtificerBagOfHolderDescription",
                 "Subclass/&EquipmentModifierArtificerBagOfHolderTitle");
             bagOfHoldingConditionGui.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBullsStrength.GuiPresentation.SpriteReference);
-            ConditionDefinition bagOfHoldingCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
-                    FeatureHelpers.BuildEquipmentAffinity(1.0f, 500.0f, "InfusionBagOfHolding", bagOfHoldingConditionGui.Build())
+            ConditionDefinition bagOfHoldingCondition = BuildCondition(new List<FeatureDefinition>() {
+                    BuildEquipmentAffinity(1.0f, 500.0f, "InfusionBagOfHolding", bagOfHoldingConditionGui.Build())
                     }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionBagOfHolding", bagOfHoldingConditionGui.Build());
 
             GuiPresentationBuilder bagOfHoldingGui = new GuiPresentationBuilder(
@@ -201,7 +201,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseDarkvisionDescription",
                 "Subclass/&PowerInfuseDarkvisionTitle");
             InfuseDarkvisionCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionSeeInvisibility.GuiPresentation.SpriteReference);
-            ConditionDefinition darkvisionCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition darkvisionCondition = BuildCondition(new List<FeatureDefinition>() {
                 DatabaseHelper.FeatureDefinitionSenses.SenseSuperiorDarkvision,
                 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionDarkvision", InfuseDarkvisionCondition.Build());
 
@@ -221,8 +221,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseMindSharpenerDescription",
                 "Subclass/&PowerInfuseMindSharpenerTitle");
             InfuseMindSharpenerCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBearsEndurance.GuiPresentation.SpriteReference);
-            ConditionDefinition infusedMindSharpenerCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
-                FeatureHelpers.BuildMagicAffinityConcentration(RuleDefinitions.ConcentrationAffinity.Advantage, 20, "MagicAffinityMindSharpener", InfuseMindSharpenerCondition.Build()),
+            ConditionDefinition infusedMindSharpenerCondition = BuildCondition(new List<FeatureDefinition>() {
+                BuildMagicAffinityConcentration(RuleDefinitions.ConcentrationAffinity.Advantage, 20, "MagicAffinityMindSharpener", InfuseMindSharpenerCondition.Build()),
                 }, RuleDefinitions.DurationType.UntilLongRest, 1, false, "ArtificerInfusedConditionMindSharpener", InfuseMindSharpenerCondition.Build());
 
             GuiPresentationBuilder InfuseMindSharpener = new GuiPresentationBuilder(
@@ -241,13 +241,13 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&PowerInfuseArmorMagicalStrengthDescription",
                 "Subclass/&PowerInfuseArmorMagicalStrengthTitle");
             InfuseArmorMagicalStrengthCondition.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionBullsStrength.GuiPresentation.SpriteReference);
-            FeatureDefinitionAbilityCheckAffinity strengthAbilityAffinity = FeatureHelpers.BuildAbilityAffinity(new List<Tuple<string, string>>()
+            FeatureDefinitionAbilityCheckAffinity strengthAbilityAffinity = BuildAbilityAffinity(new List<Tuple<string, string>>()
             {
                 new Tuple<string, string>(AttributeDefinitions.Strength, ""),
             }, 0, RuleDefinitions.DieType.D1, RuleDefinitions.CharacterAbilityCheckAffinity.Advantage, "AbilityAffinityInfusionMagicalStrength", InfuseArmorMagicalStrengthCondition.Build());
-            FeatureDefinitionSavingThrowAffinity strengthSaveAffinity = FeatureHelpers.BuildSavingThrowAffinity(new List<string>() { AttributeDefinitions.Strength },
+            FeatureDefinitionSavingThrowAffinity strengthSaveAffinity = BuildSavingThrowAffinity(new List<string>() { AttributeDefinitions.Strength },
                 RuleDefinitions.CharacterSavingThrowAffinity.Advantage, FeatureDefinitionSavingThrowAffinity.ModifierType.AddDice, 0, RuleDefinitions.DieType.D1, false, "SaveAffinityInfusionMagicalStrength", InfuseArmorMagicalStrengthCondition.Build());
-            ConditionDefinition armorMagicalStrengthCondition = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition armorMagicalStrengthCondition = BuildCondition(new List<FeatureDefinition>() {
                 strengthAbilityAffinity,
                 strengthSaveAffinity,
                 DatabaseHelper.FeatureDefinitionConditionAffinitys.ConditionAffinityProneImmunity,
@@ -272,7 +272,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 "Subclass/&ConditionResistnatArmorDescription",
                 "Subclass/&ConditionResistantArmorTitle");
             ConditionArmorResistance.SetSpriteReference(DatabaseHelper.ConditionDefinitions.ConditionAuraOfProtection.GuiPresentation.SpriteReference);
-            ConditionDefinition ArmorResistance = FeatureHelpers.BuildCondition(new List<FeatureDefinition>() {
+            ConditionDefinition ArmorResistance = BuildCondition(new List<FeatureDefinition>() {
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityAcidResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityColdResistance,
                 DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityFireResistance,
@@ -402,7 +402,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             {
                 features.Add(property.FeatureDefinition);
             }
-            ConditionDefinition itemCondition = FeatureHelpers.BuildCondition(features, RuleDefinitions.DurationType.UntilLongRest, 1, false,
+            ConditionDefinition itemCondition = BuildCondition(features, RuleDefinitions.DurationType.UntilLongRest, 1, false,
                 "Condition" + name, item.GuiPresentation);
 
             EffectDescriptionBuilder itemEffect = new EffectDescriptionBuilder();

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -55,11 +55,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (artificialServant == null)
-                {
-                    artificialServant = BuildArtificialServant();
-                }
-                return artificialServant;
+                return artificialServant ?? (artificialServant = BuildArtificialServant());
             }
         }
 
@@ -84,11 +80,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (enhancedFocus == null)
-                {
-                    enhancedFocus = BuildEnhancedFocus();
-                }
-                return enhancedFocus;
+                return enhancedFocus ?? (enhancedFocus = BuildEnhancedFocus());
             }
         }
 
@@ -112,11 +104,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedFocus == null)
-                {
-                    improvedEnhancedFocus = BuildImprovedEnhancedFocus();
-                }
-                return improvedEnhancedFocus;
+                return improvedEnhancedFocus ?? (improvedEnhancedFocus = BuildImprovedEnhancedFocus());
             }
         }
 
@@ -142,11 +130,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (enhancedDefense == null)
-                {
-                    enhancedDefense = BuildEnhancedDefense();
-                }
-                return enhancedDefense;
+                return enhancedDefense ?? (enhancedDefense = BuildEnhancedDefense());
             }
         }
 
@@ -171,11 +155,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedDefense == null)
-                {
-                    improvedEnhancedDefense = BuildImprovedEnhancedDefense();
-                }
-                return improvedEnhancedDefense;
+                return improvedEnhancedDefense ?? (improvedEnhancedDefense = BuildImprovedEnhancedDefense());
             }
         }
 
@@ -201,11 +181,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (enhancedWeapon == null)
-                {
-                    enhancedWeapon = BuildEnhancedWeapon();
-                }
-                return enhancedWeapon;
+                return enhancedWeapon ?? (enhancedWeapon = BuildEnhancedWeapon());
             }
         }
 
@@ -224,11 +200,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (improvedEnhancedWeapon == null)
-                {
-                    improvedEnhancedWeapon = BuildImprovedEnhancedWeapon();
-                }
-                return improvedEnhancedWeapon;
+                return improvedEnhancedWeapon ?? (improvedEnhancedWeapon = BuildImprovedEnhancedWeapon());
             }
         }
 
@@ -248,11 +220,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bagOfHolding == null)
-                {
-                    bagOfHolding = BuildBagOfHolding();
-                }
-                return bagOfHolding;
+                return bagOfHolding ?? (bagOfHolding = BuildBagOfHolding());
             }
         }
 
@@ -277,11 +245,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (gogglesOfNight == null)
-                {
-                    gogglesOfNight = BuildGogglesOfNight();
-                }
-                return gogglesOfNight;
+                return gogglesOfNight ?? (gogglesOfNight = BuildGogglesOfNight());
             }
         }
 
@@ -307,11 +271,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (mindSharpener == null)
-                {
-                    mindSharpener = BuildMindSharpener();
-                }
-                return mindSharpener;
+                return mindSharpener ?? (mindSharpener = BuildMindSharpener());
             }
         }
 
@@ -337,11 +297,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (armorOfMagicalStrength == null)
-                {
-                    armorOfMagicalStrength = BuildArmorOfMagicalStrength();
-                }
-                return armorOfMagicalStrength;
+                return armorOfMagicalStrength ?? (armorOfMagicalStrength = BuildArmorOfMagicalStrength());
             }
         }
 
@@ -374,11 +330,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (resistantArmor == null)
-                {
-                    resistantArmor = BuildResistantArmor();
-                }
-                return resistantArmor;
+                return resistantArmor ?? (resistantArmor = BuildResistantArmor());
             }
         }
 
@@ -412,11 +364,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (spellRefuelingRing == null)
-                {
-                    spellRefuelingRing = BuildSpellRefuelingRing();
-                }
-                return spellRefuelingRing;
+                return spellRefuelingRing ?? (spellRefuelingRing = BuildSpellRefuelingRing());
             }
         }
 
@@ -442,11 +390,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (blindingWeapon == null)
-                {
-                    blindingWeapon = BuildBlindingWeapon();
-                }
-                return blindingWeapon;
+                return blindingWeapon ?? (blindingWeapon = BuildBlindingWeapon());
             }
         }
 
@@ -485,11 +429,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfProtection == null)
-                {
-                    cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection");
-                }
-                return cloakOfProtection;
+                return cloakOfProtection ?? (cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection"));
             }
         }
 
@@ -497,11 +437,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfElvenKind == null)
-                {
-                    bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind");
-                }
-                return bootsOfElvenKind;
+                return bootsOfElvenKind ?? (bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind"));
             }
         }
 
@@ -509,11 +445,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfElvenKind == null)
-                {
-                    cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind");
-                }
-                return cloakOfElvenKind;
+                return cloakOfElvenKind ?? (cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind"));
             }
         }
 
@@ -521,11 +453,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfStridingAndSpringing == null)
-                {
-                    bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing");
-                }
-                return bootsOfStridingAndSpringing;
+                return bootsOfStridingAndSpringing ?? (bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing"));
             }
         }
 
@@ -533,11 +461,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bootsOfTheWinterland == null)
-                {
-                    bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland");
-                }
-                return bootsOfTheWinterland;
+                return bootsOfTheWinterland ?? (bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland"));
             }
         }
 
@@ -545,11 +469,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bracesrOfArchery == null)
-                {
-                    bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery");
-                }
-                return bracesrOfArchery;
+                return bracesrOfArchery ?? (bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery"));
             }
         }
 
@@ -557,11 +477,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (broochOfShielding == null)
-                {
-                    broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding");
-                }
-                return broochOfShielding;
+                return broochOfShielding ?? (broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding"));
             }
         }
 
@@ -569,11 +485,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (gauntletsOfOgrePower == null)
-                {
-                    gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower");
-                }
-                return gauntletsOfOgrePower;
+                return gauntletsOfOgrePower ?? (gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower"));
             }
         }
 
@@ -581,11 +493,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (glovesOfMissileSnaring == null)
-                {
-                    glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring");
-                }
-                return glovesOfMissileSnaring;
+                return glovesOfMissileSnaring ?? (glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring"));
             }
         }
 
@@ -593,11 +501,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (slippersOfSpiderClimbing == null)
-                {
-                    slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing");
-                }
-                return slippersOfSpiderClimbing;
+                return slippersOfSpiderClimbing ?? (slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing"));
             }
         }
 
@@ -605,11 +509,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (headbandOfIntellect == null)
-                {
-                    headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect");
-                }
-                return headbandOfIntellect;
+                return headbandOfIntellect ?? (headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect"));
             }
         }
 
@@ -617,11 +517,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (amuletOfHealth == null)
-                {
-                    amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth");
-                }
-                return amuletOfHealth;
+                return amuletOfHealth ?? (amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth"));
             }
         }
 
@@ -629,11 +525,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (beltOfGiantHillStrength == null)
-                {
-                    beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength");
-                }
-                return beltOfGiantHillStrength;
+                return beltOfGiantHillStrength ?? (beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength"));
             }
         }
 
@@ -641,11 +533,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (bracersOfDefense == null)
-                {
-                    bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense");
-                }
-                return bracersOfDefense;
+                return bracersOfDefense ?? (bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense"));
             }
         }
 
@@ -653,11 +541,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (cloakOfBat == null)
-                {
-                    cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat");
-                }
-                return cloakOfBat;
+                return cloakOfBat ?? (cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat"));
             }
         }
 
@@ -665,11 +549,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             get
             {
-                if (ringProtectionPlus1 == null)
-                {
-                    ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1");
-                }
-                return ringProtectionPlus1;
+                return ringProtectionPlus1 ?? (ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1"));
             }
         }
 

--- a/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/InfusionHelper.cs
@@ -1,9 +1,9 @@
-﻿using HarmonyLib;
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using static SolastaCommunityExpansion.Classes.Tinkerer.FeatureHelpers;
 
@@ -51,13 +51,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return infusion;
         }
 
-        public static FeatureDefinitionPower ArtificialServant
-        {
-            get
-            {
-                return artificialServant ?? (artificialServant = BuildArtificialServant());
-            }
-        }
+        public static FeatureDefinitionPower ArtificialServant => artificialServant ?? (artificialServant = BuildArtificialServant());
 
         private static FeatureDefinitionPower BuildArtificialServant()
         {
@@ -76,13 +70,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return summonArtificialServantPower;
         }
 
-        public static FeatureDefinitionPower EnhancedFocus
-        {
-            get
-            {
-                return enhancedFocus ?? (enhancedFocus = BuildEnhancedFocus());
-            }
-        }
+        public static FeatureDefinitionPower EnhancedFocus => enhancedFocus ?? (enhancedFocus = BuildEnhancedFocus());
 
         private static FeatureDefinitionPower BuildEnhancedFocus()
         {
@@ -100,13 +88,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(infusedFocusCondition, "ArtificerInfusionEnhancedFocus", enhanceFocusGui.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower ImprovedEnhancedFocus
-        {
-            get
-            {
-                return improvedEnhancedFocus ?? (improvedEnhancedFocus = BuildImprovedEnhancedFocus());
-            }
-        }
+        public static FeatureDefinitionPower ImprovedEnhancedFocus => improvedEnhancedFocus ?? (improvedEnhancedFocus = BuildImprovedEnhancedFocus());
 
         private static FeatureDefinitionPower BuildImprovedEnhancedFocus()
         {
@@ -126,13 +108,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 .AddOverriddenPower(EnhancedFocus).AddToDB();
         }
 
-        public static FeatureDefinitionPower EnhancedDefense
-        {
-            get
-            {
-                return enhancedDefense ?? (enhancedDefense = BuildEnhancedDefense());
-            }
-        }
+        public static FeatureDefinitionPower EnhancedDefense => enhancedDefense ?? (enhancedDefense = BuildEnhancedDefense());
 
         private static FeatureDefinitionPower BuildEnhancedDefense()
         {
@@ -151,13 +127,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemModifierInfusion(armorModifier, ActionDefinitions.ItemSelectionType.Equiped, "ArtificerInfusionEnhancedArmor", enhanceArmorGui.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower ImprovedEnhancedDefense
-        {
-            get
-            {
-                return improvedEnhancedDefense ?? (improvedEnhancedDefense = BuildImprovedEnhancedDefense());
-            }
-        }
+        public static FeatureDefinitionPower ImprovedEnhancedDefense => improvedEnhancedDefense ?? (improvedEnhancedDefense = BuildImprovedEnhancedDefense());
 
         private static FeatureDefinitionPower BuildImprovedEnhancedDefense()
         {
@@ -177,13 +147,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 .AddOverriddenPower(EnhancedDefense).AddToDB();
         }
 
-        public static FeatureDefinitionPower EnhancedWeapon
-        {
-            get
-            {
-                return enhancedWeapon ?? (enhancedWeapon = BuildEnhancedWeapon());
-            }
-        }
+        public static FeatureDefinitionPower EnhancedWeapon => enhancedWeapon ?? (enhancedWeapon = BuildEnhancedWeapon());
 
         private static FeatureDefinitionPower BuildEnhancedWeapon()
         {
@@ -196,13 +160,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ActionDefinitions.ItemSelectionType.WeaponNonMagical, "ArtificerInfusionEnhancedWeapon", enhanceWeaponGui.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower ImprovedEnhancedWeapon
-        {
-            get
-            {
-                return improvedEnhancedWeapon ?? (improvedEnhancedWeapon = BuildImprovedEnhancedWeapon());
-            }
-        }
+        public static FeatureDefinitionPower ImprovedEnhancedWeapon => improvedEnhancedWeapon ?? (improvedEnhancedWeapon = BuildImprovedEnhancedWeapon());
 
         private static FeatureDefinitionPower BuildImprovedEnhancedWeapon()
         {
@@ -216,13 +174,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 .AddOverriddenPower(EnhancedWeapon).AddToDB();
         }
 
-        public static FeatureDefinitionPower BagOfHolding
-        {
-            get
-            {
-                return bagOfHolding ?? (bagOfHolding = BuildBagOfHolding());
-            }
-        }
+        public static FeatureDefinitionPower BagOfHolding => bagOfHolding ?? (bagOfHolding = BuildBagOfHolding());
 
         private static FeatureDefinitionPower BuildBagOfHolding()
         {
@@ -241,13 +193,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(bagOfHoldingCondition, "ArtificerInfusionBagOfHolding", bagOfHoldingGui.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower GogglesOfNight
-        {
-            get
-            {
-                return gogglesOfNight ?? (gogglesOfNight = BuildGogglesOfNight());
-            }
-        }
+        public static FeatureDefinitionPower GogglesOfNight => gogglesOfNight ?? (gogglesOfNight = BuildGogglesOfNight());
 
         private static FeatureDefinitionPower BuildGogglesOfNight()
         {
@@ -267,13 +213,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(darkvisionCondition, "PowerInfuseDarkvision", InfuseDarkvision.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower MindSharpener
-        {
-            get
-            {
-                return mindSharpener ?? (mindSharpener = BuildMindSharpener());
-            }
-        }
+        public static FeatureDefinitionPower MindSharpener => mindSharpener ?? (mindSharpener = BuildMindSharpener());
 
         private static FeatureDefinitionPower BuildMindSharpener()
         {
@@ -293,13 +233,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(infusedMindSharpenerCondition, "ArtificerInfusionMindSharpener", InfuseMindSharpener.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower ArmorOfMagicalStrength
-        {
-            get
-            {
-                return armorOfMagicalStrength ?? (armorOfMagicalStrength = BuildArmorOfMagicalStrength());
-            }
-        }
+        public static FeatureDefinitionPower ArmorOfMagicalStrength => armorOfMagicalStrength ?? (armorOfMagicalStrength = BuildArmorOfMagicalStrength());
 
         private static FeatureDefinitionPower BuildArmorOfMagicalStrength()
         {
@@ -326,13 +260,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(armorMagicalStrengthCondition, "ArtificerInfusionArmorMagicalStrength", InfuseArmorMagicalStrength.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower ResistantArmor
-        {
-            get
-            {
-                return resistantArmor ?? (resistantArmor = BuildResistantArmor());
-            }
-        }
+        public static FeatureDefinitionPower ResistantArmor => resistantArmor ?? (resistantArmor = BuildResistantArmor());
 
         private static FeatureDefinitionPower BuildResistantArmor()
         {
@@ -360,13 +288,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return BuildItemConditionInfusion(ArmorResistance, "ArtificerInfusionResistantArmor", InfuseResistantArmor.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower SpellRefuelingRing
-        {
-            get
-            {
-                return spellRefuelingRing ?? (spellRefuelingRing = BuildSpellRefuelingRing());
-            }
-        }
+        public static FeatureDefinitionPower SpellRefuelingRing => spellRefuelingRing ?? (spellRefuelingRing = BuildSpellRefuelingRing());
 
         private static FeatureDefinitionPower BuildSpellRefuelingRing()
         {
@@ -386,13 +308,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 spellEffect.Build(), InfuseSpellRefuelingRing.Build(), true /* unique instance */).AddToDB();
         }
 
-        public static FeatureDefinitionPower BlindingWeapon
-        {
-            get
-            {
-                return blindingWeapon ?? (blindingWeapon = BuildBlindingWeapon());
-            }
-        }
+        public static FeatureDefinitionPower BlindingWeapon => blindingWeapon ?? (blindingWeapon = BuildBlindingWeapon());
 
         private static FeatureDefinitionPower BuildBlindingWeapon()
         {
@@ -425,133 +341,37 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ActionDefinitions.ItemSelectionType.Weapon, "ArtificerInfusionBlindingWeapon", radiantWeaponGui.Build()).AddToDB();
         }
 
-        public static FeatureDefinitionPower CloakOfProtection
-        {
-            get
-            {
-                return cloakOfProtection ?? (cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection"));
-            }
-        }
+        public static FeatureDefinitionPower CloakOfProtection => cloakOfProtection ?? (cloakOfProtection = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfProtection, "InfuseCloakOfProtection"));
 
-        public static FeatureDefinitionPower BootsOfElvenKind
-        {
-            get
-            {
-                return bootsOfElvenKind ?? (bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind"));
-            }
-        }
+        public static FeatureDefinitionPower BootsOfElvenKind => bootsOfElvenKind ?? (bootsOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfElvenKind, "InfuseBootsOfElvenKind"));
 
-        public static FeatureDefinitionPower CloakOfElvenKind
-        {
-            get
-            {
-                return cloakOfElvenKind ?? (cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind"));
-            }
-        }
+        public static FeatureDefinitionPower CloakOfElvenKind => cloakOfElvenKind ?? (cloakOfElvenKind = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfElvenkind, "InfuseCloakOfElvenKind"));
 
-        public static FeatureDefinitionPower BootsOfStridingAndSpringing
-        {
-            get
-            {
-                return bootsOfStridingAndSpringing ?? (bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing"));
-            }
-        }
+        public static FeatureDefinitionPower BootsOfStridingAndSpringing => bootsOfStridingAndSpringing ?? (bootsOfStridingAndSpringing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfStridingAndSpringing, "InfuseBootsOfStridingAndSpringing"));
 
-        public static FeatureDefinitionPower BootsOfTheWinterland
-        {
-            get
-            {
-                return bootsOfTheWinterland ?? (bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland"));
-            }
-        }
+        public static FeatureDefinitionPower BootsOfTheWinterland => bootsOfTheWinterland ?? (bootsOfTheWinterland = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BootsOfTheWinterland, "InfuseBootsOfTheWinterland"));
 
-        public static FeatureDefinitionPower BracesrOfArchery
-        {
-            get
-            {
-                return bracesrOfArchery ?? (bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery"));
-            }
-        }
+        public static FeatureDefinitionPower BracesrOfArchery => bracesrOfArchery ?? (bracesrOfArchery = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Archery, "InfuseBracesrOfArchery"));
 
-        public static FeatureDefinitionPower BroochOfShielding
-        {
-            get
-            {
-                return broochOfShielding ?? (broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding"));
-            }
-        }
+        public static FeatureDefinitionPower BroochOfShielding => broochOfShielding ?? (broochOfShielding = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BroochOfShielding, "InfuseBroochOfShielding"));
 
-        public static FeatureDefinitionPower GauntletsOfOgrePower
-        {
-            get
-            {
-                return gauntletsOfOgrePower ?? (gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower"));
-            }
-        }
+        public static FeatureDefinitionPower GauntletsOfOgrePower => gauntletsOfOgrePower ?? (gauntletsOfOgrePower = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower, "InfuseGauntletsOfOgrePower"));
 
-        public static FeatureDefinitionPower GlovesOfMissileSnaring
-        {
-            get
-            {
-                return glovesOfMissileSnaring ?? (glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring"));
-            }
-        }
+        public static FeatureDefinitionPower GlovesOfMissileSnaring => glovesOfMissileSnaring ?? (glovesOfMissileSnaring = PowerMimicsItem(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring, "InfuseGlovesOfMissileSnaring"));
 
-        public static FeatureDefinitionPower SlippersOfSpiderClimbing
-        {
-            get
-            {
-                return slippersOfSpiderClimbing ?? (slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing"));
-            }
-        }
+        public static FeatureDefinitionPower SlippersOfSpiderClimbing => slippersOfSpiderClimbing ?? (slippersOfSpiderClimbing = PowerMimicsItem(DatabaseHelper.ItemDefinitions.SlippersOfSpiderClimbing, "InfuseSlippersOfSpiderClimbing"));
 
-        public static FeatureDefinitionPower HeadbandOfIntellect
-        {
-            get
-            {
-                return headbandOfIntellect ?? (headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect"));
-            }
-        }
+        public static FeatureDefinitionPower HeadbandOfIntellect => headbandOfIntellect ?? (headbandOfIntellect = PowerMimicsItem(DatabaseHelper.ItemDefinitions.HeadbandOfIntellect, "InfuseHeadbandOfIntellect"));
 
-        public static FeatureDefinitionPower AmuletOfHealth
-        {
-            get
-            {
-                return amuletOfHealth ?? (amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth"));
-            }
-        }
+        public static FeatureDefinitionPower AmuletOfHealth => amuletOfHealth ?? (amuletOfHealth = PowerMimicsItem(DatabaseHelper.ItemDefinitions.AmuletOfHealth, "InfuseAmuletOfHealth"));
 
-        public static FeatureDefinitionPower BeltOfGiantHillStrength
-        {
-            get
-            {
-                return beltOfGiantHillStrength ?? (beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength"));
-            }
-        }
+        public static FeatureDefinitionPower BeltOfGiantHillStrength => beltOfGiantHillStrength ?? (beltOfGiantHillStrength = PowerMimicsItem(DatabaseHelper.ItemDefinitions.BeltOfGiantHillStrength, "InfuseBeltOfGiantHillStrength"));
 
-        public static FeatureDefinitionPower BracersOfDefense
-        {
-            get
-            {
-                return bracersOfDefense ?? (bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense"));
-            }
-        }
+        public static FeatureDefinitionPower BracersOfDefense => bracersOfDefense ?? (bracersOfDefense = PowerMimicsItem(DatabaseHelper.ItemDefinitions.Bracers_Of_Defense, "InfuseBracersOfDefense"));
 
-        public static FeatureDefinitionPower CloakOfBat
-        {
-            get
-            {
-                return cloakOfBat ?? (cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat"));
-            }
-        }
+        public static FeatureDefinitionPower CloakOfBat => cloakOfBat ?? (cloakOfBat = PowerMimicsItem(DatabaseHelper.ItemDefinitions.CloakOfBat, "InfuseCloakOfBat"));
 
-        public static FeatureDefinitionPower RingProtectionPlus1
-        {
-            get
-            {
-                return ringProtectionPlus1 ?? (ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1"));
-            }
-        }
+        public static FeatureDefinitionPower RingProtectionPlus1 => ringProtectionPlus1 ?? (ringProtectionPlus1 = PowerMimicsItem(DatabaseHelper.ItemDefinitions.RingProtectionPlus1, "InfuseRingProtectionPlus1"));
 
         public static FeatureDefinitionPowerSharedPoolBuilder BuildItemModifierInfusion(FeatureDefinition itemFeature, ActionDefinitions.ItemSelectionType itemType,
             string name, GuiPresentation gui)

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
@@ -1,21 +1,22 @@
-﻿
-using HarmonyLib;
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     // TODO verify if this is still needed. It's original goal was to help filter the Infusion selection lists during level up properly.
-    internal class Patches
+    [HarmonyPatch(typeof(CharacterBuildingManager), "LevelUpCharacter")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterBuildingManager_LevelUpClearActiveFeatures
     {
-        [HarmonyPatch(typeof(CharacterBuildingManager), "LevelUpCharacter")]
-        internal static class CharacterBuildingManager_LevelUpClearActiveFeatures
+        internal static void Postfix(CharacterBuildingManager __instance)
         {
-            internal static void Postfix(CharacterBuildingManager __instance)
-            {
-                MethodInfo dynMethod = __instance.GetType().GetMethod("RefreshAllActiveFeatures",
-                    BindingFlags.NonPublic | BindingFlags.Instance);
-                dynMethod.Invoke(__instance, new object[] { });
-            }
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            MethodInfo dynMethod = __instance.GetType().GetMethod("RefreshAllActiveFeatures",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            dynMethod.Invoke(__instance, Array.Empty<object>());
         }
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Patches.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
@@ -8,8 +8,6 @@ using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-
-
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructFeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
@@ -21,7 +19,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructFeatureSetBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetGreenmageWardenOfTheForest, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
 
@@ -29,7 +26,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.FeatureSet.Add(SummoningAffinityTinkererConstructBuilder.SummoningAffinityTinkererConstruct);
             Definition.FeatureSet.Add(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct);
             Definition.FeatureSet.Add(ProtectorConstructLevel3AutopreparedSpellsBuilder.ProtectorConstructLevel3AutopreparedSpells);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -38,7 +34,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
-
     }
 
     public class ProtectorConstructLevel3AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
@@ -79,7 +74,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummoningAffinityTinkererConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionSummoningAffinitys.SummoningAffinityKindredSpiritBond, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feature/&NoContentTitle";
             Definition.GuiPresentation.Description = "Feature/&NoContentTitle";
             Definition.GuiPresentation.SetSpriteReference(null);
@@ -124,9 +118,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererConstruct = CreateAndAddToDB(Name, Guid);
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorConstructBuilder		***********************************************************
@@ -139,7 +131,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonProtectorPowerConstructBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerClericDivineInterventionCleric, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ConjureAnimalsFourBeasts.GuiPresentation.SpriteReference);
@@ -157,7 +148,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ProtectorConstructEffect.AddEffectForm(new EffectFormBuilder().SetSummonForm(SummonForm.Type.Creature, ScriptableObject.CreateInstance<ItemDefinition>(), 1, ProtectorConstructBuilder.ProtectorConstruct.name, null, true, null, ScriptableObject.CreateInstance<EffectProxyDefinition>()).Build());
 
             Definition.SetEffectDescription(ProtectorConstructEffect.Build());
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -166,7 +156,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionPower SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
-
     }
 
     //*****************************************************************************************************************************************
@@ -207,7 +196,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SummonProtectorSpellConstructBuilder(string name, string guid) : base(DatabaseHelper.SpellDefinitions.DancingLights, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SummonProtectorConstructTitle";
             Definition.GuiPresentation.Description = "Feat/&SummonProtectorConstructDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.ConjureAnimalsFourBeasts.GuiPresentation.SpriteReference);
@@ -221,7 +209,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetVerboseComponent(false);
 
             Definition.SetEffectDescription(SummonProtectorPowerConstructBuilder.SummonProtectorConstruct.EffectDescription);
-
         }
 
         public static SpellDefinition CreateAndAddToDB(string name, string guid)
@@ -230,12 +217,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static SpellDefinition SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
-
     }
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorSpellConstruct_UpgradeBuilder		*******************************************************************
     //*****************************************************************************************************************************************
-
 
     //
     // need a new featuredefintionAutopreparedSpells list with the summon upgrade spell for the two different subclasses
@@ -314,9 +299,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionFeatureSet ProtectorConstructUpgradeFeatureSet = CreateAndAddToDB(Name, Guid);
-
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructBuilder		***************************************************************
@@ -329,7 +312,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructBuilder(string name, string guid) : base(DatabaseHelper.MonsterDefinitions.ConjuredEightBeast_Wolf, name, guid)
         {
-
             Definition.SetMonsterPresentation(DatabaseHelper.MonsterDefinitions.Ghost_Wolf.MonsterPresentation);
 
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructTitle";
@@ -351,7 +333,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.AbilityScores.AddToArray(4);     // INT
             Definition.AbilityScores.AddToArray(10);    // WIS
             Definition.AbilityScores.AddToArray(6);     // CHA
-
 
             //replaced by new bond methods?
             //assume PB=4
@@ -377,8 +358,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SkillScores.Add(Athletics);
             Definition.SkillScores.Add(Perception);
 
-
-
             Definition.SetFullyControlledWhenAllied(true);
             Definition.SetDungeonMakerPresence(MonsterDefinition.DungeonMaker.None);
             Definition.SetStandardHitPoints(20);
@@ -397,10 +376,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.Features.Add(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityFightingStyleProtection);
             Definition.Features.Add(SelfRepairBuilder.SelfRepair);
 
-
-
             Definition.AttackIterations.Clear();
-
 
             MonsterAttackIteration monsterAttackIteration = new MonsterAttackIteration();
 
@@ -409,8 +385,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Traverse.Create(monsterAttackIteration).Field("number").SetValue(1);
 
             Definition.AttackIterations.AddRange(new List<MonsterAttackIteration> { monsterAttackIteration });
-
-
         }
 
         public static MonsterDefinition CreateAndAddToDB(string name, string guid)
@@ -419,7 +393,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static MonsterDefinition ProtectorConstruct = CreateAndAddToDB(ProtectorConstructName, ProtectorConstructNameGuid);
-
     }
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstruct_UpgradeBuilder		*******************************************************
@@ -447,8 +420,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static MonsterDefinition ProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
-
-
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstructAttacksBuilder		*******************************************************
     //*****************************************************************************************************************************************
@@ -460,7 +431,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ProtectorConstructAttackBuilder(string name, string guid) : base(DatabaseHelper.MonsterAttackDefinitions.Attack_Wolf_Bite, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&ProtectorConstructAttackTitle";
             Definition.GuiPresentation.Description = "Feat/&ProtectorConstructAttackDescription";
 
@@ -497,7 +467,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             //replaced by new bond methods?
             Definition.SetEffectDescription(newEffectDescription);
             Definition.SetToHitBonus(0);
-
         }
 
         public static MonsterAttackDefinition CreateAndAddToDB(string name, string guid)
@@ -519,7 +488,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SelfRepairBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerFighterSecondWind, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&SelfRepairTitle";
             Definition.GuiPresentation.Description = "Feat/&SelfRepairDescription";
 
@@ -547,7 +515,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.EffectDescription.EffectForms.Add(effect);
             Definition.EffectDescription.SetTargetType(RuleDefinitions.TargetType.Self);
             Definition.EffectDescription.RestrictedCreatureFamilies.Add(TinkererConstructFamilyBuilder.TinkererConstructFamily.Name);
-
         }
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -569,7 +536,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected RetributionBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionPowers.PowerDomainLawHolyRetribution, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&RetributionTitle";
             Definition.GuiPresentation.Description = "Feat/&RetributionDescription";
             Definition.SetShortTitleOverride("Feat/&RetributionTitle");
@@ -591,6 +557,4 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionPower Retribution = CreateAndAddToDB(RetributionName, RetributionNameGuid);
     }
-
 }
-

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
@@ -33,7 +33,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructFeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     public class ProtectorConstructLevel3AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
@@ -60,7 +60,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructLevel3AutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel3AutopreparedSpells = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel3AutopreparedSpells = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -117,7 +117,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummoningAffinityTinkererConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionSummoningAffinity SummoningAffinityTinkererConstruct = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionSummoningAffinity SummoningAffinityTinkererConstruct = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -155,7 +155,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorPowerConstructBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
+        public static readonly FeatureDefinitionPower SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -182,7 +182,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorPowerConstruct_UpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SummonProtectorPowerConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionPower SummonProtectorPowerConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -216,7 +216,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorSpellConstructBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
+        public static readonly SpellDefinition SummonProtectorConstruct = CreateAndAddToDB(SummonProtectorConstructName, SummonProtectorConstructNameGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		SummonProtectorSpellConstruct_UpgradeBuilder		*******************************************************************
@@ -244,7 +244,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SummonProtectorSpellConstruct_UpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static SpellDefinition SummonProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly SpellDefinition SummonProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
     public class ProtectorConstructLevel15AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
@@ -271,7 +271,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructLevel15AutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel15AutopreparedSpells = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionAutoPreparedSpells ProtectorConstructLevel15AutopreparedSpells = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -298,7 +298,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructUpgradeFeatureSetBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ProtectorConstructUpgradeFeatureSet = CreateAndAddToDB(Name, Guid);
+        public static readonly FeatureDefinitionFeatureSet ProtectorConstructUpgradeFeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -392,7 +392,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ProtectorConstruct = CreateAndAddToDB(ProtectorConstructName, ProtectorConstructNameGuid);
+        public static readonly MonsterDefinition ProtectorConstruct = CreateAndAddToDB(ProtectorConstructName, ProtectorConstructNameGuid);
     }
     //*****************************************************************************************************************************************
     //***********************************		ProtectorConstruct_UpgradeBuilder		*******************************************************
@@ -417,7 +417,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstruct_UpgradeBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterDefinition ProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
+        public static readonly MonsterDefinition ProtectorConstruct_Upgrade = CreateAndAddToDB(Name, Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -474,7 +474,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ProtectorConstructAttackBuilder(name, guid).AddToDB();
         }
 
-        public static MonsterAttackDefinition ProtectorConstructAttack = CreateAndAddToDB(ProtectorConstructAttacksName, ProtectorConstructAttacksGuid);
+        public static readonly MonsterAttackDefinition ProtectorConstructAttack = CreateAndAddToDB(ProtectorConstructAttacksName, ProtectorConstructAttacksGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -522,7 +522,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SelfRepairBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower SelfRepair = CreateAndAddToDB(SelfRepairName, SelfRepairNameGuid);
+        public static readonly FeatureDefinitionPower SelfRepair = CreateAndAddToDB(SelfRepairName, SelfRepairNameGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -555,6 +555,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new RetributionBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower Retribution = CreateAndAddToDB(RetributionName, RetributionNameGuid);
+        public static readonly FeatureDefinitionPower Retribution = CreateAndAddToDB(RetributionName, RetributionNameGuid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ProtectorConstruct.cs
@@ -1,9 +1,9 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
@@ -19,9 +19,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static void BuildAndAddSubclass()
         {
-
-
-
             var subclassGuiPresentation = new GuiPresentationBuilder(
                 "Subclass/&ScoutSentinelTinkererSubclassDescription",
                 "Subclass/&ScoutSentinelTinkererSubclassTitle")
@@ -40,7 +37,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // level 14
             .AddFeatureAtLevel(ScoutSentinelFeatureSet_level15Builder.ScoutSentinelFeatureSet_level15, 15)
            .AddToDB(true);
-
         }
     }
 
@@ -53,7 +49,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         {
             Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level03Title";
             Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level03Description";
-
 
             GuiPresentation guiPresentationArmorMode = new GuiPresentation();
             guiPresentationArmorMode.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
@@ -72,8 +67,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                     RuleDefinitions.RechargeRate.ShortRest,
                     guiPresentationArmorMode
                 ).AddToDB();
-
-
 
             GuiPresentation guiPresentationSentinel = new GuiPresentation();
             guiPresentationSentinel.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
@@ -102,8 +95,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectsentinelmode.EffectForms[0].SummonForm.SetNumber(1);
             effectsentinelmode.EffectForms.Add(effectItem);
 
-
-
             ScoutSentinelTinkererSubclassBuilder.sentinelmodepower = new FeatureDefinitionPowerSharedPoolBuilder
                 (
                  "SentinelModePower"                                         // string name
@@ -119,7 +110,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                  , guiPresentationSentinel                                   // GuiPresentation guiPresentation
                  , true                                                      // bool uniqueInstanc
                 ).AddToDB();
-
 
             GuiPresentation guiPresentationScout = new GuiPresentation();
             guiPresentationScout.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
@@ -187,8 +177,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(DatabaseHelper.FeatureDefinitionAttributeModifiers.AttributeModifierFighterExtraAttack);
-
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -209,7 +197,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&ScoutSentinelFeatureSet_level09Title";
             Definition.GuiPresentation.Description = "Feat/&ScoutSentinelFeatureSet_level09Description";
 
-
             GuiPresentation guiPresentation = new GuiPresentation();
             guiPresentation.SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f));
             guiPresentation.SetDescription("Feat/&ExtraInfusionSlotsTitle");
@@ -217,8 +204,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             guiPresentation.SetSpriteReference(null);
             guiPresentation.SetSymbolChar("221E");
             guiPresentation.SetSortOrder(1);
-
-
 
             FeatureDefinitionPowerPoolModifier ExtraInfusionSlots = new FeatureDefinitionPowerPoolModifierBuilder(
                 "ExtraInfusionSlots",
@@ -229,11 +214,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 TinkererClass.InfusionPool, guiPresentation
                 ).AddToDB();
 
-
-
             Definition.FeatureSet.Clear();
             Definition.FeatureSet.Add(ExtraInfusionSlots);
-
         }
 
         public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
@@ -282,8 +264,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             effectImprovedSentinelmode.EffectForms[0].SummonForm.SetTrackItem(false);
             effectImprovedSentinelmode.EffectForms[0].SummonForm.SetNumber(1);
             effectImprovedSentinelmode.EffectForms.Add(effectItem);
-
-
 
             FeatureDefinitionPowerSharedPoolBuilder Improvedsentinelmodepowerbuilder = new FeatureDefinitionPowerSharedPoolBuilder
                 (
@@ -355,15 +335,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level15 = CreateAndAddToDB(ScoutSentinelFeatureSet_level15Name, ScoutSentinelFeatureSet_level15Guid);
     }
 
-
-
-
     //*****************************************************************************************************************************************
     //***********************************		SubclassAutopreparedSpellsBuilder		*******************************************************
     //*****************************************************************************************************************************************
-
-
-
 
     public class ScoutSentinelAutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
@@ -372,11 +346,8 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ScoutSentinelAutopreparedSpellsBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAutoPreparedSpellss.AutoPreparedSpellsDomainBattle, name, guid)
         {
-
-
             Definition.GuiPresentation.Title = "Feat/&AutoPreparedSpellsTitle";
             Definition.GuiPresentation.Description = "Feat/&AutoPreparedSpellsDescription";
-
 
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_3 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
@@ -396,7 +367,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             })
             };
 
-
             FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup autoPreparedSpellsGroup_Level_9 = new FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup
             {
                 ClassLevel = 9,
@@ -414,7 +384,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 ,DatabaseHelper.SpellDefinitions.GreaterInvisibility
             })
             };
-
 
             //  added extra spells to balance spells withput "implemented"=true flag yet
             //blur for mirror image
@@ -441,11 +410,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
                 autoPreparedSpellsGroup_Level_13,
                 autoPreparedSpellsGroup_Level_17
             });
-
         }
-
-
-
 
         public static FeatureDefinitionAutoPreparedSpells CreateAndAddToDB(string name, string guid)
         {
@@ -454,7 +419,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionAutoPreparedSpells SubclassAutopreparedSpells = CreateAndAddToDB(SubclassAutopreparedSpellsName, SubclassAutopreparedSpellsGuid);
     }
-
 
     //*****************************************************************************************************************************************
     //***********************************		SubclassProficienciesBuilder		*******************************************************
@@ -470,7 +434,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&SubclassProficienciesTitle"; //Feature/&NoContentTitle
             Definition.GuiPresentation.Description = "Feat/&SubclassProficienciesDescription";//Feature/&NoContentTitle
             Definition.Proficiencies.Add(DatabaseHelper.ArmorCategoryDefinitions.HeavyArmorCategory.Name);
-
         }
 
         public static FeatureDefinitionProficiency CreateAndAddToDB(string name, string guid)
@@ -495,8 +458,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&SubclassMovementTitle";
             Definition.GuiPresentation.Description = "Feat/&SubclassMovementDescription";
             Definition.SetHeavyArmorImmunity(true);
-
-
         }
 
         public static FeatureDefinitionMovementAffinity CreateAndAddToDB(string name, string guid)
@@ -506,9 +467,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionMovementAffinity SubclassMovementAffinities = CreateAndAddToDB(SubclassMovementAffinitiesName, SubclassMovementAffinitiesGuid);
     }
-
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		UseArmorWeaponsAsFocusBuilder		*******************************************************
@@ -521,14 +479,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected UseArmorWeaponsAsFocusBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinitySpellBladeIntoTheFray, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&UseArmorWeaponsAsFocusTitle";
             Definition.GuiPresentation.Description = "Feat/&UseArmorWeaponsAsFocusDescription";
             Definition.SetCanUseProficientWeaponAsFocus(true);
             Definition.SetSomaticWithWeapon(true);
             Definition.SetRangeSpellNoProximityPenalty(false);
-
-
         }
 
         public static FeatureDefinitionMagicAffinity CreateAndAddToDB(string name, string guid)
@@ -537,10 +492,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         }
 
         public static FeatureDefinitionMagicAffinity UseArmorWeaponsAsFocus = CreateAndAddToDB(UseArmorWeaponsAsFocusName, UseArmorWeaponsAsFocusGuid);
-
     }
-
-
 
     //*****************************************************************************************************************************************
     //***********************************		IntToAttackAndDamageBuilder		*******************************************************
@@ -553,7 +505,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected IntToAttackAndDamageBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierShillelagh, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Feat/&IntToAttackAndDamageTitle";
             Definition.GuiPresentation.Description = "Feat/&IntToAttackAndDamageDescription";
 
@@ -565,8 +516,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             //    assetReference.SetField("m_AssetGUID", "ad68a1be3193a314c911afd02ca8d360");
             //    Definition.SetImpactParticleReference(assetReference);
 
-
-
         }
 
         public static FeatureDefinitionAttackModifier CreateAndAddToDB(string name, string guid)
@@ -576,8 +525,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static FeatureDefinitionAttackModifier IntToAttackAndDamage = CreateAndAddToDB(IntToAttackAndDamageName, IntToAttackAndDamageGuid);
     }
-
-
 
     //*************************************************************************************************************************
     //***********************************		Sentinel Suit Weapon           		*******************************************
@@ -590,17 +537,13 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected SentinelSuitWeaponBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.UnarmedStrikeBase, name, guid)
         {
-
-
             // can only take 3 ( at game launch in may, havent checked since)
             Definition.IsFocusItem = true;
             Definition.IsUsableDevice = true;
             Definition.IsWeapon = true;
             //         Definition.IsFood = true;
 
-
             Definition.SetInDungeonEditor(true);
-
 
             EffectForm damageEffect = new EffectForm
             {
@@ -630,10 +573,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             balancingeffect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             balancingeffect.ConditionForm.ConditionDefinition = ThunderStruckBalancingAdvantageConditionBuilder.ThunderStruckBalancingAdvantage;
 
-
-
-
-
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
             newEffectDescription.Copy(Definition.WeaponDescription.EffectDescription);
@@ -651,7 +590,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             newEffectDescription.SetCanBePlacedOnCharacter(true);
             newEffectDescription.SetRangeType(RuleDefinitions.RangeType.MeleeHit);
 
-
             newEffectDescription.SetEffectParticleParameters(DatabaseHelper.SpellDefinitions.Shatter.EffectDescription.EffectParticleParameters);
 
             WeaponDescription ThunderPunch = new WeaponDescription();
@@ -663,13 +601,10 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ThunderPunch.SetEffectDescription(newEffectDescription);
             ThunderPunch.WeaponTags.Add("ScoutSentinelWeapon");
 
-
-
-            ItemPropertyDescription UsingBonusActionItemPower = new ItemPropertyDescription(DatabaseHelper.ItemDefinitions.BeltOfDwarvenKind.StaticProperties[6]); ;
+            ItemPropertyDescription UsingBonusActionItemPower = new ItemPropertyDescription(DatabaseHelper.ItemDefinitions.BeltOfDwarvenKind.StaticProperties[6]);
             UsingBonusActionItemPower.SetFeatureDefinition(UsingitemPowerBuilder.UsingitemPower);
             UsingBonusActionItemPower.SetType(ItemPropertyDescription.PropertyType.Feature);
             UsingBonusActionItemPower.SetKnowledgeAffinity(EquipmentDefinitions.KnowledgeAffinity.InactiveAndHidden);
-
 
             DeviceFunctionDescription deviceFunctionDescription = new DeviceFunctionDescription(DatabaseHelper.ItemDefinitions.PotionOfComprehendLanguages.UsableDeviceDescription.DeviceFunctions[0]);
             deviceFunctionDescription.SetCanOverchargeSpell(false);
@@ -692,7 +627,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             usableDeviceDescription.SetMagicAttackBonus(11);
             usableDeviceDescription.SetSaveDC(19);
             usableDeviceDescription.DeviceFunctions.Add(deviceFunctionDescription);
-
 
             Definition.SlotTypes.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
             Definition.SlotsWhereActive.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
@@ -723,9 +657,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Equipment/&ThunderPunchTitle";
             Definition.GuiPresentation.Description = "Equipment/&ThunderPunchDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower.GuiPresentation.SpriteReference);
-
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -735,8 +666,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
     }
-
-
 
     internal class ThunderShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -748,7 +677,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Title = "Feat/&ThunderShieldTitle";
             Definition.GuiPresentation.Description = "Feat/&ThunderShieldDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Shield.GuiPresentation.SpriteReference);
-
 
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.LongRest);
             Definition.SetCostPerUse(1);
@@ -772,7 +700,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             healingEffect.SetApplyLevel(EffectForm.LevelApplianceType.MultiplyBonus);
             healingEffect.SetLevelType(RuleDefinitions.LevelSourceType.CharacterLevel);
             healingEffect.SetLevelMultiplier(1);
-
 
             //Add to our new effect
             EffectDescription newEffectDescription = new EffectDescription();
@@ -800,7 +727,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
     }
 
-
     internal class ThunderStruckConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
     {
         private const string ThunderStruckName = "ThunderStruck";
@@ -826,8 +752,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             assetReference.SetField("m_AssetGUID", "3e25fca5d3585174f9b7e20aca6ef3d9");
             Definition.SetConditionStartParticleReference(assetReference);
             Definition.SetConditionParticleReference(assetReference);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -845,9 +769,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ThunderStruckDisadvantageCombatAffintityBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionCombatAffinitys.CombatAffinityPoisoned, name, guid)
         {
-
             Definition.SetMyAttackAdvantage(RuleDefinitions.AdvantageType.Disadvantage);
-
         }
 
         public static FeatureDefinitionCombatAffinity CreateAndAddToDB(string name, string guid)
@@ -876,7 +798,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
 
             Definition.Features.Add(BalancingAdvantageCombatAffintityBuilder.BalancingAdvantage);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -894,7 +815,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected BalancingAdvantageCombatAffintityBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionCombatAffinitys.CombatAffinityCursedByBestowCurseOnAttackRoll, name, guid)
         {
-
             Definition.SetMyAttackAdvantage(RuleDefinitions.AdvantageType.Advantage);
             Definition.SetSituationalContext(RuleDefinitions.SituationalContext.TargetIsEffectSource);
         }
@@ -913,13 +833,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected UsingitemPowerBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityThiefFastHands, name, guid)
         {
-
             Definition.AuthorizedActions.Clear();
             Definition.AuthorizedActions.Add(ActionDefinitions.Id.UseItemBonus);
 
             Definition.GuiPresentation.Title = "Feat/&UsingitemPowerTitle";
             Definition.GuiPresentation.Description = "Feat/&UsingitemPowerDescription";
-
         }
 
         public static FeatureDefinitionActionAffinity CreateAndAddToDB(string name, string guid)
@@ -930,15 +848,9 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
         public static FeatureDefinitionActionAffinity UsingitemPower = CreateAndAddToDB(UsingitemPowerName, UsingitemPowerGuid);
     }
 
-
-
-
-
-
     //**************************************************************************************************************************************
     //************************************************      Scout Suit Weapon        *******************************************************
     //**************************************************************************************************************************************
-
 
     internal class ScoutSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
     {
@@ -947,7 +859,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ScoutSuitWeaponBuilder(string name, string guid) : base(DatabaseHelper.ItemDefinitions.Dart, name, guid)
         {
-
             // can only take 3    (at game launch in may, havent checked since)
             Definition.IsFocusItem = true;
             Definition.IsWeapon = true;
@@ -1009,7 +920,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             LightningCloakMovement.SetType(ItemPropertyDescription.PropertyType.Feature);
             LightningCloakMovement.SetKnowledgeAffinity(EquipmentDefinitions.KnowledgeAffinity.InactiveAndHidden);
 
-
             Definition.SlotTypes.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
             Definition.SlotsWhereActive.AddRange(new List<string> { "MainHandSlot", "OffHandSlot", "GlovesSlot", "UtilitySlot" });
 
@@ -1041,9 +951,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring.GuiPresentation.SpriteReference);
 
             Definition.SetItemPresentation(DatabaseHelper.ItemDefinitions.UnarmedStrikeBase.ItemPresentation);
-
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -1053,7 +960,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
     }
-
 
     internal class LightningSpearAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
     {
@@ -1131,7 +1037,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ImprovedSentinelSuitWeaponBuilder(string name, string guid) : base(SentinelSuitWeaponBuilder.SentinelSuitWeapon, name, guid)
         {
-
             Definition.GuiPresentation.Title = "Equipment/&ImprovedThunderPunchTitle";
             Definition.GuiPresentation.Description = "Equipment/&ImprovedThunderPunchDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GauntletsOfOgrePower.GuiPresentation.SpriteReference);
@@ -1148,8 +1053,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             Definition.UsableDeviceDescription.DeviceFunctions.Add(grapplefunction);
             Definition.UsableDeviceDescription.SetChargesCapitalNumber(10);
-
-
         }
 
         public static ItemDefinition CreateAndAddToDB(string name, string guid)
@@ -1159,7 +1062,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
     }
-
 
     internal class GauntletsGrappleBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
     {
@@ -1172,14 +1074,12 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.GuiPresentation.Description = "Feat/&GauntletsGrappleDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.FeatureDefinitionPowers.PowerShadowTamerRopeGrapple.GuiPresentation.SpriteReference);
 
-
             Definition.SetRechargeRate(RuleDefinitions.RechargeRate.LongRest);
             Definition.SetCostPerUse(1);
             Definition.SetFixedUsesPerRecharge(6);
             Definition.SetActivationTime(RuleDefinitions.ActivationTime.BonusAction);
             Definition.SetShortTitleOverride("Feat/&GauntletsGrappleTitle");
             Definition.SetReactionContext(RuleDefinitions.ReactionTriggerContext.HitByMelee);
-
 
             EffectForm motionEffect = new EffectForm
             {
@@ -1251,17 +1151,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         protected ImprovedScoutSuitWeaponBuilder(string name, string guid) : base(ScoutSuitWeaponBuilder.ScoutSuitWeapon, name, guid)
         {
-
-
-
             Definition.GuiPresentation.Title = "Equipment/&ImprovedLightningSpearTitle";
             Definition.GuiPresentation.Description = "Equipment/&ImprovedLightningSpearDescription";
             Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.ItemDefinitions.GlovesOfMissileSnaring.GuiPresentation.SpriteReference);
 
-
             Definition.SetInDungeonEditor(true);
-
-
 
             //next attack advantage // condition true strike or guiding bolt
             EffectForm NextAttackAdvantage = new EffectForm
@@ -1272,7 +1166,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             NextAttackAdvantage.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             NextAttackAdvantage.ConditionForm.ConditionDefinition = AdvantageAttackOnEnemyBuilder.AdvantageAttackOnEnemy;
 
-
             // combat affinity cursed on attack roll
             EffectForm EnemyAttackDisadvantageEffect = new EffectForm
             {
@@ -1281,7 +1174,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             };
             EnemyAttackDisadvantageEffect.ConditionForm.Operation = ConditionForm.ConditionOperation.Add;
             EnemyAttackDisadvantageEffect.ConditionForm.ConditionDefinition = DisadvantageOnAttackByEnemyBuilder.DisadvantageOnAttackByEnemy;
-
 
             //extra damage on attack
             EffectForm ExtraAttackEffect = new EffectForm
@@ -1296,7 +1188,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             LightSourceForm lightSourceForm = new LightSourceForm();
             lightSourceForm.Copy(DatabaseHelper.SpellDefinitions.Shine.EffectDescription.EffectForms[0].LightSourceForm);
 
-
             EffectForm MagicalLightSourceEffect = new EffectForm();
             MagicalLightSourceEffect.SetLevelMultiplier(1);
             MagicalLightSourceEffect.SetLevelType(RuleDefinitions.LevelSourceType.CharacterLevel);
@@ -1305,13 +1196,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             MagicalLightSourceEffect.FormType = EffectForm.EffectFormType.LightSource;
             MagicalLightSourceEffect.SetLightSourceForm(lightSourceForm);
 
-
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(EnemyAttackDisadvantageEffect);
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(ExtraAttackEffect);
             Definition.WeaponDescription.EffectDescription.EffectForms.Add(NextAttackAdvantage);
             // game hangs when light effect is added, dont know why
             //Definition.WeaponDescription.EffectDescription.EffectForms.Add(MagicalLightSourceEffect);
-
 
         }
 
@@ -1333,7 +1222,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // Jolted - enemey has disadvantage on scout sentinel after weapon hits
             Definition.GuiPresentation.Title = "Rules/&DisadvantageOnAttackByEnemyTitle";
             Definition.GuiPresentation.Description = "Rules/&DisadvantageOnAttackByEnemyDescription";
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -1382,15 +1270,11 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
             Definition.HasSpecialInterruptionOfType(RuleDefinitions.ConditionInterruption.Damaged);
 
-
-
             Definition.SetAdditionalDamageWhenHit(true);
             Definition.SetAdditionalDamageDieNumber(1);
             Definition.SetAdditionalDamageDieType(RuleDefinitions.DieType.D6);
             Definition.SetAdditionalDamageType(RuleDefinitions.DamageTypeLightning);
             Definition.SetAdditionalDamageQuantity(ConditionDefinition.DamageQuantity.Dice);
-
-
         }
 
         public static ConditionDefinition CreateAndAddToDB(string name, string guid)
@@ -1400,5 +1284,4 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
         public static ConditionDefinition ExtraDamageOnAttackCondition = CreateAndAddToDB(ExtraDamageOnAttackConditionName, ExtraDamageOnAttackConditionGuid);
     }
-
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer

--- a/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/ScoutSentinelSubClass.cs
@@ -162,7 +162,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSentinelFeatureSet_level03Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level03 = CreateAndAddToDB(ScoutSentinelFeatureSet_level03Name, ScoutSentinelFeatureSet_level03Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level03 = CreateAndAddToDB(ScoutSentinelFeatureSet_level03Name, ScoutSentinelFeatureSet_level03Guid);
     }
 
     internal class ScoutSentinelFeatureSet_level05Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
@@ -184,7 +184,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSentinelFeatureSet_level05Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level05 = CreateAndAddToDB(ScoutSentinelFeatureSet_level05Name, ScoutSentinelFeatureSet_level05Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level05 = CreateAndAddToDB(ScoutSentinelFeatureSet_level05Name, ScoutSentinelFeatureSet_level05Guid);
     }
 
     internal class ScoutSentinelFeatureSet_level09Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
@@ -223,7 +223,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSentinelFeatureSet_level09Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level09 = CreateAndAddToDB(ScoutSentinelFeatureSet_level09Name, ScoutSentinelFeatureSet_level09Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level09 = CreateAndAddToDB(ScoutSentinelFeatureSet_level09Name, ScoutSentinelFeatureSet_level09Guid);
     }
 
     internal class ScoutSentinelFeatureSet_level15Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
@@ -332,7 +332,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSentinelFeatureSet_level15Builder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level15 = CreateAndAddToDB(ScoutSentinelFeatureSet_level15Name, ScoutSentinelFeatureSet_level15Guid);
+        public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet_level15 = CreateAndAddToDB(ScoutSentinelFeatureSet_level15Name, ScoutSentinelFeatureSet_level15Guid);
     }
 
     //*****************************************************************************************************************************************
@@ -417,7 +417,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSentinelAutopreparedSpellsBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAutoPreparedSpells SubclassAutopreparedSpells = CreateAndAddToDB(SubclassAutopreparedSpellsName, SubclassAutopreparedSpellsGuid);
+        public static readonly FeatureDefinitionAutoPreparedSpells SubclassAutopreparedSpells = CreateAndAddToDB(SubclassAutopreparedSpellsName, SubclassAutopreparedSpellsGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -441,7 +441,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SubclassProficienciesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionProficiency SubclassProficiencies = CreateAndAddToDB(SubclassProficienciesName, SubclassProficienciesGuid);
+        public static readonly FeatureDefinitionProficiency SubclassProficiencies = CreateAndAddToDB(SubclassProficienciesName, SubclassProficienciesGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -465,7 +465,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SubclassMovementAffinitiesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMovementAffinity SubclassMovementAffinities = CreateAndAddToDB(SubclassMovementAffinitiesName, SubclassMovementAffinitiesGuid);
+        public static readonly FeatureDefinitionMovementAffinity SubclassMovementAffinities = CreateAndAddToDB(SubclassMovementAffinitiesName, SubclassMovementAffinitiesGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -491,7 +491,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new UseArmorWeaponsAsFocusBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMagicAffinity UseArmorWeaponsAsFocus = CreateAndAddToDB(UseArmorWeaponsAsFocusName, UseArmorWeaponsAsFocusGuid);
+        public static readonly FeatureDefinitionMagicAffinity UseArmorWeaponsAsFocus = CreateAndAddToDB(UseArmorWeaponsAsFocusName, UseArmorWeaponsAsFocusGuid);
     }
 
     //*****************************************************************************************************************************************
@@ -523,7 +523,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new IntToAttackAndDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAttackModifier IntToAttackAndDamage = CreateAndAddToDB(IntToAttackAndDamageName, IntToAttackAndDamageGuid);
+        public static readonly FeatureDefinitionAttackModifier IntToAttackAndDamage = CreateAndAddToDB(IntToAttackAndDamageName, IntToAttackAndDamageGuid);
     }
 
     //*************************************************************************************************************************
@@ -664,7 +664,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new SentinelSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
+        public static readonly ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
     }
 
     internal class ThunderShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
@@ -724,7 +724,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderShieldBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
+        public static readonly FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
     }
 
     internal class ThunderStruckConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -759,7 +759,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ThunderStruck = CreateAndAddToDB(ThunderStruckName, ThunderStruckGuid);
+        public static readonly ConditionDefinition ThunderStruck = CreateAndAddToDB(ThunderStruckName, ThunderStruckGuid);
     }
 
     internal class ThunderStruckDisadvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
@@ -777,7 +777,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckDisadvantageCombatAffintityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionCombatAffinity Disadvantage = CreateAndAddToDB(ThunderStruckDisadvantageName, ThunderStruckDisadvantageGuid);
+        public static readonly FeatureDefinitionCombatAffinity Disadvantage = CreateAndAddToDB(ThunderStruckDisadvantageName, ThunderStruckDisadvantageGuid);
     }
     internal class ThunderStruckBalancingAdvantageConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
     {
@@ -805,7 +805,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ThunderStruckBalancingAdvantageConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ThunderStruckBalancingAdvantage = CreateAndAddToDB(ThunderStruckBalancingAdvantageName, ThunderStruckBalancingAdvantageGuid);
+        public static readonly ConditionDefinition ThunderStruckBalancingAdvantage = CreateAndAddToDB(ThunderStruckBalancingAdvantageName, ThunderStruckBalancingAdvantageGuid);
     }
 
     internal class BalancingAdvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
@@ -824,7 +824,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new BalancingAdvantageCombatAffintityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionCombatAffinity BalancingAdvantage = CreateAndAddToDB(BalancingAdvantageName, BalancingAdvantageGuid);
+        public static readonly FeatureDefinitionCombatAffinity BalancingAdvantage = CreateAndAddToDB(BalancingAdvantageName, BalancingAdvantageGuid);
     }
     internal class UsingitemPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
     {
@@ -845,7 +845,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new UsingitemPowerBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionActionAffinity UsingitemPower = CreateAndAddToDB(UsingitemPowerName, UsingitemPowerGuid);
+        public static readonly FeatureDefinitionActionAffinity UsingitemPower = CreateAndAddToDB(UsingitemPowerName, UsingitemPowerGuid);
     }
 
     //**************************************************************************************************************************************
@@ -958,7 +958,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ScoutSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
+        public static readonly ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
     }
 
     internal class LightningSpearAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
@@ -984,7 +984,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningSpearAdditionalDamageBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAdditionalDamage LightningSpearAdditionalDamage = CreateAndAddToDB(LightningSpearAdditionalDamageName, LightningSpearAdditionalDamageGuid);
+        public static readonly FeatureDefinitionAdditionalDamage LightningSpearAdditionalDamage = CreateAndAddToDB(LightningSpearAdditionalDamageName, LightningSpearAdditionalDamageGuid);
     }
     internal class LightningCloakMovementAffinitiesBuilder : BaseDefinitionBuilder<FeatureDefinitionMovementAffinity>
     {
@@ -1001,7 +1001,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningCloakMovementAffinitiesBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionMovementAffinity LightningCloakMovementAffinities = CreateAndAddToDB(LightningCloakMovementAffinitiesName, LightningCloakMovementAffinitiesGuid);
+        public static readonly FeatureDefinitionMovementAffinity LightningCloakMovementAffinities = CreateAndAddToDB(LightningCloakMovementAffinitiesName, LightningCloakMovementAffinitiesGuid);
     }
     internal class LightningCloakAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
     {
@@ -1024,7 +1024,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new LightningCloakAbilityCheckAffinityBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionAbilityCheckAffinity LightningCloakAbilityCheckAffinity = CreateAndAddToDB(LightningCloakAbilityCheckAffinityName, LightningCloakAbilityCheckAffinityGuid);
+        public static readonly FeatureDefinitionAbilityCheckAffinity LightningCloakAbilityCheckAffinity = CreateAndAddToDB(LightningCloakAbilityCheckAffinityName, LightningCloakAbilityCheckAffinityGuid);
     }
 
     //*************************************************************************************************************************
@@ -1060,7 +1060,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ImprovedSentinelSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
+        public static readonly ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
     }
 
     internal class GauntletsGrappleBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
@@ -1138,7 +1138,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new GauntletsGrappleBuilder(name, guid).AddToDB();
         }
 
-        public static FeatureDefinitionPower GauntletsGrapple = CreateAndAddToDB(GauntletsGrappleName, GauntletsGrappleGuid);
+        public static readonly FeatureDefinitionPower GauntletsGrapple = CreateAndAddToDB(GauntletsGrappleName, GauntletsGrappleGuid);
     }
 
     //**************************************************************************************************************************************
@@ -1209,7 +1209,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ImprovedScoutSuitWeaponBuilder(name, guid).AddToDB();
         }
 
-        public static ItemDefinition ImprovedScoutSuitWeapon = CreateAndAddToDB(ImprovedScoutSuitWeaponName, ImprovedScoutSuitWeaponGuid);
+        public static readonly ItemDefinition ImprovedScoutSuitWeapon = CreateAndAddToDB(ImprovedScoutSuitWeaponName, ImprovedScoutSuitWeaponGuid);
     }
 
     internal class DisadvantageOnAttackByEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1229,7 +1229,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new DisadvantageOnAttackByEnemyBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition DisadvantageOnAttackByEnemy = CreateAndAddToDB(DisadvantageOnAttackByEnemyName, DisadvantageOnAttackByEnemyGuid);
+        public static readonly ConditionDefinition DisadvantageOnAttackByEnemy = CreateAndAddToDB(DisadvantageOnAttackByEnemyName, DisadvantageOnAttackByEnemyGuid);
     }
 
     internal class AdvantageAttackOnEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1249,7 +1249,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new AdvantageAttackOnEnemyBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition AdvantageAttackOnEnemy = CreateAndAddToDB(AdvantageAttackOnEnemyName, AdvantageAttackOnEnemyGuid);
+        public static readonly ConditionDefinition AdvantageAttackOnEnemy = CreateAndAddToDB(AdvantageAttackOnEnemyName, AdvantageAttackOnEnemyGuid);
     }
 
     internal class ExtraDamageOnAttackConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
@@ -1282,6 +1282,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return new ExtraDamageOnAttackConditionBuilder(name, guid).AddToDB();
         }
 
-        public static ConditionDefinition ExtraDamageOnAttackCondition = CreateAndAddToDB(ExtraDamageOnAttackConditionName, ExtraDamageOnAttackConditionGuid);
+        public static readonly ConditionDefinition ExtraDamageOnAttackCondition = CreateAndAddToDB(ExtraDamageOnAttackConditionName, ExtraDamageOnAttackConditionGuid);
     }
 }

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using static CharacterClassDefinition;
 

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
@@ -155,7 +155,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             };
             ArtificerBuilder.AddEquipmentRow(providedGear);
 
-
             //public List<FeatureUnlockByLevel> FeatureUnlocks { get; }
             FeatureDefinitionProficiency armorProf = FeatureHelpers.BuildProficiency(RuleDefinitions.ProficiencyType.Armor,
                 new List<string>() { EquipmentDefinitions.LightArmorCategory, EquipmentDefinitions.MediumArmorCategory, EquipmentDefinitions.ShieldCategory },
@@ -247,7 +246,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 
             ArtificerBuilder.AddFeatureAtLevel(InfusionPool, 2);
 
-
             // Infusions -- Focus, Weapon, Mind Sharpener, Armor of Magical Strength are given in subclasses
             // Defense
             GuiPresentationBuilder infusionChoiceGui = new GuiPresentationBuilder(
@@ -265,9 +263,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             // Repeating Shot-- no point it seems
             // Returning Weapon-- not currently do-able
 
-
             // right tool for the job (level 3) (can I just give enchanting tool at level 3?)-- tools are available in the store, just skipping for now
-
 
             // Subclasses
             FeatureDefinitionSubclassChoice subclasses = ArtificerBuilder.BuildSubclassChoice(3, "Specialist", false, "SubclassChoiceArtificerSpecialistArchetypes",
@@ -432,7 +428,6 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             ArtificerBuilder.AddFeatureAtLevel(level14Infusions, 18);
 
             ArtificerBuilder.AddFeatureAtLevel(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, 19);
-
 
             GuiPresentationBuilder SoulOfArtificeGui = new GuiPresentationBuilder(
                 "Subclass/&PowerTinkererSoulOfArtificeSavesDescription",

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererClass.cs
@@ -10,7 +10,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
     internal static class TinkererClass
     {
-        public static Guid GuidNamespace = new Guid("7aee1270-7a61-48d9-8670-cf087c551c16");
+        public static readonly Guid GuidNamespace = new Guid("7aee1270-7a61-48d9-8670-cf087c551c16");
 
         public static readonly FeatureDefinitionPower InfusionPool = new FeatureDefinitionPowerPoolBuilder("AttributeModiferArtificerInfusionHealingPool",
             GuidHelper.Create(GuidNamespace, "AttributeModiferArtificerInfusionHealingPool").ToString(),

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
@@ -1,7 +1,7 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal class TinkererSpellList : BaseDefinitionBuilder<SpellListDefinition>
+    internal sealed class TinkererSpellList : BaseDefinitionBuilder<SpellListDefinition>
     {
         private TinkererSpellList(string name, string guid, GuiPresentation guiPresentation) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Classes/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch.cs
@@ -435,7 +435,7 @@ namespace SolastaCommunityExpansion.Classes
 
             classSpellCast.SetSlotsPerLevel(witchCastingSlots);
             classSpellCast.SetSlotsRecharge(RuleDefinitions.RechargeRate.LongRest);
-            classSpellCast.SetSpellCastingOrigin(FeatureDefinitionCastSpell.CastingOrigin.Class);
+            classSpellCast.SetSpellCastingOrigin(CastingOrigin.Class);
             classSpellCast.SetSpellCastingAbility(AttributeDefinitions.Charisma);
             classSpellCast.SetSpellCastingLevel(9);
             classSpellCast.SetSpellKnowledge(RuleDefinitions.SpellKnowledge.Selection);

--- a/SolastaCommunityExpansion/Classes/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch.cs
@@ -451,7 +451,6 @@ namespace SolastaCommunityExpansion.Classes
 
         private static void BuildRitualCasting()
         {
-
             FeatureDefinitionFeatureSetRitualCasting = new FeatureDefinitionFeatureSetBuilder(
                     DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetWizardRitualCasting,
                     "WitchFeatureSetRitualCasting",
@@ -469,12 +468,10 @@ namespace SolastaCommunityExpansion.Classes
                             .SetRitualCasting((RuleDefinitions.RitualCasting)ExtraRitualCasting.Known).AddToDB())
                     .AddFeature(DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityWizardRitualCasting)
                     .AddToDB();
-
         }
 
         private static void BuildWitchCurses()
         {
-
             // Legend: 
             // +: implemented 
             // -: will not implement
@@ -578,12 +575,10 @@ namespace SolastaCommunityExpansion.Classes
                     .AddFeature(lovelessCurse)
                     .AddFeature(visionsCurse)
                     .AddToDB();
-
         }
 
         private static void BuildMaledictions()
         {
-
             // Maledictions are actions unless mentioned otherwise
             // If a Malediction calls for an attack roll or saving throw, it uses your spell attack bonus or spell save DC, unless mentioned otherwise. 
             // All Maledictions require verbal or somatic components
@@ -662,7 +657,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var apathyEffectDescription = new EffectDescription();
             apathyEffectDescription.Copy(DatabaseHelper.SpellDefinitions.CalmEmotionsOnEnemy.EffectDescription);
             apathyEffectDescription.SetDurationParameter(1);
@@ -692,7 +686,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.CalmEmotions.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             var charmEffectDescription = new EffectDescription();
             charmEffectDescription.Copy(DatabaseHelper.SpellDefinitions.CharmPerson.EffectDescription);
@@ -725,7 +718,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var evileyeEffectDescription = new EffectDescription();
             evileyeEffectDescription.Copy(DatabaseHelper.SpellDefinitions.Fear.EffectDescription);
             evileyeEffectDescription.SetDurationParameter(1);
@@ -757,7 +749,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             var obfuscateEffectDescription = new EffectDescription();
             obfuscateEffectDescription.Copy(DatabaseHelper.SpellDefinitions.FogCloud.EffectDescription);
             obfuscateEffectDescription.SetCanBePlacedOnCharacter(true);
@@ -785,7 +776,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.FogCloud.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             EffectForm poxEffectForm = new EffectForm
             {
@@ -827,7 +817,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.PoisonSpray.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
 
             EffectForm ruinEffectForm = new EffectForm
             {
@@ -902,7 +891,6 @@ namespace SolastaCommunityExpansion.Classes
                     true)
                     .AddToDB();
 
-
             FeatureDefinitionFeatureSetMaledictions = new FeatureDefinitionFeatureSetBuilder(
                     DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetWizardRitualCasting,
                     "WitchFeatureSetMaledictions",
@@ -921,12 +909,10 @@ namespace SolastaCommunityExpansion.Classes
                     .AddFeature(pox)
                     .AddFeature(ruin)
                     .AddToDB();
-
         }
 
         private static void BuildCackle()
         {
-
             // At 2nd level, you can use your bonus action to cackle. 
             // The duration of your Malediction extends by 1 round for each creature affected within 60 feet of you. 
             // Not all witches laugh maniacally when they cackle, but all cackles require a verbal component, as a spell. 
@@ -979,7 +965,6 @@ namespace SolastaCommunityExpansion.Classes
                             .SetSpriteReference(DatabaseHelper.SpellDefinitions.HideousLaughter.GuiPresentation.SpriteReference),
                     true)
                     .AddToDB();
-
         }
 
         private static CharacterClassDefinition BuildAndAddClass()
@@ -1224,7 +1209,6 @@ namespace SolastaCommunityExpansion.Classes
                 //            subClassChoices.Subclasses.Add(new PurpleWitch().GetSubclass(classDef).name);
                 subClassChoices.Subclasses.Add(new RedWitch().GetSubclass(witch).name);
                 subClassChoices.Subclasses.Add(new WhiteWitch().GetSubclass(witch).name);
-
             }
 
             void BuildProgression()

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/CustomFightingStyle.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/CustomFightingStyle.cs
@@ -1,8 +1,8 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Diagnostics;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.CustomFeatureDefinitions
 {

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionOnAttackHitEffect.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/FeatureDefinitionOnAttackHitEffect.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.CustomFeatureDefinitions
 {

--- a/SolastaCommunityExpansion/Feats/AcehighFeats.cs
+++ b/SolastaCommunityExpansion/Feats/AcehighFeats.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using static FeatureDefinitionSavingThrowAffinity;
 
 namespace SolastaCommunityExpansion.Feats
@@ -69,7 +69,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new PowerAttackPowerBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackPowerBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionPower PowerAttackPower = CreateAndAddToDB(PowerAttackPowerName, PowerAttackPowerNameGuid);
         }
@@ -113,7 +115,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new PowerAttackTwoHandedPowerBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackTwoHandedPowerBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionPower PowerAttackTwoHandedPower = CreateAndAddToDB(PowerAttackTwoHandedPowerName, PowerAttackTwoHandedPowerNameGuid);
         }
@@ -137,7 +141,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionAttackModifier CreateAndAddToDB(string name, string guid)
-                => new PowerAttackOneHandedAttackModifierBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackOneHandedAttackModifierBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionAttackModifier PowerAttackAttackModifier
                 = CreateAndAddToDB(PowerAttackAttackModifierName, PowerAttackAttackModifierNameGuid);
@@ -162,7 +168,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionAttackModifier CreateAndAddToDB(string name, string guid)
-                => new PowerAttackTwoHandedAttackModifierBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackTwoHandedAttackModifierBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionAttackModifier PowerAttackTwoHandedAttackModifier = CreateAndAddToDB(PowerAttackTwoHandedAttackModifierName, PowerAttackTwoHandedAttackModifierNameGuid);
         }
@@ -186,7 +194,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new PowerAttackConditionBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackConditionBuilder(name, guid).AddToDB();
+            }
 
             public static readonly ConditionDefinition PowerAttackCondition = CreateAndAddToDB(PowerAttackConditionName, PowerAttackConditionNameGuid);
         }
@@ -210,7 +220,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new PowerAttackTwoHandedConditionBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackTwoHandedConditionBuilder(name, guid).AddToDB();
+            }
 
             public static readonly ConditionDefinition PowerAttackTwoHandedCondition = CreateAndAddToDB(PowerAttackTwoHandedConditionName, PowerAttackTwoHandedConditionNameGuid);
         }
@@ -232,7 +244,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatDefinition CreateAndAddToDB(string name, string guid)
-                => new PowerAttackFeatBuilder(name, guid).AddToDB();
+            {
+                return new PowerAttackFeatBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatDefinition PowerAttackFeat = CreateAndAddToDB(PowerAttackFeatName, PowerAttackFeatNameGuid);
         }
@@ -254,7 +268,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatDefinition CreateAndAddToDB(string name, string guid)
-                => new RecklessFuryFeatBuilder(name, guid).AddToDB();
+            {
+                return new RecklessFuryFeatBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatDefinition RecklessFuryFeat = CreateAndAddToDB(RecklessFuryFeatName, RecklessFuryFeatNameGuid);
         }
@@ -302,7 +318,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new RagePowerBuilder(name, guid).AddToDB();
+            {
+                return new RagePowerBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionPower RagePower = CreateAndAddToDB(RagePowerName, RagePowerNameGuid);
         }
@@ -330,7 +348,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new RageFeatConditionBuilder(name, guid).AddToDB();
+            {
+                return new RageFeatConditionBuilder(name, guid).AddToDB();
+            }
 
             public static readonly ConditionDefinition RageFeatCondition = CreateAndAddToDB(RageFeatConditionName, RageFeatConditionNameGuid);
         }
@@ -356,7 +376,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionSavingThrowAffinity CreateAndAddToDB(string name, string guid)
-                => new RageStrengthSavingThrowAffinityBuilder(name, guid).AddToDB();
+            {
+                return new RageStrengthSavingThrowAffinityBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionSavingThrowAffinity RageStrengthSavingThrowAffinity = CreateAndAddToDB(RageStrengthSavingThrowAffinityName, RageStrengthSavingThrowAffinityNameGuid);
         }
@@ -377,7 +399,9 @@ namespace SolastaCommunityExpansion.Feats
             }
 
             public static FeatureDefinitionAttackModifier CreateAndAddToDB(string name, string guid)
-                => new RageDamageBonusAttackModifierBuilder(name, guid).AddToDB();
+            {
+                return new RageDamageBonusAttackModifierBuilder(name, guid).AddToDB();
+            }
 
             public static readonly FeatureDefinitionAttackModifier RageDamageBonusAttackModifier = CreateAndAddToDB(RageDamageBonusAttackModifierName, RageDamageBonusAttackModifierNameGuid);
         }

--- a/SolastaCommunityExpansion/Feats/ArmorFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ArmorFeats.cs
@@ -18,7 +18,7 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&ProfLightArmorTitle");
             FeatureDefinition lightProf = BuildProficiency(RuleDefinitions.ProficiencyType.Armor, new List<string>()
             {
-                EquipmentDefinitions.LightArmorCategory.ToString()
+                EquipmentDefinitions.LightArmorCategory
             }, "FeatLightArmorProficiency", lightProfPresentation.Build()
             );
             GuiPresentationBuilder dexPresentation = new GuiPresentationBuilder(
@@ -44,8 +44,8 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&ProfMediumArmorTitle");
             FeatureDefinition mediumProf = BuildProficiency(RuleDefinitions.ProficiencyType.Armor, new List<string>()
             {
-                EquipmentDefinitions.MediumArmorCategory.ToString(),
-                EquipmentDefinitions.ShieldCategory.ToString(),
+                EquipmentDefinitions.MediumArmorCategory,
+                EquipmentDefinitions.ShieldCategory,
             }, "FeatMediumArmorProficiency", mediumProfPresentation.Build()
             );
 

--- a/SolastaCommunityExpansion/Feats/ArmorFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ArmorFeats.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Feats
 {

--- a/SolastaCommunityExpansion/Feats/CasterFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CasterFeats.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.Builders;
-using SolastaCommunityExpansion.Features;
-using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using SolastaCommunityExpansion.Builders;
+using SolastaCommunityExpansion.Features;
+using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Feats
 {

--- a/SolastaCommunityExpansion/Feats/CasterFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CasterFeats.cs
@@ -366,7 +366,6 @@ namespace SolastaCommunityExpansion.Feats
             particleParams.Copy(DatabaseHelper.FeatureDefinitionPowers.PowerWizardArcaneRecovery.EffectDescription.EffectParticleParameters);
             effectDescriptionBuilder.SetParticleEffectParameters(particleParams);
 
-
             return BuildPowerFromEffectDescription(usesPerRecharge, usesDetermination, activationTime, costPerUse, recharge,
                 false, false, savingThrowDifficultyAbility, effectDescriptionBuilder.Build(), name, guiPresentation);
         }

--- a/SolastaCommunityExpansion/Feats/CraftyFeats.cs
+++ b/SolastaCommunityExpansion/Feats/CraftyFeats.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Feats

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -34,7 +34,9 @@ namespace SolastaCommunityExpansion.Feats
         }
 
         public static FeatDefinition CreateAndAddToDB(string name, string guid)
-            => new DualFlurryFeatBuilder(name, guid).AddToDB();
+        {
+            return new DualFlurryFeatBuilder(name, guid).AddToDB();
+        }
 
         public static readonly FeatDefinition DualFlurryFeat = CreateAndAddToDB(DualFlurryFeatName, DualFlurryFeatNameGuid);
 
@@ -90,7 +92,9 @@ namespace SolastaCommunityExpansion.Feats
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionDualFlurryApplyBuilder("ConditionDualFlurryApply", GuidHelper.Create(DualFlurryFeatBuilder.DualFlurryGuid, "ConditionDualFlurryApply").ToString()).AddToDB();
+        {
+            return new ConditionDualFlurryApplyBuilder("ConditionDualFlurryApply", GuidHelper.Create(DualFlurryFeatBuilder.DualFlurryGuid, "ConditionDualFlurryApply").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {
@@ -120,7 +124,9 @@ namespace SolastaCommunityExpansion.Feats
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionDualFlurryGrantBuilder("ConditionDualFlurryGrant", GuidHelper.Create(DualFlurryFeatBuilder.DualFlurryGuid, "ConditionDualFlurryGrant").ToString()).AddToDB();
+        {
+            return new ConditionDualFlurryGrantBuilder("ConditionDualFlurryGrant", GuidHelper.Create(DualFlurryFeatBuilder.DualFlurryGuid, "ConditionDualFlurryGrant").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {
@@ -162,7 +168,9 @@ namespace SolastaCommunityExpansion.Feats
         }
 
         public static FeatDefinition CreateAndAddToDB(string name, string guid)
-            => new TorchbearerFeatBuilder(name, guid).AddToDB();
+        {
+            return new TorchbearerFeatBuilder(name, guid).AddToDB();
+        }
 
         public static readonly FeatDefinition TorchbearerFeat = CreateAndAddToDB(TorchbearerFeatName, TorchbearerFeatNameGuid);
 

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -216,7 +216,7 @@ namespace SolastaCommunityExpansion.Feats
             }
             RulesetItem off_item = hero.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeOffHand].EquipedItem;
 
-            return (off_item != null && off_item.ItemDefinition != null && off_item.ItemDefinition.IsLightSourceItem);
+            return off_item != null && off_item.ItemDefinition != null && off_item.ItemDefinition.IsLightSourceItem;
         }
     }
 }

--- a/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
+++ b/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
@@ -1,10 +1,10 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaCommunityExpansion.FightingStyles;
 using SolastaCommunityExpansion.Models;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Feats
 {

--- a/SolastaCommunityExpansion/Feats/HealingFeats.cs
+++ b/SolastaCommunityExpansion/Feats/HealingFeats.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Feats

--- a/SolastaCommunityExpansion/Feats/OtherFeats.cs
+++ b/SolastaCommunityExpansion/Feats/OtherFeats.cs
@@ -1,8 +1,8 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaModApi;
-using System;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Feats
 {

--- a/SolastaCommunityExpansion/Feats/OtherFeats.cs
+++ b/SolastaCommunityExpansion/Feats/OtherFeats.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Feats
                 "Feat/&FeatSavageAttackerDescription",
                 "Feat/&FeatSavageAttackerTitle");
 
-            string rerollKey = "Feat/&FeatSavageAttackerReroll";
+            const string rerollKey = "Feat/&FeatSavageAttackerReroll";
             FeatureDefinitionDieRollModifier savageAttackDieRoll = BuildDieRollModifier(RuleDefinitions.RollContext.AttackDamageValueRoll,
                 1 /* reroll count */, 1 /* reroll min value */, rerollKey, "DieRollModifierFeatSavageAttacker",
                 savageAttackerPresentation.Build());

--- a/SolastaCommunityExpansion/Features/ConditionDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ConditionDefinitionBuilder.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Features

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionAbilityCheckAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionAbilityCheckAffinityBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Features
 {

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionActionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionActionAffinityBuilder.cs
@@ -7,6 +7,5 @@ namespace SolastaCommunityExpansion.Features
         public FeatureDefinitionActionAffinityBuilder(FeatureDefinitionActionAffinity toCopy, string name, string guid) : base(toCopy, name, guid)
         {
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionAdditionalDamageBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionAdditionalDamageBuilder.cs
@@ -1,7 +1,7 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Features

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionAttributeModifierBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionAttributeModifierBuilder.cs
@@ -19,5 +19,4 @@ namespace SolastaCommunityExpansion.Features
             return this;
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionBonusCantripsBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionBonusCantripsBuilder.cs
@@ -19,11 +19,8 @@ namespace SolastaCommunityExpansion.Features
 
         public FeatureDefinitionBonusCantripsBuilder AddBonusCantrip(SpellDefinition spellDefinition)
         {
-
             Definition.BonusCantrips.Add(spellDefinition);
             return this;
         }
-
     }
-
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionConditionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionConditionAffinityBuilder.cs
@@ -10,6 +10,5 @@ namespace SolastaCommunityExpansion.Features
         {
             Definition.SetGuiPresentation(guiPresentation);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionDamageAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionDamageAffinityBuilder.cs
@@ -10,6 +10,5 @@ namespace SolastaCommunityExpansion.Features
         {
             Definition.SetGuiPresentation(guiPresentation);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionFeatureSetBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionFeatureSetBuilder.cs
@@ -5,7 +5,6 @@ namespace SolastaCommunityExpansion.Features
 {
     public class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
     {
-
         public FeatureDefinitionFeatureSetBuilder(FeatureDefinitionFeatureSet toCopy, string name, string guid,
            GuiPresentation guiPresentation) : base(toCopy, name, guid)
         {
@@ -20,24 +19,20 @@ namespace SolastaCommunityExpansion.Features
 
         public FeatureDefinitionFeatureSetBuilder AddFeature(FeatureDefinition featureDefinition)
         {
-
             Definition.FeatureSet.Add(featureDefinition);
             return this;
         }
 
         public FeatureDefinitionFeatureSetBuilder SetMode(FeatureDefinitionFeatureSet.FeatureSetMode mode)
         {
-
             Definition.SetMode(mode);
             return this;
         }
 
         public FeatureDefinitionFeatureSetBuilder SetUniqueChoices(bool uniqueChoice)
         {
-
             Definition.SetUniqueChoices(uniqueChoice);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Features
 {

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionMagicAffinityBuilder.cs
@@ -77,6 +77,5 @@ namespace SolastaCommunityExpansion.Features
             Definition.SetRitualCasting(ritualCasting);
             return this;
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionPowerBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionPowerBuilder.cs
@@ -143,7 +143,6 @@ namespace SolastaCommunityExpansion.Features
             return this;
         }
 
-
         public FeatureDefinitionPowerBuilder SetShowCasting(bool casting)
         {
             Definition.SetShowCasting(casting);

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionProficiencyBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionProficiencyBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.Features
 {

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
@@ -1,7 +1,7 @@
-﻿using SolastaModApi;
+﻿using System.Collections.Generic;
+using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.SchoolOfMagicDefinitions;
 
 namespace SolastaCommunityExpansion.Features

--- a/SolastaCommunityExpansion/Features/FeatureDefinitionSummoningAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Features/FeatureDefinitionSummoningAffinityBuilder.cs
@@ -7,6 +7,5 @@ namespace SolastaCommunityExpansion.Features
         public FeatureDefinitionSummoningAffinityBuilder(FeatureDefinitionSummoningAffinity toCopy, string name, string guid) : base(toCopy, name, guid)
         {
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Features/ItemBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ItemBuilder.cs
@@ -103,7 +103,6 @@ namespace SolastaCommunityExpansion.Features
 
         public static ItemDefinition BuildNewMagicWeapon(Guid collectionGuid, ItemDefinition baseItem, ItemDefinition magicalExample, string name)
         {
-
             string itemName = "Enchanted_" + baseItem.Name + "_" + name;
             ItemDefinitionBuilder builder = new ItemDefinitionBuilder(baseItem, itemName, GuidHelper.Create(collectionGuid, itemName).ToString());
             // Set is magical

--- a/SolastaCommunityExpansion/Features/ItemBuilder.cs
+++ b/SolastaCommunityExpansion/Features/ItemBuilder.cs
@@ -1,9 +1,9 @@
-﻿using SolastaModApi;
-using SolastaModApi.Extensions;
-using SolastaModApi.Infrastructure;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using SolastaModApi;
+using SolastaModApi.Extensions;
+using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Features
 {

--- a/SolastaCommunityExpansion/Features/SpellListBuilder.cs
+++ b/SolastaCommunityExpansion/Features/SpellListBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Features
 {

--- a/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
+++ b/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
@@ -1,10 +1,10 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaCommunityExpansion.Features;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 
 namespace SolastaCommunityExpansion.FightingStyles
 {

--- a/SolastaCommunityExpansion/Helpers/Extensions.cs
+++ b/SolastaCommunityExpansion/Helpers/Extensions.cs
@@ -14,8 +14,6 @@ namespace SolastaCommunityExpansion.Helpers
         /// <param name="actor"></param>
         /// <param name="populateActorFeaturesToBrowse">Set to true to populate actor.FeaturesToBrowse as well as returning features.  false to just return features.</param>
         /// <param name="featuresOrigin"></param>
-        /// <returns></returns>
-        /// <summary>
         public static ICollection<T> EnumerateFeaturesToBrowse<T>(
             this RulesetActor actor, bool populateActorFeaturesToBrowse = false, Dictionary<FeatureDefinition, RuleDefinitions.FeatureOrigin> featuresOrigin = null)
         {

--- a/SolastaCommunityExpansion/Hotkeys.cs
+++ b/SolastaCommunityExpansion/Hotkeys.cs
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion
 
         // Debug Overlay
         internal const InputCommands.Id CTRL_SHIFT_D = (InputCommands.Id)44440005;
-        
+
         // Export Character
         internal const InputCommands.Id CTRL_SHIFT_E = (InputCommands.Id)44440006;
 

--- a/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -47,9 +45,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Deflection", DatabaseHelper.ItemDefinitions.Enchanted_BreastplateOfDeflection,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BreastplateOfDeflection),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ArmorAndShieldData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,26 +11,24 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Shield_Wooden,
                             DatabaseHelper.ItemDefinitions.Shield,
                             DatabaseHelper.ItemDefinitions.HideArmor,
                             DatabaseHelper.ItemDefinitions.StuddedLeather,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_HalfPlate,
                             DatabaseHelper.ItemDefinitions.Primed_Leather_Armor,
                             DatabaseHelper.ItemDefinitions.Primed_ScaleMail,
                             DatabaseHelper.ItemDefinitions.Primed_Breastplate,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             new MagicItemDataHolder("Sturdiness", DatabaseHelper.ItemDefinitions.Enchanted_HalfPlateOfSturdiness,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_HalfplateOfSturdiness),
@@ -45,8 +43,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Deflection", DatabaseHelper.ItemDefinitions.Enchanted_BreastplateOfDeflection,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BreastplateOfDeflection),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,25 +11,23 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Club,
                             DatabaseHelper.ItemDefinitions.Maul,
                             DatabaseHelper.ItemDefinitions.Warhammer,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Morningstar,
                             DatabaseHelper.ItemDefinitions.Primed_Mace,
                             DatabaseHelper.ItemDefinitions.Primed_Greatsword,
                             DatabaseHelper.ItemDefinitions.Primed_Battleaxe,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                              // Same as +1
                             new MagicItemDataHolder("Acuteness", DatabaseHelper.ItemDefinitions.Enchanted_Mace_Of_Acuteness,
@@ -43,8 +41,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Punisher", DatabaseHelper.ItemDefinitions.Enchanted_Battleaxe_Punisher,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BattleaxePunisher),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/BashingWeaponsData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -45,9 +43,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Punisher", DatabaseHelper.ItemDefinitions.Enchanted_Battleaxe_Punisher,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_BattleaxePunisher),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (crossbowItems == null)
-                {
-                    crossbowItems = new ItemCollection()
+                return crossbowItems ?? (crossbowItems = new ItemCollection()
                     {
                         BaseGuid = new Guid("6eff8e23-1b2f-4e48-8cde-3abda9d4bc3b"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -43,9 +41,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Medusa", DatabaseHelper.ItemDefinitions.Enchanted_Shortbow_Medusa,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortbowMedusa),
                         }
-                    };
-                }
-                return crossbowItems;
+                    });
             }
             set => crossbowItems = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/CrossbowData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,22 +11,20 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection CrossbowItems
         {
-            get
+            get => crossbowItems ?? (crossbowItems = new ItemCollection()
             {
-                return crossbowItems ?? (crossbowItems = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("6eff8e23-1b2f-4e48-8cde-3abda9d4bc3b"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("6eff8e23-1b2f-4e48-8cde-3abda9d4bc3b"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.LightCrossbow,
                             DatabaseHelper.ItemDefinitions.HeavyCrossbow,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Longbow,
                             DatabaseHelper.ItemDefinitions.Primed_Shortbow,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             // Same as +1
                             new MagicItemDataHolder("Accuracy", DatabaseHelper.ItemDefinitions.Enchanted_Longbow_Of_Accurary,
@@ -41,8 +39,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Medusa", DatabaseHelper.ItemDefinitions.Enchanted_Shortbow_Medusa,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortbowMedusa),
                         }
-                    });
-            }
+            });
             set => crossbowItems = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -39,9 +37,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Frostburn", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Frostburn,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/HandaxeData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,20 +11,18 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Handaxe,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Dagger,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             // Same as +1
                             new MagicItemDataHolder("Acuteness", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_of_Acuteness,
@@ -37,8 +35,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Frostburn", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Frostburn,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
@@ -1,10 +1,10 @@
-﻿using SolastaCommunityExpansion.Builders;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaModApi;
 using SolastaModApi.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SolastaCommunityExpansion.ItemCrafting
 {

--- a/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ItemRecipeGenerationHelper.cs
@@ -50,7 +50,6 @@ namespace SolastaCommunityExpansion.ItemCrafting
                         StockItem(DatabaseHelper.MerchantDefinitions.Store_Merchant_Gorim_Ironsoot_Cyflen_GeneralStore, craftingManual);
                     }
                 }
-
             }
         }
 
@@ -149,7 +148,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 recipes.Add(builder.AddToDB());
             }
 
-            string groupKey = "EnchantingIngredients";
+            const string groupKey = "EnchantingIngredients";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)
@@ -203,7 +202,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
             };
             IEnumerable<RecipeDefinition> recipes = primedToBase.Keys.Select(item => CreatePrimingRecipe(baseGuid, primedToBase[item], item));
 
-            string groupKey = "PrimedItems";
+            const string groupKey = "PrimedItems";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)
@@ -230,7 +229,6 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 {DatabaseHelper.ItemDefinitions.CAERLEM_TirmarianHolySymbol, DatabaseHelper.ItemDefinitions.Art_Item_50_GP_JadePendant},
                 {DatabaseHelper.ItemDefinitions.BONEKEEP_MagicRune, DatabaseHelper.ItemDefinitions.Art_Item_25_GP_EngraveBoneDice},
                 {DatabaseHelper.ItemDefinitions.CaerLem_Gate_Plaque, DatabaseHelper.ItemDefinitions.Art_Item_25_GP_SilverChalice},
-
             };
             List<RecipeDefinition> recipes = new List<RecipeDefinition>();
             foreach (ItemDefinition item in ForgeryToIngredient.Keys)
@@ -265,7 +263,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                 recipes.Add(builder.AddToDB());
             }
 
-            string groupKey = "RelicForgeries";
+            const string groupKey = "RelicForgeries";
             Models.ItemCraftingContext.RecipeBooks.Add(groupKey, new List<ItemDefinition>());
 
             foreach (RecipeDefinition recipe in recipes)

--- a/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,16 +11,14 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Quarterstaff,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Mace,
                             DatabaseHelper.ItemDefinitions.Primed_Longsword,
@@ -28,7 +26,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             DatabaseHelper.ItemDefinitions.Primed_Shortsword,
                             DatabaseHelper.ItemDefinitions.Primed_Dagger,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                              // Same as +1
                             new MagicItemDataHolder("Acuteness", DatabaseHelper.ItemDefinitions.Enchanted_Mace_Of_Acuteness,
@@ -48,8 +46,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/QuarterstaffData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -50,9 +48,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -46,9 +44,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ScimitarData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,23 +11,21 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Scimitar,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Longsword,
                             DatabaseHelper.ItemDefinitions.Primed_Greatsword,
                             DatabaseHelper.ItemDefinitions.Primed_Shortsword,
                             DatabaseHelper.ItemDefinitions.Primed_Dagger,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             new MagicItemDataHolder("Stormblade", DatabaseHelper.ItemDefinitions.Enchanted_Longsword_Stormblade,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_LongswordStormblade),
@@ -44,8 +42,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Souldrinker", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Souldrinker,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerSouldrinker),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,21 +11,19 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Spear,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Rapier,
                             DatabaseHelper.ItemDefinitions.Primed_Shortsword,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             new MagicItemDataHolder("BlackViper", DatabaseHelper.ItemDefinitions.Enchanted_Rapier_Blackadder,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_RapierBlackAdder),
@@ -40,8 +38,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Sharpness", DatabaseHelper.ItemDefinitions.Enchanted_Shortsword_of_Sharpness,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortwordOfSharpness),
                         }
-                    });
-            }
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/SpearData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -42,9 +40,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Sharpness", DatabaseHelper.ItemDefinitions.Enchanted_Shortsword_of_Sharpness,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_ShortwordOfSharpness),
                         }
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
@@ -13,9 +13,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
         {
             get
             {
-                if (items == null)
-                {
-                    items = new ItemCollection()
+                return items ?? (items = new ItemCollection()
                     {
                         BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
                         BaseWeapons = new List<ItemDefinition>()
@@ -41,9 +39,7 @@ namespace SolastaCommunityExpansion.ItemCrafting
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         },
                         NumProduced = 3,
-                    };
-                }
-                return items;
+                    });
             }
             set => items = value;
         }

--- a/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
@@ -1,6 +1,6 @@
-﻿using SolastaModApi;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaCommunityExpansion.ItemCrafting.ItemCollection;
 
 namespace SolastaCommunityExpansion.ItemCrafting
@@ -11,21 +11,19 @@ namespace SolastaCommunityExpansion.ItemCrafting
 
         internal static ItemCollection Items
         {
-            get
+            get => items ?? (items = new ItemCollection()
             {
-                return items ?? (items = new ItemCollection()
-                    {
-                        BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
-                        BaseWeapons = new List<ItemDefinition>()
+                BaseGuid = new Guid("16757d1b-518f-4669-af43-1ddf5d23c223"),
+                BaseWeapons = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Javelin,
                             DatabaseHelper.ItemDefinitions.Dart,
                         },
-                        PossiblePrimedItemsToReplace = new List<ItemDefinition>()
+                PossiblePrimedItemsToReplace = new List<ItemDefinition>()
                         {
                             DatabaseHelper.ItemDefinitions.Primed_Dagger,
                         },
-                        MagicToCopy = new List<MagicItemDataHolder>()
+                MagicToCopy = new List<MagicItemDataHolder>()
                         {
                             // Same as +1
                             new MagicItemDataHolder("Acuteness", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_of_Acuteness,
@@ -38,9 +36,8 @@ namespace SolastaCommunityExpansion.ItemCrafting
                             new MagicItemDataHolder("Frostburn", DatabaseHelper.ItemDefinitions.Enchanted_Dagger_Frostburn,
                                 DatabaseHelper.RecipeDefinitions.Recipe_Enchantment_DaggerFrostburn),
                         },
-                        NumProduced = 3,
-                    });
-            }
+                NumProduced = 3,
+            });
             set => items = value;
         }
     }

--- a/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
+++ b/SolastaCommunityExpansion/ItemCrafting/ThrowingWeaponData.cs
@@ -49,4 +49,3 @@ namespace SolastaCommunityExpansion.ItemCrafting
         }
     }
 }
-

--- a/SolastaCommunityExpansion/Level20/Classes/ClericBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/ClericBuilder.cs
@@ -1,5 +1,5 @@
-﻿using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SolastaModApi.Extensions;
 using static SolastaCommunityExpansion.Level20.Features.PowerClericDivineInterventionImprovementBuilder;
 using static SolastaCommunityExpansion.Level20.Features.PowerClericTurnUndeadBuilder;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;

--- a/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
@@ -1,5 +1,5 @@
-﻿using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;

--- a/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/DruidBuilder.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Level20.Classes
 {
     internal static class DruidBuilder
     {
-
         internal static void Load()
         {
             // add missing progression

--- a/SolastaCommunityExpansion/Level20/Classes/PaladinBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/PaladinBuilder.cs
@@ -1,7 +1,7 @@
-﻿using SolastaCommunityExpansion.Level20.Features;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Level20.Features;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionAutoPreparedSpellss;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;

--- a/SolastaCommunityExpansion/Level20/Classes/RangerBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/RangerBuilder.cs
@@ -1,7 +1,7 @@
-﻿using SolastaModApi.Extensions;
-using System.Collections.Generic;
-using static SolastaCommunityExpansion.Level20.Features.RangerVanishActionBuilder;
+﻿using System.Collections.Generic;
+using SolastaModApi.Extensions;
 using static SolastaCommunityExpansion.Level20.Features.RangerFeralSensesBuilder;
+using static SolastaCommunityExpansion.Level20.Features.RangerVanishActionBuilder;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;

--- a/SolastaCommunityExpansion/Level20/Classes/SorcererBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/SorcererBuilder.cs
@@ -1,6 +1,6 @@
-﻿using SolastaCommunityExpansion.Level20.Features;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Level20.Features;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;

--- a/SolastaCommunityExpansion/Level20/Classes/WizardBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Classes/WizardBuilder.cs
@@ -1,5 +1,5 @@
-﻿using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;

--- a/SolastaCommunityExpansion/Level20/Features/AttributeModifierFighterIndomitableBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/AttributeModifierFighterIndomitableBuilder.cs
@@ -17,7 +17,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
-            => new AttributeModifierFighterIndomitableBuilder(name, guid).AddToDB();
+        {
+            return new AttributeModifierFighterIndomitableBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionAttributeModifier AttributeModifierFighterIndomitableAdd =
             CreateAndAddToDB(AttributeModifierFighterIndomitableAddName, AttributeModifierFighterIndomitableAddGuid);

--- a/SolastaCommunityExpansion/Level20/Features/IndomitableMightBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/IndomitableMightBuilder.cs
@@ -20,7 +20,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinition CreateAndAddToDB(string name, string guid)
-            => new IndomitableMightBuilder(name, guid).AddToDB();
+        {
+            return new IndomitableMightBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinition IndomitableMight =
             CreateAndAddToDB(IndomitableMightName, IndomitableMightGuid);

--- a/SolastaCommunityExpansion/Level20/Features/PowerClericDivineInterventionImprovementBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerClericDivineInterventionImprovementBuilder.cs
@@ -22,7 +22,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(FeatureDefinitionPower basePower, string name, string guid)
-            => new PowerClericDivineInterventionImprovementBuilder(basePower, name, guid).AddToDB();
+        {
+            return new PowerClericDivineInterventionImprovementBuilder(basePower, name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionPower PowerClericDivineInterventionImprovementCleric =
             CreateAndAddToDB(PowerClericDivineInterventionCleric, PowerClericDivineInterventionImprovementClericName, PowerClericDivineInterventionImprovementClericGuid);

--- a/SolastaCommunityExpansion/Level20/Features/PowerClericTurnUndeadBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerClericTurnUndeadBuilder.cs
@@ -18,7 +18,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid, int challengeRating)
-            => new PowerClericTurnUndeadBuilder(name, guid, challengeRating).AddToDB();
+        {
+            return new PowerClericTurnUndeadBuilder(name, guid, challengeRating).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionPower PowerClericTurnUndead14 =
             CreateAndAddToDB(PowerClericTurnUndead14Name, PowerClericTurnUndead14Guid, 3);

--- a/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
@@ -16,7 +16,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-            => new PowerFighterActionSurge2Builder(name, guid).AddToDB();
+        {
+            return new PowerFighterActionSurge2Builder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionPower PowerFighterActionSurge2 =
             CreateAndAddToDB(PowerFighterActionSurgeName, PowerFighterActionSurgeGuid);

--- a/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Level20.Features
         protected PowerFighterActionSurge2Builder(string name, string guid) : base(PowerFighterActionSurge, name, guid)
         {
             Definition.SetFixedUsesPerRecharge(2);
-            Definition.SetOverriddenPower(DatabaseHelper.FeatureDefinitionPowers.PowerFighterActionSurge);
+            Definition.SetOverriddenPower(PowerFighterActionSurge);
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
@@ -37,5 +37,4 @@ namespace SolastaCommunityExpansion.Level20.Features
             }
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
@@ -24,12 +24,6 @@ namespace SolastaCommunityExpansion.Level20.Features
             Definition.GuiPresentation.Title = "Feature/&PowerPaladinAuraOfCourage18Title";
         }
 
-        internal static FeatureDefinitionPower Instance
-        {
-            get
-            {
-                return _instance ?? (_instance = new PowerPaladinAuraOfCourage18Builder().AddToDB());
-            }
-        }
+        internal static FeatureDefinitionPower Instance => _instance ?? (_instance = new PowerPaladinAuraOfCourage18Builder().AddToDB());
     }
 }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
@@ -28,12 +28,7 @@ namespace SolastaCommunityExpansion.Level20.Features
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new PowerPaladinAuraOfCourage18Builder().AddToDB();
-                }
-
-                return _instance;
+                return _instance ?? (_instance = new PowerPaladinAuraOfCourage18Builder().AddToDB());
             }
         }
     }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
@@ -24,12 +24,6 @@ namespace SolastaCommunityExpansion.Level20.Features
             Definition.GuiPresentation.Title = "Feature/&PowerPaladinAuraOfProtection18Title";
         }
 
-        internal static FeatureDefinitionPower Instance
-        {
-            get
-            {
-                return _instance ?? (_instance = new PowerPaladinAuraOfProtection18Builder().AddToDB());
-            }
-        }
+        internal static FeatureDefinitionPower Instance => _instance ?? (_instance = new PowerPaladinAuraOfProtection18Builder().AddToDB());
     }
 }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
@@ -28,12 +28,7 @@ namespace SolastaCommunityExpansion.Level20.Features
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new PowerPaladinAuraOfProtection18Builder().AddToDB();
-                }
-
-                return _instance;
+                return _instance ?? (_instance = new PowerPaladinAuraOfProtection18Builder().AddToDB());
             }
         }
     }

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinCleansingTouchBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinCleansingTouchBuilder.cs
@@ -31,7 +31,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-            => new PowerPaladinCleansingTouchBuilder(name, guid).AddToDB();
+        {
+            return new PowerPaladinCleansingTouchBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionPower PowerPaladinCleansingTouch =
             CreateAndAddToDB(PowerPaladinCleansingTouchName, PowerPaladinCleansingTouchGuid);

--- a/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
@@ -10,7 +10,6 @@ namespace SolastaCommunityExpansion.Level20.Features
 
         protected PrimalChampionBuilder(string name, string guid) : base(name, guid)
         {
-
             Definition.GuiPresentation.Description = "Feature/&PrimalChampionDescription";
             Definition.GuiPresentation.Title = "Feature/&PrimalChampionTitle";
         }

--- a/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
@@ -15,7 +15,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static PrimalChampion CreateAndAddToDB(string name, string guid)
-            => new PrimalChampionBuilder(name, guid).AddToDB();
+        {
+            return new PrimalChampionBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly PrimalChampion PrimalChampion =
             CreateAndAddToDB(PrimalChampionName, PrimalChampionGuid);

--- a/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueBlindSenseBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueBlindSenseBuilder.cs
@@ -17,7 +17,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionSense CreateAndAddToDB(string name, string guid)
-            => new ProficiencyRogueBlindSenseBuilder(name, guid).AddToDB();
+        {
+            return new ProficiencyRogueBlindSenseBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionSense ProficiencyRogueBlindSense
             = CreateAndAddToDB(ProficiencyRogueBlindSenseName, ProficiencyRogueBlindSensedGuid);

--- a/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueSlipperyMindBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueSlipperyMindBuilder.cs
@@ -16,7 +16,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionProficiency CreateAndAddToDB(string name, string guid)
-            => new ProficiencyRogueSlipperyMindBuilder(name, guid).AddToDB();
+        {
+            return new ProficiencyRogueSlipperyMindBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionProficiency ProficiencyRogueSlipperyMind
             = CreateAndAddToDB(ProficiencyRogueSlipperyMindName, ProficiencyRogueSlipperyMindGuid);

--- a/SolastaCommunityExpansion/Level20/Features/RangerFeralSensesBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/RangerFeralSensesBuilder.cs
@@ -17,7 +17,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionSense CreateAndAddToDB(string name, string guid)
-            => new RangerFeralSensesBuilder(name, guid).AddToDB();
+        {
+            return new RangerFeralSensesBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionSense RangerFeralSenses =
             CreateAndAddToDB(RangerFeralSensesName, RangerFeralSensesGuid);

--- a/SolastaCommunityExpansion/Level20/Features/RangerVanishActionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/RangerVanishActionBuilder.cs
@@ -19,7 +19,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionActionAffinity CreateAndAddToDB(string name, string guid)
-            => new RangerVanishActionBuilder(name, guid).AddToDB();
+        {
+            return new RangerVanishActionBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionActionAffinity RangerVanishAction
             = CreateAndAddToDB(RangerVanishActionName, RangerVanishActionGuid);

--- a/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
@@ -57,7 +57,9 @@ namespace SolastaCommunityExpansion.Level20.Features
         }
 
         private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-            => new SorcerousRestorationBuilder(name, guid).AddToDB();
+        {
+            return new SorcerousRestorationBuilder(name, guid).AddToDB();
+        }
 
         internal static readonly FeatureDefinitionPower SorcerousRestoration =
             CreateAndAddToDB(SorcerousRestorationName, SorcerousRestorationGuid);

--- a/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
@@ -27,7 +27,6 @@ namespace SolastaCommunityExpansion.Level20.Features
             restoration.AddEffectForm(restoreForm);
             Definition.SetEffectDescription(restoration.Build());
 
-
             GuiPresentationBuilder gui = new GuiPresentationBuilder(
                "Sorceror/&ZSSorcerousRestorationDescription",
                "Sorceror/&ZSSorcerousRestorationTitle");

--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -47,9 +47,9 @@ namespace SolastaCommunityExpansion.Level20
                     {
                         spellListDefinition.SpellsByLevel.Add(
                             new SpellListDefinition.SpellsByLevelDuplet
-                            { 
-                                Level = spellListDefinition.SpellsByLevel.Count, 
-                                Spells = new List<SpellDefinition>() 
+                            {
+                                Level = spellListDefinition.SpellsByLevel.Count,
+                                Spells = new List<SpellDefinition>()
                             });
                     }
                 }

--- a/SolastaCommunityExpansion/Level20/SpellsHelper.cs
+++ b/SolastaCommunityExpansion/Level20/SpellsHelper.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Level20
             var dbFeatureDefinitionCastSpell = DatabaseRepository.GetDatabase<FeatureDefinitionCastSpell>();
 
             foreach (var featureDefinitionCastSpell in dbFeatureDefinitionCastSpell
-                .Where(x => x.SpellCastingOrigin != FeatureDefinitionCastSpell.CastingOrigin.Monster))
+                .Where(x => x.SpellCastingOrigin != CastingOrigin.Monster))
             {
                 while (featureDefinitionCastSpell.KnownCantrips.Count < MOD_MAX_LEVEL + 1)
                 {

--- a/SolastaCommunityExpansion/Main.cs
+++ b/SolastaCommunityExpansion/Main.cs
@@ -1,8 +1,8 @@
-﻿using ModKit;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using ModKit;
 using UnityModManagerNet;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
@@ -16,14 +16,30 @@ namespace SolastaCommunityExpansion
         internal static readonly string MOD_FOLDER = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
         [Conditional("DEBUG")]
-        internal static void Log(string msg) => Logger.Log(msg);
-        internal static void Error(Exception ex) => Logger?.Error(ex.ToString());
-        internal static void Error(string msg) => Logger?.Error(msg);
-        internal static void Warning(string msg) => Logger?.Warning(msg);
+        internal static void Log(string msg)
+        {
+            Logger.Log(msg);
+        }
+
+        internal static void Error(Exception ex)
+        {
+            Logger?.Error(ex.ToString());
+        }
+
+        internal static void Error(string msg)
+        {
+            Logger?.Error(msg);
+        }
+
+        internal static void Warning(string msg)
+        {
+            Logger?.Warning(msg);
+        }
+
         internal static UnityModManager.ModEntry.ModLogger Logger { get; private set; }
         internal static ModManager<Core, Settings> Mod { get; private set; }
         internal static MenuManager Menu { get; private set; }
-        internal static Settings Settings { get { return Mod.Settings; } }
+        internal static Settings Settings => Mod.Settings;
 
         internal static bool Load(UnityModManager.ModEntry modEntry)
         {

--- a/SolastaCommunityExpansion/Models/AdditionalNamesContext.cs
+++ b/SolastaCommunityExpansion/Models/AdditionalNamesContext.cs
@@ -35,7 +35,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         dwarfNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("ElfFemale"))
                     {
                         elfHighNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -48,7 +47,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         elfHighNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("SylvanElfFemale"))
                     {
                         elfSylvanNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -61,7 +59,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         elfSylvanNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalfElfFemale"))
                     {
                         halfElfNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -74,7 +71,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halfElfNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalfOrcFemale"))
                     {
                         halfOrcNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -83,7 +79,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halfOrcNames.RacePresentation.MaleNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HalflingFemale"))
                     {
                         halflingNames.RacePresentation.FemaleNameOptions.Add(name);
@@ -96,7 +91,6 @@ namespace SolastaCommunityExpansion.Models
                     {
                         halflingNames.RacePresentation.SurNameOptions.Add(name);
                     }
-
                     else if (term.Contains("HumanFemale"))
                     {
                         humanNames.RacePresentation.FemaleNameOptions.Add(name);

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -49,7 +49,6 @@ namespace SolastaCommunityExpansion.Models
             private string assetGuid;
             private AssetReferenceSprite assetReferenceSprite;
             private List<GameAdventureConversationInfo> conversationInfos = new List<GameAdventureConversationInfo>();
-            private readonly List<TextBreaker> textBreakers = new List<TextBreaker>();
             private string title;
 
             public GameAdventureEntryDungeonMaker()
@@ -61,7 +60,7 @@ namespace SolastaCommunityExpansion.Models
                 assetGuid = assetReferenceSprite == null ? string.Empty : assetReferenceSprite.AssetGUID;
                 assetReferenceSprite = sprite;
                 conversationInfos.Add(new GameAdventureConversationInfo(actorName, text, actorName != ""));
-                textBreakers.Add(new TextBreaker());
+                TextBreakers.Add(new TextBreaker());
                 title = header;
             }
 
@@ -77,7 +76,7 @@ namespace SolastaCommunityExpansion.Models
 
             public override AssetReference IllustrationReference => assetReferenceSprite;
 
-            public List<TextBreaker> TextBreakers => textBreakers;
+            public List<TextBreaker> TextBreakers { get; } = new List<TextBreaker>();
 
             public string Title => title;
 
@@ -86,9 +85,9 @@ namespace SolastaCommunityExpansion.Models
                 base.ComputeHeight(areaWidth, textCompute);
                 Height = AdventureLogDefinition.ConversationHeaderHeight;
 
-                for (var i = 0; i < textBreakers.Count; ++i)
+                for (var i = 0; i < TextBreakers.Count; ++i)
                 {
-                    var textBreaker = textBreakers[i];
+                    var textBreaker = TextBreakers[i];
 
                     if (conversationInfos[i].ActorName != "")
                     {
@@ -136,7 +135,7 @@ namespace SolastaCommunityExpansion.Models
                         captionHashes.Add(hashCode);
                     }
 
-                    textBreakers.Add(new TextBreaker());
+                    TextBreakers.Add(new TextBreaker());
                 }
             }
         }

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -54,7 +54,6 @@ namespace SolastaCommunityExpansion.Models
 
             public GameAdventureEntryDungeonMaker()
             {
-
             }
 
             public GameAdventureEntryDungeonMaker(AdventureLogDefinition adventureLogDefinition, string header, string text, string actorName, AssetReferenceSprite sprite) : base(adventureLogDefinition)

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Models
             if (isUserText)
             {
                 var builder = new StringBuilder();
-                var fragments = itemDefinition.DocumentDescription.ContentFragments.Select(x => x.Text).ToList();
+                var fragments = itemDefinition.DocumentDescription.ContentFragments.ConvertAll(x => x.Text);
 
                 fragments.ForEach(x => builder.Append(x));
                 LogEntry(itemDefinition.FormatTitle(), builder.ToString(), string.Empty, assetReferenceSprite);

--- a/SolastaCommunityExpansion/Models/AdventureLogContext.cs
+++ b/SolastaCommunityExpansion/Models/AdventureLogContext.cs
@@ -1,7 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Text;
+using HarmonyLib;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Models

--- a/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
+++ b/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
@@ -1,5 +1,5 @@
-﻿using SolastaModApi;
-using SolastaModApi.Extensions;
+﻿using SolastaModApi.Extensions;
+using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;
 
 namespace SolastaCommunityExpansion.Models
 {
@@ -9,13 +9,11 @@ namespace SolastaCommunityExpansion.Models
         {
             if (active)
             {
-                FeatureDefinitionFeatureSetExtensions.SetMode(
-                    DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, FeatureDefinitionFeatureSet.FeatureSetMode.Union);
+                FeatureSetAbilityScoreChoice.SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union);
             }
             else
             {
-                FeatureDefinitionFeatureSetExtensions.SetMode(
-                    DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetAbilityScoreChoice, FeatureDefinitionFeatureSet.FeatureSetMode.Exclusion);
+                FeatureSetAbilityScoreChoice.SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Exclusion);
             }
         }
 

--- a/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
+++ b/SolastaCommunityExpansion/Models/AsiAndFeatContext.cs
@@ -23,6 +23,5 @@ namespace SolastaCommunityExpansion.Models
         {
             Switch(Main.Settings.EnablesAsiAndFeat);
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Models/CharacterExportContext.cs
+++ b/SolastaCommunityExpansion/Models/CharacterExportContext.cs
@@ -113,10 +113,10 @@ namespace SolastaCommunityExpansion.Models
 
             heroCharacter.CharacterInventory.EnumerateAllItems(inventoryItems);
 
-            var attunedItems = inventoryItems.Select(i => new { Item = i, Name = i.AttunedToCharacter }).ToList();
+            var attunedItems = inventoryItems.ConvertAll(i => new { Item = i, Name = i.AttunedToCharacter });
             var customItems = inventoryItems.FindAll(i => Gui.GameLocation?.UserCampaign?.UserItems?.Exists(ui => ui.ReferenceItemDefinition == i.ItemDefinition) == true).ToList();
-            var heroItemGuids = heroCharacter.Items.Select(i => new { Item = i, i.Guid }).ToList();
-            var inventoryItemGuids = inventoryItems.Select(i => new { Item = i, i.Guid }).ToList();
+            var heroItemGuids = heroCharacter.Items.ConvertAll(i => new { Item = i, i.Guid });
+            var inventoryItemGuids = inventoryItems.ConvertAll(i => new { Item = i, i.Guid });
 
             try
             {

--- a/SolastaCommunityExpansion/Models/ClassesContext.cs
+++ b/SolastaCommunityExpansion/Models/ClassesContext.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.Classes;
-using SolastaCommunityExpansion.Classes.Tinkerer;
-using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SolastaCommunityExpansion.Classes;
+using SolastaCommunityExpansion.Classes.Tinkerer;
+using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/ConjurationsContext.cs
+++ b/SolastaCommunityExpansion/Models/ConjurationsContext.cs
@@ -160,32 +160,36 @@ namespace SolastaCommunityExpansion.Models
 
             // Helpers
 
-/*            MonsterBuilder GetMonsterBuilder(string name, string title, MonsterDefinition baseMonster)
-            {
-                return new MonsterBuilder(name, CreateGuid(name), title, baseMonster.GuiPresentation.Description, baseMonster);
-            }
+            /*            MonsterBuilder GetMonsterBuilder(string name, string title, MonsterDefinition baseMonster)
+                        {
+                            return new MonsterBuilder(name, CreateGuid(name), title, baseMonster.GuiPresentation.Description, baseMonster);
+                        }
 
-            MonsterAttackIteration CreateAttackIteration(MonsterAttackIteration attackIteration, string namePrefix, int attacks = 2)
-            {
-                // copy existing attack iteration and bump up ToHitBonus and DamageBonus by 1
-                var attackDefinition = CreateAttackDefinition(attackIteration.MonsterAttackDefinition, namePrefix);
+                        MonsterAttackIteration CreateAttackIteration(MonsterAttackIteration attackIteration, string namePrefix, int attacks = 2)
+                        {
+                            // copy existing attack iteration and bump up ToHitBonus and DamageBonus by 1
+                            var attackDefinition = CreateAttackDefinition(attackIteration.MonsterAttackDefinition, namePrefix);
 
-                return new MonsterAttackIteration(attackDefinition, attacks);
-            }
+                            return new MonsterAttackIteration(attackDefinition, attacks);
+                        }
 
-            MonsterAttackDefinition CreateAttackDefinition(MonsterAttackDefinition attackDefinition, string namePrefix)
-            {
-                var name = $"{namePrefix}_{attackDefinition.Name}";
+                        MonsterAttackDefinition CreateAttackDefinition(MonsterAttackDefinition attackDefinition, string namePrefix)
+                        {
+                            var name = $"{namePrefix}_{attackDefinition.Name}";
 
-                var builder = new MonsterAttackDefinitionBuilder(name, CreateGuid(name), attackDefinition);
+                            var builder = new MonsterAttackDefinitionBuilder(name, CreateGuid(name), attackDefinition);
 
-                builder.SetDamageBonusOfFirstDamageForm(4);
-                builder.SetToHitBonus(7);
+                            builder.SetDamageBonusOfFirstDamageForm(4);
+                            builder.SetToHitBonus(7);
 
-                return builder.AddToDB();
-            }
-*/        }
+                            return builder.AddToDB();
+                        }
+            */
+        }
 
-        private static string CreateGuid(string name) => GuidHelper.Create(Namespace, name).ToString("N");
+        private static string CreateGuid(string name)
+        {
+            return GuidHelper.Create(Namespace, name).ToString("N");
+        }
     }
 }

--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace SolastaCommunityExpansion.Models
 {
     internal static class CustomFeaturesContext
-    {   
+    {
         internal static void RecursiveGrantCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features)
         {
             foreach (FeatureDefinition grantedFeature in features)

--- a/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
+++ b/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using TA;
-using UnityEngine;
 using static SolastaModApi.DatabaseHelper.DecisionPackageDefinitions;
 using static SolastaModApi.DatabaseHelper.FactionDefinitions;
 using static SolastaModApi.DatabaseHelper.FormationDefinitions;

--- a/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
+++ b/SolastaCommunityExpansion/Models/EncounterSpawnContext.cs
@@ -106,7 +106,7 @@ namespace SolastaCommunityExpansion.Models
                     "Message/&SpawnCustomEncounterTitle",
                     Gui.Format("Message/&SpawnCustomEncounterDescription", position.x.ToString(), position.x.ToString()),
                     "Message/&MessageYesTitle", "Message/&MessageNoTitle",
-                    new MessageModal.MessageValidatedHandler(() => { StageEncounter(position); }),
+                    new MessageModal.MessageValidatedHandler(() => StageEncounter(position)),
                     null);
             }
         }

--- a/SolastaCommunityExpansion/Models/FaceUnlockContext.cs
+++ b/SolastaCommunityExpansion/Models/FaceUnlockContext.cs
@@ -1,5 +1,5 @@
-﻿using SolastaModApi.Extensions;
-using System.Linq;
+﻿using System.Linq;
+using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.CharacterRaceDefinitions;
 using static SolastaModApi.DatabaseHelper.CharacterSubclassDefinitions;
 using static SolastaModApi.DatabaseHelper.MorphotypeElementDefinitions;

--- a/SolastaCommunityExpansion/Models/FeatsContext.cs
+++ b/SolastaCommunityExpansion/Models/FeatsContext.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.Feats;
-using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using SolastaCommunityExpansion.Feats;
+using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/FightingStyleContext.cs
+++ b/SolastaCommunityExpansion/Models/FightingStyleContext.cs
@@ -1,7 +1,7 @@
-﻿using SolastaCommunityExpansion.FightingStyles;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SolastaCommunityExpansion.FightingStyles;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/FightingStyleContext.cs
+++ b/SolastaCommunityExpansion/Models/FightingStyleContext.cs
@@ -92,4 +92,3 @@ namespace SolastaCommunityExpansion.Models
         }
     }
 }
-

--- a/SolastaCommunityExpansion/Models/FlexibleBackgroundsContext.cs
+++ b/SolastaCommunityExpansion/Models/FlexibleBackgroundsContext.cs
@@ -1,5 +1,5 @@
-﻿using SolastaCommunityExpansion.Builders;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using static SolastaModApi.DatabaseHelper.CharacterBackgroundDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionProficiencys;
 

--- a/SolastaCommunityExpansion/Models/FlexibleRacesContext.cs
+++ b/SolastaCommunityExpansion/Models/FlexibleRacesContext.cs
@@ -1,5 +1,5 @@
-﻿using SolastaCommunityExpansion.Builders;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -201,7 +201,7 @@ namespace SolastaCommunityExpansion.Models
                     "Message/&TeleportPartyTitle",
                     Gui.Format("Message/&TeleportPartyDescription", position.x.ToString(), position.x.ToString()),
                     "Message/&MessageYesTitle", "Message/&MessageNoTitle",
-                    new MessageModal.MessageValidatedHandler(() => { TeleportParty(position); }),
+                    new MessageModal.MessageValidatedHandler(() => TeleportParty(position)),
                     null);
             }
 

--- a/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
+++ b/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
@@ -123,7 +123,6 @@ namespace SolastaCommunityExpansion.Models
 
             BuildFeatureUnlocks(initialFeats, alternateHuman, out FeatureUnlockByLevel featureUnlockByLevelNonHuman, out FeatureUnlockByLevel featureUnlockByLevelHuman);
 
-
             foreach (var characterRaceDefinition in DatabaseRepository.GetDatabase<CharacterRaceDefinition>().GetAllElements())
             {
                 if (!IsSubRace(characterRaceDefinition))

--- a/SolastaCommunityExpansion/Models/InventoryManagementContext.cs
+++ b/SolastaCommunityExpansion/Models/InventoryManagementContext.cs
@@ -123,7 +123,7 @@ namespace SolastaCommunityExpansion.Models
 
             BySortGroup.Inverted = false;
             BySortGroup.Selected = true;
-            BySortGroup.SortRequested = new SortGroup.SortRequestedHandler((sortCategory, inverted) =>
+            BySortGroup.SortRequested = new SortGroup.SortRequestedHandler((_, inverted) =>
             {
                 BySortGroup.Inverted = inverted;
                 BySortGroup.Refresh();

--- a/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemCraftingContext.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.ItemCrafting;
-using SolastaModApi;
-using SolastaModApi.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SolastaCommunityExpansion.ItemCrafting;
+using SolastaModApi;
+using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -42,7 +42,7 @@ namespace SolastaCommunityExpansion.Models
                 return new WandIdentifyBuilder(name, guid, title, description, original).AddToDB();
             }
 
-            internal static readonly ItemDefinition WandIdentify = WandIdentifyBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition WandIdentify = CreateAndAddToDB(
                 "WandIdentify",
                 "46ae7624-4d24-455a-98f9-d41403b0ae19",
                 "Equipment/&WandIdentifyTitle",
@@ -87,7 +87,7 @@ namespace SolastaCommunityExpansion.Models
                 return new FocusDefinitionBuilder(name, guid, title, description, original, type, assetReferenceSprite).AddToDB();
             }
 
-            internal static readonly ItemDefinition ArcaneStaff = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition ArcaneStaff = CreateAndAddToDB(
                 "ArcaneStaff",
                 "991e1fec-9777-4635-948f-5bedcb96147d",
                 "Equipment/&ArcaneStaffTitle",
@@ -96,7 +96,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 QuarterstaffPlus1.GuiPresentation.SpriteReference);
 
-            internal static readonly ItemDefinition DruidicAmulet = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition DruidicAmulet = CreateAndAddToDB(
                 "DruidicAmulet",
                 "3487d3b2-1058-4c0f-8009-9e4f525cb0e0",
                 "Equipment/&DruidicAmuletTitle",
@@ -105,7 +105,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 BeltOfGiantHillStrength.GuiPresentation.SpriteReference);
 
-            internal static readonly ItemDefinition LivewoodClub = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition LivewoodClub = CreateAndAddToDB(
                 "LivewoodClub",
                 "dd27119b-01e0-4a47-a043-98b89dc930a1",
                 "Equipment/&LivewoodClubTitle",
@@ -114,7 +114,7 @@ namespace SolastaCommunityExpansion.Models
                 EquipmentDefinitions.FocusType.Druidic,
                 null);
 
-            internal static readonly ItemDefinition LivewoodStaff = FocusDefinitionBuilder.CreateAndAddToDB(
+            internal static readonly ItemDefinition LivewoodStaff = CreateAndAddToDB(
                 "LivewoodStaff",
                 "ff3ec29c-734f-4ef6-8d6e-ceb961d9a8a0",
                 "Equipment/&LivewoodStaffTitle",
@@ -280,7 +280,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockAntiquarian()
         {
-            foreach (var stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_Antiquarians_Halman_Summer.StockUnitDescriptions.Where(
+            foreach (var stock in Store_Merchant_Antiquarians_Halman_Summer.StockUnitDescriptions.Where(
                 x => !x.ItemDefinition.Name.Contains("Manual") && !x.ItemDefinition.Name.Contains("Tome")))
             {
                 stock.SetReassortAmount(Main.Settings.RestockAntiquarians ? 1 : 0);
@@ -290,7 +290,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockArcaneum()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_Arcaneum_Heddlon_Surespell.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_Arcaneum_Heddlon_Surespell.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockArcaneum ? 1 : 0);
             }
@@ -298,7 +298,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockCircleOfDanantar()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_CircleOfDanantar_Joriel_Foxeye.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_CircleOfDanantar_Joriel_Foxeye.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockCircleOfDanantar ? 1 : 0);
             }
@@ -306,7 +306,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void SwitchRestockTowerOfKnowledge()
         {
-            foreach (StockUnitDescription stock in DatabaseHelper.MerchantDefinitions.Store_Merchant_TowerOfKnowledge_Maddy_Greenisle.StockUnitDescriptions)
+            foreach (StockUnitDescription stock in Store_Merchant_TowerOfKnowledge_Maddy_Greenisle.StockUnitDescriptions)
             {
                 stock.SetReassortAmount(Main.Settings.RestockTowerOfKnowledge ? 1 : 0);
             }

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -37,8 +37,10 @@ namespace SolastaCommunityExpansion.Models
                 Store_Merchant_Hugo_Requer_Cyflen_Potions.StockUnitDescriptions.Add(stockFocus);
             }
 
-            private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original) =>
-                new WandIdentifyBuilder(name, guid, title, description, original).AddToDB();
+            private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original)
+            {
+                return new WandIdentifyBuilder(name, guid, title, description, original).AddToDB();
+            }
 
             internal static readonly ItemDefinition WandIdentify = WandIdentifyBuilder.CreateAndAddToDB(
                 "WandIdentify",
@@ -80,8 +82,10 @@ namespace SolastaCommunityExpansion.Models
                 Store_Merchant_Hugo_Requer_Cyflen_Potions.StockUnitDescriptions.Add(stockFocus);
             }
 
-            private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original, EquipmentDefinitions.FocusType type, AssetReferenceSprite assetReferenceSprite) =>
-                new FocusDefinitionBuilder(name, guid, title, description, original, type, assetReferenceSprite).AddToDB();
+            private static ItemDefinition CreateAndAddToDB(string name, string guid, string title, string description, ItemDefinition original, EquipmentDefinitions.FocusType type, AssetReferenceSprite assetReferenceSprite)
+            {
+                return new FocusDefinitionBuilder(name, guid, title, description, original, type, assetReferenceSprite).AddToDB();
+            }
 
             internal static readonly ItemDefinition ArcaneStaff = FocusDefinitionBuilder.CreateAndAddToDB(
                 "ArcaneStaff",

--- a/SolastaCommunityExpansion/Models/PickPocketContext.cs
+++ b/SolastaCommunityExpansion/Models/PickPocketContext.cs
@@ -1,8 +1,7 @@
-﻿
+﻿using System.Collections.Generic;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
 using static RuleDefinitions;
 using static SolastaModApi.DatabaseHelper.LootPackDefinitions;
 

--- a/SolastaCommunityExpansion/Models/PlayerControllerContext.cs
+++ b/SolastaCommunityExpansion/Models/PlayerControllerContext.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static bool IsOffGame => Gui.Game == null;
 
-        internal static List<GameLocationCharacter> PlayerCharacters { get; private set; } = new List<GameLocationCharacter>();
+        internal static List<GameLocationCharacter> PlayerCharacters { get; } = new List<GameLocationCharacter>();
 
         internal static int[] PlayerCharactersChoices
         {

--- a/SolastaCommunityExpansion/Models/PowersContext.cs
+++ b/SolastaCommunityExpansion/Models/PowersContext.cs
@@ -1,9 +1,9 @@
-﻿using SolastaModApi;
-using SolastaModApi.Extensions;
-using SolastaCommunityExpansion.Features;
-using System;
+﻿using System;
 using System.Linq;
 using SolastaCommunityExpansion.Builders;
+using SolastaCommunityExpansion.Features;
+using SolastaModApi;
+using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
+++ b/SolastaCommunityExpansion/Models/RemoveBugVisualModelsContext.cs
@@ -11,7 +11,6 @@ namespace SolastaCommunityExpansion.Models
         {
             if (Main.Settings.RemoveBugVisualModels)
             {
-
                 // Spiderlings, fire spider, kindred spirit spider, BadlandsSpider(normal, conjured and wildshaped versions)
                 const string assetReference_spider_1 = "362fc51df586d254ab182ef854396f82";
                 //CrimsonSpiderling, PhaseSpider, SpectralSpider, CrimsonSpider, deep spider(normal, conjured and wildshaped versions)
@@ -47,9 +46,7 @@ namespace SolastaCommunityExpansion.Models
                 MonsterDefinition ape = DatabaseHelper.MonsterDefinitions.Ape_MonsterDefinition;
                 AssetReference apePrefab = new AssetReference("8f4589a9a294b444785fab045256a713");
 
-
                 MonsterDefinition[] listofAllMonsters = DatabaseRepository.GetDatabase<MonsterDefinition>().GetAllElements();
-
 
                 // check every monster for targeted prefab guid references
                 foreach (MonsterDefinition monster in listofAllMonsters)

--- a/SolastaCommunityExpansion/Models/RespecContext.cs
+++ b/SolastaCommunityExpansion/Models/RespecContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using HarmonyLib;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
@@ -29,7 +28,9 @@ namespace SolastaCommunityExpansion.Models
             }
 
             private static RestActivityDefinition CreateAndAddToDB(string name, string guid)
-                => new RestActivityRespecBuilder(name, guid).AddToDB();
+            {
+                return new RestActivityRespecBuilder(name, guid).AddToDB();
+            }
 
             public static readonly RestActivityDefinition RestActivityRespec
                 = CreateAndAddToDB(RespecName, RespecGuid);
@@ -50,11 +51,20 @@ namespace SolastaCommunityExpansion.Models
 
             internal static bool IsRespecing => RespecState == RESPEC_STATE_RESPECING;
 
-            internal static void AbortRespec() => RespecState = RESPEC_STATE_ABORTED;
+            internal static void AbortRespec()
+            {
+                RespecState = RESPEC_STATE_ABORTED;
+            }
 
-            internal static void StartRespec() => RespecState = RESPEC_STATE_RESPECING;
+            internal static void StartRespec()
+            {
+                RespecState = RESPEC_STATE_RESPECING;
+            }
 
-            internal static void StopRespec() => RespecState = RESPEC_STATE_NORESPEC;
+            internal static void StopRespec()
+            {
+                RespecState = RESPEC_STATE_NORESPEC;
+            }
 
             private static readonly List<RulesetItemSpellbook> rulesetItemSpellbooks = new List<RulesetItemSpellbook>();
 

--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -1,9 +1,9 @@
-﻿using ModKit;
-using SolastaCommunityExpansion.Spells;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using ModKit;
+using SolastaCommunityExpansion.Spells;
 
 namespace SolastaCommunityExpansion.Models
 {
@@ -256,11 +256,20 @@ namespace SolastaCommunityExpansion.Models
             SwitchSpellList(spellDefinition);
         }
 
-        internal static bool AreAllSpellListsSelected() => RegisteredSpellsList.All(x => AreAllSpellListsSelected(x));
+        internal static bool AreAllSpellListsSelected()
+        {
+            return RegisteredSpellsList.All(x => AreAllSpellListsSelected(x));
+        }
 
-        internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition) => Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellsContext.SpellLists.Count;
+        internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition)
+        {
+            return Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellsContext.SpellLists.Count;
+        }
 
-        internal static bool AreMinimumSpellListsSelected() => RegisteredSpellsList.All(x => AreMinimumSpellListsSelected(x));
+        internal static bool AreMinimumSpellListsSelected()
+        {
+            return RegisteredSpellsList.All(x => AreMinimumSpellListsSelected(x));
+        }
 
         internal static bool AreMinimumSpellListsSelected(SpellDefinition spellDefinition)
         {
@@ -275,7 +284,10 @@ namespace SolastaCommunityExpansion.Models
             return minimumSpellLists.All(x => selectedSpellLists.Contains(x));
         }
 
-        internal static bool AreSuggestedSpellListsSelected() => RegisteredSpellsList.All(x => AreSuggestedSpellListsSelected(x));
+        internal static bool AreSuggestedSpellListsSelected()
+        {
+            return RegisteredSpellsList.All(x => AreSuggestedSpellListsSelected(x));
+        }
 
         internal static bool AreSuggestedSpellListsSelected(SpellDefinition spellDefinition)
         {

--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -256,11 +256,11 @@ namespace SolastaCommunityExpansion.Models
             SwitchSpellList(spellDefinition);
         }
 
-        internal static bool AreAllSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreAllSpellListsSelected(x));
+        internal static bool AreAllSpellListsSelected() => RegisteredSpellsList.All(x => AreAllSpellListsSelected(x));
 
         internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition) => Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellsContext.SpellLists.Count;
 
-        internal static bool AreMinimumSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreMinimumSpellListsSelected(x));
+        internal static bool AreMinimumSpellListsSelected() => RegisteredSpellsList.All(x => AreMinimumSpellListsSelected(x));
 
         internal static bool AreMinimumSpellListsSelected(SpellDefinition spellDefinition)
         {
@@ -272,10 +272,10 @@ namespace SolastaCommunityExpansion.Models
                 return false;
             }
 
-            return !minimumSpellLists.Any(x => !selectedSpellLists.Contains(x));
+            return minimumSpellLists.All(x => selectedSpellLists.Contains(x));
         }
 
-        internal static bool AreSuggestedSpellListsSelected() => !RegisteredSpellsList.Any(x => !AreSuggestedSpellListsSelected(x));
+        internal static bool AreSuggestedSpellListsSelected() => RegisteredSpellsList.All(x => AreSuggestedSpellListsSelected(x));
 
         internal static bool AreSuggestedSpellListsSelected(SpellDefinition spellDefinition)
         {
@@ -287,7 +287,7 @@ namespace SolastaCommunityExpansion.Models
                 return false;
             }
 
-            return !suggestedSpellLists.Any(x => !selectedSpellLists.Contains(x));
+            return suggestedSpellLists.All(x => selectedSpellLists.Contains(x));
         }
 
         public static string GenerateSpellsDescription()

--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -263,7 +263,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static bool AreAllSpellListsSelected(SpellDefinition spellDefinition)
         {
-            return Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellsContext.SpellLists.Count;
+            return Main.Settings.SpellSpellListEnabled[spellDefinition.Name].Count == SpellLists.Count;
         }
 
         internal static bool AreMinimumSpellListsSelected()

--- a/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaCommunityExpansion/Models/SrdAndHouseRulesContext.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using SolastaModApi.Extensions;
-using System.Collections.Generic;
 using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
 

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -129,5 +129,4 @@ namespace SolastaCommunityExpansion.Models
             return outString.ToString();
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Models/SubclassesContext.cs
+++ b/SolastaCommunityExpansion/Models/SubclassesContext.cs
@@ -1,13 +1,13 @@
-﻿using SolastaCommunityExpansion.Subclasses;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SolastaCommunityExpansion.Subclasses;
 using SolastaCommunityExpansion.Subclasses.Barbarian;
 using SolastaCommunityExpansion.Subclasses.Druid;
 using SolastaCommunityExpansion.Subclasses.Fighter;
 using SolastaCommunityExpansion.Subclasses.Ranger;
 using SolastaCommunityExpansion.Subclasses.Rogue;
 using SolastaCommunityExpansion.Subclasses.Wizard;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace SolastaCommunityExpansion.Models
 {

--- a/SolastaCommunityExpansion/Models/TelemaCampaignContext.cs
+++ b/SolastaCommunityExpansion/Models/TelemaCampaignContext.cs
@@ -19,7 +19,9 @@ namespace SolastaCommunityExpansion.Models
             }
 
             public static CampaignDefinition CreateAndAddToDB(string name, string guid)
-                => new TelemaCampaignUnleashedBuilder(name, guid).AddToDB();
+            {
+                return new TelemaCampaignUnleashedBuilder(name, guid).AddToDB();
+            }
 
             public static readonly CampaignDefinition TelemaDemoUnleashed = CreateAndAddToDB(TelemaDemoUnleashedName, TelemaDemoUnleashedGuid);
         }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CharacterBuildingManagerPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using HarmonyLib;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationBattleManagerPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaCommunityExpansion.Helpers;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationCharacterPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetActorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetActorPatcher.cs
@@ -55,7 +55,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
     internal static class RulesetActor_InflictCondition
     {
-
         internal static void Prefix(string conditionDefinitionName,
             ref int sourceAmount)
         {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -32,7 +32,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
             ritualSpells.AddRange(spellRepertoire.AutoPreparedSpells
                 .Where(s => s.Ritual)
                 .Where(s => spellRepertoire.MaxSpellLevelOfSpellCastingLevel >= s.SpellLevel));
-
         }
     }
 
@@ -107,7 +106,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
             {
                 Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
             }
-
         }
     }
 

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -104,7 +104,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
         {
             foreach (FeatDefinition feat in feats)
             {
-                Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
+                CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -134,8 +134,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
             hero.EnumerateFeaturesToBrowse<FeatureDefinitionPower>(hero.FeaturesToBrowse, null);
             foreach (FeatureDefinitionPower featureDefinitionPower in hero.FeaturesToBrowse.Cast<FeatureDefinitionPower>())
             {
-                if (featureDefinitionPower is IConditionalPower &&
-                    !(featureDefinitionPower as IConditionalPower).IsActive(hero))
+                if ((featureDefinitionPower as IConditionalPower)?.IsActive(hero) == false)
                 {
                     continue;
                 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -139,7 +139,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
                 {
                     continue;
                 }
-                RulesetUsablePower rulesetUsablePower = hero.UsablePowers.FirstOrDefault(up => up.PowerDefinition == featureDefinitionPower);
+                RulesetUsablePower rulesetUsablePower = hero.UsablePowers.Find(up => up.PowerDefinition == featureDefinitionPower);
                 if (rulesetUsablePower != null)
                 {
                     // If we found a power that was already on the character, re-add the same instance.
@@ -231,7 +231,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
                 }
             }
 
-            return (null, null, hero.TrainedFeats.FirstOrDefault(tf => tf.Features.Contains(featureDefinition)));
+            return (null, null, hero.TrainedFeats.Find(tf => tf.Features.Contains(featureDefinition)));
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
@@ -66,7 +66,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
             int? modifiedMinRoll = RulesetCharacter_ResolveContestCheck.MinimumStrengthAbilityCheckDieRoll(__instance, baseBonus, rollModifier, proficiencyName);
 
-            if (modifiedMinRoll.HasValue && modifiedMinRoll.Value > minRoll)
+            if (modifiedMinRoll > minRoll)
             {
                 minRoll = modifiedMinRoll.Value;
             }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
@@ -170,7 +170,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
     {
         public static void Postfix(RulesetCharacter __instance)
         {
-            Models.CustomFeaturesContext.RechargeLinkedPowers(__instance, RuleDefinitions.RestType.LongRest);
+            CustomFeaturesContext.RechargeLinkedPowers(__instance, RuleDefinitions.RestType.LongRest);
         }
     }
 
@@ -183,7 +183,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
         {
             if (!simulate)
             {
-                Models.CustomFeaturesContext.RechargeLinkedPowers(__instance, restType);
+                CustomFeaturesContext.RechargeLinkedPowers(__instance, restType);
             }
 
             // The player isn't recharging the shared pool features, just the pool.

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
@@ -1,8 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using System.Collections.Generic;
-using System.Linq;
 using SolastaCommunityExpansion.Models;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetCharacterPatcher.cs
@@ -140,8 +140,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
             return featuresToBrowse
                 .OfType<IMinimumAbilityCheckTotal>()
-                .Select(feature => feature.MinimumStrengthAbilityCheckTotal(character, proficiencyName))
-                .Max();
+                .Max(feature => feature.MinimumStrengthAbilityCheckTotal(character, proficiencyName));
         }
     }
 

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using SolastaCommunityExpansion.Helpers;
-using HarmonyLib;
 using System.Linq;
+using HarmonyLib;
+using SolastaCommunityExpansion.Helpers;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
 
     internal static class RulesetImplementationManagerLocation_ApplySummonForm
     {
-        internal static Dictionary<string, int> ConditionToAmount { get; private set; } = new Dictionary<string, int>();
+        internal static Dictionary<string, int> ConditionToAmount { get; } = new Dictionary<string, int>();
 
         internal static void Prefix(
             EffectForm effectForm,

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RulesetImplementationManagerLocationPatcher.cs
@@ -56,7 +56,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
                                             ConditionToAmount.AddOrReplace(addedCondition.Name, sourceAmount);
                                         }
                                         break;
-
                                 }
                             }
                         }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/SpellsByLevelGroupPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/SpellsByLevelGroupPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures
 {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/CursorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/CursorPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaModApi.Infrastructure;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/DatabaseSelectionModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/DatabaseSelectionModalPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserCampaignPoolManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserCampaignPoolManagerPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationEditorScreenPatcher.cs
@@ -64,16 +64,16 @@ namespace SolastaCommunityExpansion.Patches.DungeonMaker
                     Main.Log($"room orientation before ({ur.Orientation}, {ur.OrientedWidth}, {ur.OrientedHeight})");
                     Main.Log($"current room position ({ur.Position.x}, {ur.Position.y})");
 
-                    var currentRoomCenter = new Vector3(ur.Position.x + ur.OrientedWidth / 2f, ur.Position.y + ur.OrientedHeight / 2f);
+                    var currentRoomCenter = new Vector3(ur.Position.x + (ur.OrientedWidth / 2f), ur.Position.y + (ur.OrientedHeight / 2f));
                     Main.Log($"current room center ({currentRoomCenter.x}, {currentRoomCenter.y})");
 
-                    var newRoomCenter = rotation * (currentRoomCenter - dungeonCenter) + dungeonCenter;
+                    var newRoomCenter = (rotation * (currentRoomCenter - dungeonCenter)) + dungeonCenter;
                     Main.Log($"new room center ({newRoomCenter.x}, {newRoomCenter.y})");
 
                     ur.Rotate(rotationAngle);
                     Main.Log($"room orientation after {ur.Orientation}, {ur.OrientedWidth}, {ur.OrientedHeight}");
 
-                    ur.Position = new Vector2Int(Mathf.RoundToInt(newRoomCenter.x - ur.OrientedWidth / 2f), Mathf.RoundToInt(newRoomCenter.y - ur.OrientedHeight / 2f));
+                    ur.Position = new Vector2Int(Mathf.RoundToInt(newRoomCenter.x - (ur.OrientedWidth / 2f)), Mathf.RoundToInt(newRoomCenter.y - (ur.OrientedHeight / 2f)));
                     Main.Log($"new room position ({ur.Position.x}, {ur.Position.y})");
                 }
 

--- a/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationPoolManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/DungeonMaker/UserLocationPoolManagerPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.DungeonMaker
 {

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -45,7 +45,7 @@ namespace SolastaCommunityExpansion.Patches
             // Subclasses may rely on classes being loaded (as well as spells and powers) in order to properly refer back to the class.
             SubclassesContext.Load();
 
-            ServiceRepository.GetService<IRuntimeService>().RuntimeLoaded += (runtime) =>
+            ServiceRepository.GetService<IRuntimeService>().RuntimeLoaded += (_) =>
             {
                 FlexibleRacesContext.Switch();
                 InitialChoicesContext.RefreshFirstLevelTotalFeats();

--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.Models;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SolastaCommunityExpansion.Patches
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/DocumentModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/DocumentModalPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GameLocationBanterManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GameLocationBanterManagerPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GameLocationLabelScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GameLocationLabelScreenPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GamePartyStatusScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GamePartyStatusScreenPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GuiAdventureLinePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/GuiAdventureLinePatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog

--- a/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/PosterScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/AdventureLog/PosterScreenPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.AdventureLog
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/CharacterEditionScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/CharacterEditionScreenPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.CharactersPool
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/CharactersPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/CharactersPanelPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using UnityEngine.UI;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.CharactersPool

--- a/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/GuiPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharactersPool/GuiPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.CharactersPool
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageDeitySelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageDeitySelectionPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageRaceSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageRaceSelectionPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageSubclassSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageSubclassSelectionPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
@@ -10,10 +10,9 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
     /// <summary>
     /// Currently when a character is teleported off screen the camera doesn't follow.
     /// This patch will attempt to follow the character if initiated by a teleport game gadget
-    /// The don't follow character in battle patch will interact with this patch to cancel 
+    /// The don't follow character in battle patch will interact with this patch to cancel
     /// following if we're in battle and the character is on screen.
     /// </summary>
-
     [HarmonyPatch(typeof(FunctorTeleport), "Execute")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class FunctorTeleport_Execute

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/FunctorTeleportPatcher.cs
@@ -1,9 +1,8 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.Location
 {

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/PowerSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/PowerSelectionPanelPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaModApi.Infrastructure;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using HarmonyLib;
+using SolastaModApi.Infrastructure;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
@@ -168,8 +168,9 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
 
                 if (spellRepertoire.SpellCastingFeature.SpellReadyness == RuleDefinitions.SpellReadyness.Prepared &&
                     spellRepertoire.PreparedSpells
-                        .Where(spellDefinition => spellDefinition.SpellLevel == level)
-                        .Any(spellDefinition => spellDefinition.ActivationTime == spellActivationTime))
+                        .Any(spellDefinition =>
+                            spellDefinition.SpellLevel == level
+                            && spellDefinition.ActivationTime == spellActivationTime))
                 {
                     return true;
                 }

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/SpellSelectionPanelPatcher.cs
@@ -72,7 +72,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                                 spellLevelsOnLine = 0;
                                 needNewLine = true;
                                 indexOfLine = 0;
-
                             }
                         }
                     }
@@ -152,7 +151,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                     case ActionDefinitions.ActionType.NoCost:
                         spellActivationTime = RuleDefinitions.ActivationTime.NoCost;
                         break;
-
                 }
 
                 if (level == 0)

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/ViewPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/ViewPatcher.cs
@@ -10,12 +10,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
     {
         internal static bool Prefix()
         {
-            if (ModManagerUI.IsOpen)
-            {
-                return false;
-            }
-
-            return true;
+            return !ModManagerUI.IsOpen;
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/GameUi/Monsters/GuiCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Monsters/GuiCharacterPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using SolastaCommunityExpansion.Models;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using HarmonyLib;
+using SolastaCommunityExpansion.Models;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/SolastaCommunityExpansion/Patches/GameUi/Monsters/HealthGaugeGroupPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Monsters/HealthGaugeGroupPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using SolastaCommunityExpansion.Models;
-using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.Monsters

--- a/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameGadgetPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameGadgetPatcher.cs
@@ -13,8 +13,6 @@ namespace SolastaCommunityExpansion.Patches.GameUi.ScreenMap
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class GameGadget_ComputeIsRevealed
     {
-
-
         internal static void Postfix(GameGadget __instance, ref bool ___revealed, ref bool __result)
         {
             if (!__instance.Revealed || Gui.GameLocation.UserLocation == null || !Main.Settings.EnableAdditionalIconsOnLevelMap)

--- a/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameLocationScreenMapPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/GameLocationScreenMapPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using SolastaCommunityExpansion.Helpers;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.Helpers;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.ScreenMap

--- a/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/MapGadgetItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/ScreenMap/MapGadgetItemPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
+using HarmonyLib;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.ScreenMap

--- a/SolastaCommunityExpansion/Patches/GameUi/Tooltip/TooltipPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Tooltip/TooltipPanelPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.Tooltip
 {

--- a/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/ArchetypesPreviewModalPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/CharactersPanelPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/HigherLevelFeaturesModalPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetCharacterHeroPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/Level20/RulesetSpellRepertoirePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/RulesetSpellRepertoirePatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.Level20
 {

--- a/SolastaCommunityExpansion/Patches/Level20/UserCampaignEditorScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/UserCampaignEditorScreenPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Level20/UserLocationSettingsModalPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.Level20Context;
 
 namespace SolastaCommunityExpansion.Patches.Level20

--- a/SolastaCommunityExpansion/Patches/PartySize/GameLocationPositioningManagerPatch.cs
+++ b/SolastaCommunityExpansion/Patches/PartySize/GameLocationPositioningManagerPatch.cs
@@ -1,9 +1,9 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.PartySize
 {

--- a/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Respec/RulesetCharacterHeroPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.Respec
 {

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.SaveByLocation
 {

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/GameSerializationManagerPatcher.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Patches.SaveByLocation
 
             // Enable/disable the 'load' button in the load save panel
 
-            __result = !___saving && !___loading && ___loadDisabledTokens.Count <= 0;
+            __result = !___saving && !___loading && ___loadDisabledTokens.Count == 0;
 
             return false;
         }

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/LoadPanelPatcher.cs
@@ -1,10 +1,10 @@
-﻿using HarmonyLib;
-using ModKit;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using HarmonyLib;
+using ModKit;
 using UnityEngine;
 using UnityEngine.UI;
 using static GuiDropdown;

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/MainMenuScreenPatcher.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.SaveByLocationContext;
 
 namespace SolastaCommunityExpansion.Patches.SaveByLocation

--- a/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SaveByLocation/TacticalAdventuresApplicationPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 using static SolastaCommunityExpansion.Models.SaveByLocationContext;
 
 namespace SolastaCommunityExpansion.Patches.SaveByLocation

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/ActiveCharacterPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/ActiveCharacterPanelPatcher.cs
@@ -26,7 +26,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             var spell = __instance.GuiCharacter.RulesetCharacterHero?.ConcentratedSpell;
             if (spell == null)
             {
-                Main.Log($"ActiveCharacterPanel_OnStopConcentratingCb: No spell.");
+                Main.Log("ActiveCharacterPanel_OnStopConcentratingCb: No spell.");
                 return;
             }
 

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
@@ -15,8 +15,6 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
         }
         */
 
-    /// <summary>
-    /// </summary>
     [HarmonyPatch(typeof(EquipmentDefinitions), "ScaleAndRoundCosts")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class EquipmentDefinitions_ScaleAndRoundCosts

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
@@ -28,10 +28,10 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 
             // convert to copper
             int cp =
-                1000 * baseCosts[0] + // platinum
-                100 * baseCosts[1] + // gold
-                50 * baseCosts[2] + // electrum?
-                10 * baseCosts[3] + // silver
+                (1000 * baseCosts[0]) + // platinum
+                (100 * baseCosts[1]) + // gold
+                (50 * baseCosts[2]) + // electrum?
+                (10 * baseCosts[3]) + // silver
                 baseCosts[4]; // copper
 
             // scale
@@ -54,7 +54,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             else
             {
                 // else keep 2 sig fig
-                scaledGold = SignificantDigits.Round(scaledGold, 2);
+                scaledGold = scaledGold.Round(2);
             }
 
             // convert back to cp
@@ -64,8 +64,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             scaledCosts[4] = scaledAndRoundedCopper % 10;
             scaledCosts[3] = (scaledAndRoundedCopper - scaledCosts[4]) / 10 % 10;
             // scaledCosts[2] always zero?
-            scaledCosts[1] = (scaledAndRoundedCopper - scaledCosts[3] * 10 - scaledCosts[4]) / 100 % 10;
-            scaledCosts[0] = (scaledAndRoundedCopper - scaledCosts[1] * 100 - scaledCosts[3] * 10 - scaledCosts[4]) / 1000;
+            scaledCosts[1] = (scaledAndRoundedCopper - (scaledCosts[3] * 10) - scaledCosts[4]) / 100 % 10;
+            scaledCosts[0] = (scaledAndRoundedCopper - (scaledCosts[1] * 100) - (scaledCosts[3] * 10) - scaledCosts[4]) / 1000;
 
             // only show platinum if baseCosts had platinum
             if (baseCosts[0] == 0)

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/EquipmentDefinitionsPatcher.cs
@@ -1,6 +1,6 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 {

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/GameLocationBattlePatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/GameLocationBattlePatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 {

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RuleDefinitionsPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RuleDefinitionsPatcher.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using HarmonyLib;
 using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/RulesetCharacterPatcher.cs
@@ -106,7 +106,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
 
             if (itemToUse == null)
             {
-                Main.Log($"Didn't find item.");
+                Main.Log("Didn't find item.");
 
                 return false;
             }
@@ -133,7 +133,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
             }
             else
             {
-                Main.Log($"Destroy item");
+                Main.Log("Destroy item");
 
                 __instance.CharacterInventory.DestroyItem(rulesetItem);
             }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
@@ -42,8 +42,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
         public static bool Prefix(SubspellSelectionModal __instance, int index, int ___slotLevel,
             RulesetSpellRepertoire ___spellRepertoire, SpellsByLevelBox.SpellCastEngagedHandler ___spellCastEngaged)
         {
-            if (!Main.Settings.EnableUpcastConjureElementalAndFey
-               || !SpellDefinition_SubspellsList.FilteredSubspells.Any())
+            if (!Main.Settings.EnableUpcastConjureElementalAndFey ||
+                SpellDefinition_SubspellsList.FilteredSubspells.Count == 0)
             {
                 return true;
             }

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SubspellSelectionModalPatcher.cs
@@ -112,8 +112,8 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules
                     ChallengeRating = g.Key,
                     SpellDefinitions = g.Select(s => s.SpellDefinition).OrderBy(s => Gui.Format(s.GuiPresentation.Title))
                 })
-                .OrderByDescending(s => s.ChallengeRating)
                 .Where(s => s.ChallengeRating <= FilterBySlotLevel.Value)
+                .OrderByDescending(s => s.ChallengeRating)
                 .ToList();
 
             var allOrMostPowerful = Main.Settings.OnlyShowMostPowerfulUpcastConjuredElementalOrFey

--- a/SolastaCommunityExpansion/Patches/Tools/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Tools/RulesetCharacterHeroPatcher.cs
@@ -1,5 +1,5 @@
-﻿using HarmonyLib;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
 
 namespace SolastaCommunityExpansion.Patches.Tools
 {

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -9,7 +9,6 @@ namespace SolastaCommunityExpansion
 {
     public class Core
     {
-
     }
 
     [Serializable]
@@ -164,7 +163,6 @@ namespace SolastaCommunityExpansion
         public bool FullyControlConjurations { get; set; }
         public bool DismissControlledConjurationsWhenDeliberatelyDropConcentration { get; set; }
         public bool OnlyShowMostPowerfulUpcastConjuredElementalOrFey { get; set; }
-
 
         // House
         public bool AllowAnyClassToWearSylvanArmor { get; set; }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -108,9 +108,9 @@ namespace SolastaCommunityExpansion
         public int OverrideRogueConArtistImprovedManipulationSpellDc { get; set; } = 3;
         public int OverrideWizardMasterManipulatorArcaneManipulationSpellDc { get; set; } = 2;
         public int ClassSliderPosition { get; set; } = 1;
-        public List<string> ClassEnabled { get; private set; } = new List<string>();
+        public List<string> ClassEnabled { get; } = new List<string>();
         public int SubclassSliderPosition { get; set; } = 1;
-        public List<string> SubclassEnabled { get; private set; } = new List<string>();
+        public List<string> SubclassEnabled { get; } = new List<string>();
 
         //
         // Characters - Feats
@@ -118,20 +118,20 @@ namespace SolastaCommunityExpansion
 
         public int FeatPowerAttackModifier { get; set; } = 3;
         public int FeatSliderPosition { get; set; } = 1;
-        public List<string> FeatEnabled { get; private set; } = new List<string>();
+        public List<string> FeatEnabled { get; } = new List<string>();
 
         //
         // Characters - Fighting Styles
         //
 
         public int FightingStyleSliderPosition { get; set; } = 1;
-        public List<string> FightingStyleEnabled { get; private set; } = new List<string>();
+        public List<string> FightingStyleEnabled { get; } = new List<string>();
 
         //
         // Characters - Powers
         //
 
-        public List<string> PowerEnabled { get; private set; } = new List<string>();
+        public List<string> PowerEnabled { get; } = new List<string>();
 
         //
         // Characters - Spells
@@ -201,9 +201,9 @@ namespace SolastaCommunityExpansion
         public int SetBeltOfDwarvenKindBeardChances { get; set; } = 50;
 
         // Crafting
-        public List<string> CraftingInStore { get; private set; } = new List<string>();
-        public List<string> CraftingItemsInDM { get; private set; } = new List<string>();
-        public List<string> CraftingRecipesInDM { get; private set; } = new List<string>();
+        public List<string> CraftingInStore { get; } = new List<string>();
+        public List<string> CraftingItemsInDM { get; } = new List<string>();
+        public List<string> CraftingRecipesInDM { get; } = new List<string>();
 
         // Merchants
         public bool StockGorimStoreWithAllNonMagicalClothing { get; set; }

--- a/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
+++ b/SolastaCommunityExpansion/SolastaCommunityExpansion.csproj
@@ -45,22 +45,22 @@
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <WarningLevel>5</WarningLevel>
-	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 	  <WarningLevel>5</WarningLevel>
-	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Install|AnyCPU'">
 	  <WarningLevel>5</WarningLevel>
-	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Install|AnyCPU'">
 	  <WarningLevel>5</WarningLevel>
-	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SolastaCommunityExpansion/Spells/BazouSpells.cs
+++ b/SolastaCommunityExpansion/Spells/BazouSpells.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using SolastaModApi;
-using SolastaModApi.Extensions;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Features;
 using SolastaCommunityExpansion.Models;
-using SolastaCommunityExpansion.Builders;
+using SolastaModApi;
+using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Spells
 {

--- a/SolastaCommunityExpansion/Spells/BazouSpells.cs
+++ b/SolastaCommunityExpansion/Spells/BazouSpells.cs
@@ -96,7 +96,6 @@ namespace SolastaCommunityExpansion.Spells
             //            spell.EffectDescription.EffectForms.Add(effectForm);
 
             return spell;
-
         }
 
         private static SpellDefinition BuildFindFamiliar()

--- a/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
+++ b/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
@@ -1,5 +1,5 @@
-﻿using static SolastaModApi.DatabaseHelper.SpellDefinitions;
-using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
+﻿using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
+using static SolastaModApi.DatabaseHelper.SpellDefinitions;
 
 namespace SolastaCommunityExpansion.Spells
 {

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -918,7 +918,7 @@ namespace SolastaCommunityExpansion.Spells
                 DatabaseHelper.SmartAttributeDefinitions.Intelligence.name,
                 20,
                 false,
-                new List<SaveAffinityBySenseDescription> { }
+                new List<SaveAffinityBySenseDescription>()
                 )
             .AddEffectForm(new EffectFormBuilder()
                 .SetConditionForm(

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
+using SolastaCommunityExpansion.Features;
 using SolastaCommunityExpansion.Models;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
-using SolastaCommunityExpansion.Features;
 using UnityEngine.AddressableAssets;
-using SolastaCommunityExpansion.Builders;
 
 namespace SolastaCommunityExpansion.Spells
 {
@@ -224,9 +224,15 @@ namespace SolastaCommunityExpansion.Spells
 
         private const string DhBaseString = "DH";
 
-        private static string GetSpellTitleTerm(string text) => $"Spell/&{DhBaseString}{text}Title";
+        private static string GetSpellTitleTerm(string text)
+        {
+            return $"Spell/&{DhBaseString}{text}Title";
+        }
 
-        private static string GetSpellDescriptionTerm(string text) => $"Spell/&{DhBaseString}{text}Description";
+        private static string GetSpellDescriptionTerm(string text)
+        {
+            return $"Spell/&{DhBaseString}{text}Description";
+        }
 
         private static SpellDefinition BuildFingerOfDeath()
         {
@@ -449,7 +455,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new ReverseGravityConditionBuilder(name, guid).AddToDB();
+            {
+                return new ReverseGravityConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition ReverseGravityCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -985,7 +993,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             internal static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new FeeblemindConditionBuilder(name, guid).AddToDB();
+            {
+                return new FeeblemindConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition FeeblemindCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -1008,7 +1018,9 @@ namespace SolastaCommunityExpansion.Spells
                 Definition.SetSituationalContext(RuleDefinitions.SituationalContext.None);
             }
             private static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
-                => new FeeblemindIntAttributeModifierBuilder(name, guid).AddToDB();
+            {
+                return new FeeblemindIntAttributeModifierBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionAttributeModifier FeeblemindIntAttributeModifier = CreateAndAddToDB(Name, Guid);
         }
@@ -1032,7 +1044,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
-                => new FeeblemindChaAttributeModifierBuilder(name, guid).AddToDB();
+            {
+                return new FeeblemindChaAttributeModifierBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionAttributeModifier FeeblemindCha_AttributeModifier = CreateAndAddToDB(Name, Guid);
         }
@@ -1062,7 +1076,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static FeatureDefinitionActionAffinity CreateAndAddToDB(string name, string guid)
-                => new FeeblemindActionAffinityBuilder(name, guid).AddToDB();
+            {
+                return new FeeblemindActionAffinityBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionActionAffinity FeeblemindActionAffinity = CreateAndAddToDB(Name, Guid);
         }
@@ -1138,7 +1154,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new HolyAuraConditionBuilder(name, guid).AddToDB();
+            {
+                return new HolyAuraConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition HolyAuraCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -1164,7 +1182,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             internal static FeatureDefinitionDamageAffinity CreateAndAddToDB(string name, string guid)
-                => new HolyAuraDamageAffinityBuilder(name, guid).AddToDB();
+            {
+                return new HolyAuraDamageAffinityBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionDamageAffinity HolyAuraDamageAffinity = CreateAndAddToDB(Name, Guid);
         }
@@ -1209,7 +1229,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new HolyAuraBlindingPowerBuilder(name, guid).AddToDB();
+            {
+                return new HolyAuraBlindingPowerBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionPower HolyAuraBlindingPower = CreateAndAddToDB(Name, Guid);
         }
@@ -1449,7 +1471,9 @@ namespace SolastaCommunityExpansion.Spells
                     DatabaseHelper.FeatureDefinitionDamageAffinitys.DamageAffinityPsychicImmunity);
             }
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new MindBlankConditionBuilder(name, guid).AddToDB();
+            {
+                return new MindBlankConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition MindBlankCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -1680,7 +1704,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new ForesightConditionBuilder(name, guid).AddToDB();
+            {
+                return new ForesightConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition ForesightCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -2059,7 +2085,9 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new TimeStopConditionBuilder(name, guid).AddToDB();
+            {
+                return new TimeStopConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition TimeStopCondition = CreateAndAddToDB(Name, Guid);
         }
@@ -2138,7 +2166,9 @@ namespace SolastaCommunityExpansion.Spells
                 // weird condition is the same as phantasma killer condition, just for more people
             }
             private static ConditionDefinition CreateAndAddToDB(string name, string guid)
-                => new WeirdConditionBuilder(name, guid).AddToDB();
+            {
+                return new WeirdConditionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ConditionDefinition WeirdCondition = CreateAndAddToDB(Name, Guid);
         }

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -210,7 +210,7 @@ namespace SolastaCommunityExpansion.Spells
                     effectDefinitionName = formsParams.activeEffect.SourceDefinition.Name;
                 }
 
-                int sourceAbilityBonus = formsParams.activeEffect != null ? formsParams.activeEffect.ComputeSourceAbilityBonus(formsParams.sourceCharacter) : 0;
+                int sourceAbilityBonus = (formsParams.activeEffect?.ComputeSourceAbilityBonus(formsParams.sourceCharacter)) ?? 0;
 
                 formsParams.targetCharacter.InflictCondition(condition.Name, durationType, durationParam, RuleDefinitions.TurnOccurenceType.EndOfTurn, "11Effect", sourceGuid, sourceFaction, formsParams.effectLevel, effectDefinitionName, 0, sourceAbilityBonus);
             }

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -10,7 +10,7 @@ using SolastaCommunityExpansion.Builders;
 
 namespace SolastaCommunityExpansion.Spells
 {
-    internal class SrdSpells
+    internal static class SrdSpells
     {
         private static readonly SpellDefinition DivineWord = BuildDivineWord();
         private static readonly SpellDefinition FingerOfDeath = BuildFingerOfDeath();
@@ -230,7 +230,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildFingerOfDeath()
         {
-            string text = "FingerOfDeathSpell";
+            const string text = "FingerOfDeathSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -366,7 +366,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildReverseGravity()
         {
-            string text = "ReverseGravitySpell";
+            const string text = "ReverseGravitySpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -530,36 +530,36 @@ namespace SolastaCommunityExpansion.Spells
                 new FeatureDefinitionCastSpell.SlotsByLevelDuplet() { Slots = new List<int> {13,6,1,1,1,0,0,0,0,0}, Level = 20 },
             });
 
-            string text = "ConjureCelestialSpell";
+            const string text = "ConjureCelestialSpell";
 
             MonsterDefinition BaseTemplateName = DatabaseHelper.MonsterDefinitions.KindredSpiritViper;
             MonsterDefinition MonsterShaderReference = DatabaseHelper.MonsterDefinitions.KindredSpiritViper;
 
-            string NewName = "CustomCouatl";
-            string NewTitle = "CustomCouatlTitle";
-            string NewDescription = "CustomCouatlDescription";
+            const string NewName = "CustomCouatl";
+            const string NewTitle = "CustomCouatlTitle";
+            const string NewDescription = "CustomCouatlDescription";
             CharacterSizeDefinition Size = DatabaseHelper.CharacterSizeDefinitions.Medium;
-            string Alignment = "LawfulGood";
-            int ArmorClass = 19;
-            int HitDice = 13;
-            RuleDefinitions.DieType HitDiceType = RuleDefinitions.DieType.D8;
-            int HitPointsBonus = 39;
-            int StandardHitPoints = 97;
-            int AttributeStrength = 16;
-            int AttributeDexterity = 20;
-            int AttributeConstitution = 17;
-            int AttributeIntelligence = 18;
-            int AttributeWisdom = 20;
-            int AttributeCharisma = 18;
-            int SavingThrowStrength = 0;
-            int SavingThrowDexterity = 0;
-            int SavingThrowConstitution = 5;
-            int SavingThrowIntelligence = 0;
-            int SavingThrowWisdom = 7;
-            int SavingThrowCharisma = 6;
-            int CR = 4;
-            bool LegendaryCreature = false;
-            string Type = "Celestial";
+            const string Alignment = "LawfulGood";
+            const int ArmorClass = 19;
+            const int HitDice = 13;
+            const RuleDefinitions.DieType HitDiceType = RuleDefinitions.DieType.D8;
+            const int HitPointsBonus = 39;
+            const int StandardHitPoints = 97;
+            const int AttributeStrength = 16;
+            const int AttributeDexterity = 20;
+            const int AttributeConstitution = 17;
+            const int AttributeIntelligence = 18;
+            const int AttributeWisdom = 20;
+            const int AttributeCharisma = 18;
+            const int SavingThrowStrength = 0;
+            const int SavingThrowDexterity = 0;
+            const int SavingThrowConstitution = 5;
+            const int SavingThrowIntelligence = 0;
+            const int SavingThrowWisdom = 7;
+            const int SavingThrowCharisma = 6;
+            const int CR = 4;
+            const bool LegendaryCreature = false;
+            const string Type = "Celestial";
 
             List<FeatureDefinition> Features = new List<FeatureDefinition>()
             {
@@ -650,9 +650,9 @@ namespace SolastaCommunityExpansion.Spells
 
             List<LegendaryActionDescription> LegendaryActionOptions = new List<LegendaryActionDescription>();
 
-            bool GroupAttacks = false;
+            const bool GroupAttacks = false;
 
-            bool PhantomDistortion = true;
+            const bool PhantomDistortion = true;
             // AttachedParticlesReference = "0286006526f6f9c4fa61ed8ead4f72cc"
             AssetReference AttachedParticlesReference = DatabaseHelper.MonsterDefinitions.FeyBear.MonsterPresentation.GetField<UnityEngine.AddressableAssets.AssetReference>("attachedParticlesReference");
             AssetReferenceSprite SpriteReference = DatabaseHelper.MonsterDefinitions.KindredSpiritViper.GuiPresentation.SpriteReference;
@@ -864,7 +864,7 @@ namespace SolastaCommunityExpansion.Spells
         */
         private static SpellDefinition BuildDominateMonster()
         {
-            string text = "DominateMonsterSpell";
+            const string text = "DominateMonsterSpell";
 
             EffectDescription effectDescription = new EffectDescription();
 
@@ -894,7 +894,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildFeeblemind()
         {
-            string text = "FeeblemindSpell";
+            const string text = "FeeblemindSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -1006,7 +1006,6 @@ namespace SolastaCommunityExpansion.Spells
                 Definition.SetModifierType2(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Force);
                 Definition.SetModifierValue(1);
                 Definition.SetSituationalContext(RuleDefinitions.SituationalContext.None);
-
             }
             private static FeatureDefinitionAttributeModifier CreateAndAddToDB(string name, string guid)
                 => new FeeblemindIntAttributeModifierBuilder(name, guid).AddToDB();
@@ -1070,7 +1069,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildHolyAura()
         {
-            string text = "HolyAuraSpell";
+            const string text = "HolyAuraSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1117,7 +1116,6 @@ namespace SolastaCommunityExpansion.Spells
 
             return holyAuraSpell.AddToDB();
         }
-
 
         internal class HolyAuraConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
         {
@@ -1218,8 +1216,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildIncendiaryCloud()
         {
-
-            string text = "IncendiaryCloudSpell";
+            const string text = "IncendiaryCloudSpell";
 
             //
             // TODO: Why this effect description isn't used?
@@ -1323,7 +1320,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMaze()
         {
-            string text = "MazeSpell";
+            const string text = "MazeSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -1384,8 +1381,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMindBlank()
         {
-
-            string text = "MindBlankSpell";
+            const string text = "MindBlankSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder();
             effectDescription.SetDurationData(
@@ -1460,7 +1456,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordStun()
         {
-            string text = "PowerWordStunSpell";
+            const string text = "PowerWordStunSpell";
 
             ConditionForm conditionForm = new ConditionForm()
                 .SetApplyToSelf(false)
@@ -1529,10 +1525,9 @@ namespace SolastaCommunityExpansion.Spells
             return powerWordStunSpell.AddToDB();
         }
 
-
         private static SpellDefinition BuildSunBurst()
         {
-            string text = "SunBurstSpell";
+            const string text = "SunBurstSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1616,7 +1611,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildForesight()
         {
-            string text = "ForesightSpell";
+            const string text = "ForesightSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1692,7 +1687,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMassHeal()
         {
-            string text = "MassHealSpell";
+            const string text = "MassHealSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1739,7 +1734,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildMeteorSwarmSingleTarget()
         {
-            string text = "MeteorSwarmSingleTargetSpell";
+            const string text = "MeteorSwarmSingleTargetSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(
@@ -1812,7 +1807,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordHeal()
         {
-            string text = "PowerWordHealSpell";
+            const string text = "PowerWordHealSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -1858,7 +1853,6 @@ namespace SolastaCommunityExpansion.Spells
                     })
                 .Build());
 
-
             GuiPresentation guiPresentationSpell = new GuiPresentation()
                 .SetColor(new UnityEngine.Color(1f, 1f, 1f, 1f))
                 .SetDescription(GetSpellDescriptionTerm(text))
@@ -1881,7 +1875,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildPowerWordKill()
         {
-            string text = "PowerWordKillSpell";
+            const string text = "PowerWordKillSpell";
 
             KillForm killForm = new KillForm()
                 .SetKillCondition(RuleDefinitions.KillCondition.UnderHitPoints)
@@ -1932,7 +1926,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildShapechange()
         {
-            string text = "ShapechangeSpell";
+            const string text = "ShapechangeSpell";
 
             ShapeChangeForm shapeChangeForm = new ShapeChangeForm()
                 .SetKeepMentalAbilityScores(true)
@@ -2001,7 +1995,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildTimeStop()
         {
-            string text = "TimeStopSpell";
+            const string text = "TimeStopSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
             .SetDurationData(
@@ -2072,7 +2066,7 @@ namespace SolastaCommunityExpansion.Spells
 
         private static SpellDefinition BuildWeird()
         {
-            string text = "WeirdSpell";
+            const string text = "WeirdSpell";
 
             EffectDescriptionBuilder effectDescription = new EffectDescriptionBuilder()
                 .SetDurationData(

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -173,10 +173,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                         CreateNamespacedGuid("PathOfTheLightLightsProtectionOpportunityAttackImmunity"),
                         "Feature/&NoContentTitle",
                         "Feature/&NoContentTitle",
-                        definition =>
-                        {
-                            definition.ConditionName = IlluminatedConditionName;
-                        });
+                        definition => definition.ConditionName = IlluminatedConditionName);
 
                     featureSetDefinition.FeatureSet.Add(conditionalOpportunityAttackImmunity);
                 });
@@ -409,10 +406,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                 CreateNamespacedGuid("PathOfTheLightIlluminatedDisadvantage"),
                 "Subclass/&BarbarianPathOfTheLightIlluminatedDisadvantageDescription",
                 "Feature/&NoContentTitle",
-                definition =>
-                {
-                    definition.ConditionName = IlluminatedConditionName;
-                });
+                definition => definition.ConditionName = IlluminatedConditionName);
 
             return disadvantageAgainstNonSource;
         }
@@ -499,7 +493,6 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
                 character.PersonalLightSource = null;
             }
         }
-
 
         // Helper classes
 

--- a/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
+++ b/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
@@ -283,7 +283,9 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionBarkWardBuilder("BarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "BarkWard").ToString()).AddToDB();
+        {
+            return new ConditionBarkWardBuilder("BarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "BarkWard").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {
@@ -358,7 +360,9 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionImprovedBarkWardBuilder("ImprovedBarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "ImprovedBarkWard").ToString()).AddToDB();
+        {
+            return new ConditionImprovedBarkWardBuilder("ImprovedBarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "ImprovedBarkWard").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {
@@ -433,7 +437,9 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionSuperiorBarkWardBuilder("SuperiorBarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "SuperiorBarkWard").ToString()).AddToDB();
+        {
+            return new ConditionSuperiorBarkWardBuilder("SuperiorBarkWard", GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "SuperiorBarkWard").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {

--- a/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
+++ b/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
@@ -19,11 +19,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass());
         }
 
         private const string DruidForestGuardianDruidSubclassName = "DruidForestGuardianDruidSubclass";

--- a/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
+++ b/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
@@ -231,7 +231,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
                 true).AddToDB();
             superiorBarkWard.SetOverriddenPower(improvedBarkWard);
 
-
             return new Dictionary<int, FeatureDefinitionPowerSharedPool>{
                 {2, barkWard},
                 {10, improvedBarkWard},
@@ -316,8 +315,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             EffectDescriptionBuilder improvedBarkWardRetaliationEffect = new EffectDescriptionBuilder();
             improvedBarkWardRetaliationEffect.AddEffectForm(damageEffect.Build());
 
-
-
             return new FeatureDefinitionPowerBuilder("improvedBarkWardRetaliate",
                 GuidHelper.Create(CircleOfTheForestGuardian.DFG_BASE_GUID, "improvedBarkWardRetaliate").ToString(),
                 0,
@@ -362,7 +359,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             Definition.SetDurationParameter(10);
             Definition.SetDurationType(RuleDefinitions.DurationType.Minute);
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB()
@@ -438,7 +434,6 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
             Definition.SetDurationParameter(10);
             Definition.SetDurationType(RuleDefinitions.DurationType.Minute);
             Definition.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
-
         }
 
         public static ConditionDefinition CreateAndAddToDB()

--- a/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
@@ -48,7 +48,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             }
 
             public static FeatureDefinitionAbilityCheckAffinity CreateAndAddToDB(string name, string guid)
-                => new RoyalEnvoyAbilityCheckAffinityBuilder(name, guid).AddToDB();
+            {
+                return new RoyalEnvoyAbilityCheckAffinityBuilder(name, guid).AddToDB();
+            }
 
             public static FeatureDefinitionAbilityCheckAffinity RoyalEnvoyAbilityCheckAffinity
                 => CreateAndAddToDB(RoyalEnvoyAbilityCheckName, RoyalEnvoyAbilityCheckGuid);
@@ -69,7 +71,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             }
 
             public static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
-                 => new RoyalEnvoyFeatureBuilder(name, guid).AddToDB();
+            {
+                return new RoyalEnvoyFeatureBuilder(name, guid).AddToDB();
+            }
 
             public static FeatureDefinitionFeatureSet RoyalEnvoyFeatureSet
                 => CreateAndAddToDB(RoyalEnvoyFeatureName, RoyalEnvoyFeatureGuid);
@@ -106,7 +110,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new RallyingCryPowerBuilder(name, guid).AddToDB();
+            {
+                return new RallyingCryPowerBuilder(name, guid).AddToDB();
+            }
 
             public static FeatureDefinitionPower RallyingCryPower
                 => CreateAndAddToDB(RallyingCryPowerName, RallyingCryPowerGuid);
@@ -157,7 +163,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-                => new InspiringSurgePowerBuilder(name, guid).AddToDB();
+            {
+                return new InspiringSurgePowerBuilder(name, guid).AddToDB();
+            }
 
             public static FeatureDefinitionPower InspiringSurgePower
                 => CreateAndAddToDB(InspiringSurgePowerName, InspiringSurgePowerNameGuid);

--- a/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
@@ -94,15 +94,15 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 effectDescription.Copy(Definition.EffectDescription);
                 effectDescription.EffectForms[0].HealingForm.HealingCap = RuleDefinitions.HealingCap.MaximumHitPoints;
                 effectDescription.EffectForms[0].HealingForm.DiceNumber = 4;
-                FeatureDefinitionPowerExtensions.SetEffectDescription(Definition, effectDescription);
+                Definition.SetEffectDescription(effectDescription);
             }
 
             private void SetupGUI()
             {
                 Definition.GuiPresentation.Title = "Feature/&RallyingCryPowerTitle";
                 Definition.GuiPresentation.Description = "Feature/&RallyingCryPowerDescription";
-                FeatureDefinitionPowerExtensions.SetShortTitleOverride(Definition, "Feature/&RallyingCryPowerTitleShort");
-                GuiPresentationExtensions.SetSpriteReference(Definition.GuiPresentation, DatabaseHelper.SpellDefinitions.HealingWord.GuiPresentation.SpriteReference);
+                Definition.SetShortTitleOverride("Feature/&RallyingCryPowerTitleShort");
+                Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.HealingWord.GuiPresentation.SpriteReference);
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
@@ -145,15 +145,15 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                     effectDescription.EffectForms.Add(effectForm);
                 }
 
-                FeatureDefinitionPowerExtensions.SetEffectDescription(Definition, effectDescription);
+                Definition.SetEffectDescription(effectDescription);
             }
 
             private void SetupGUI()
             {
                 Definition.GuiPresentation.Title = "Feature/&InspiringSurgePowerTitle";
                 Definition.GuiPresentation.Description = "Feature/&InspiringSurgePowerDescription";
-                FeatureDefinitionPowerExtensions.SetShortTitleOverride(Definition, "Feature/&InspiringSurgePowerTitleShort");
-                GuiPresentationExtensions.SetSpriteReference(Definition.GuiPresentation, DatabaseHelper.SpellDefinitions.Heroism.GuiPresentation.SpriteReference);
+                Definition.SetShortTitleOverride("Feature/&InspiringSurgePowerTitleShort");
+                Definition.GuiPresentation.SetSpriteReference(DatabaseHelper.SpellDefinitions.Heroism.GuiPresentation.SpriteReference);
             }
 
             public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -71,7 +71,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
 
         public static FeatureDefinitionPowerSharedPool CreateAndAddToDB()
-            => Build(KnockDownPowerName, KnockDownPowerNameGuid);
+        {
+            return Build(KnockDownPowerName, KnockDownPowerNameGuid);
+        }
     }
 
     internal static class InspirePowerBuilder
@@ -127,7 +129,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
 
         public static FeatureDefinitionPowerSharedPool CreateAndAddToDB()
-            => Build(InspirePowerName, InspirePowerNameGuid);
+        {
+            return Build(InspirePowerName, InspirePowerNameGuid);
+        }
     }
 
     internal static class CounterStrikePowerBuilder
@@ -167,7 +171,9 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
 
         public static FeatureDefinitionPowerSharedPool CreateAndAddToDB()
-            => Build(CounterStrikePowerName, CounterStrikePowerNameGuid);
+        {
+            return Build(CounterStrikePowerName, CounterStrikePowerNameGuid);
+        }
     }
 
     internal static class GambitResourcePoolBuilder
@@ -176,9 +182,11 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         private const string GambitResourcePoolNameGuid = "00da2b27-139a-4ca0-a285-aaa70d108bc8";
 
         public static FeatureDefinitionPower CreateAndAddToDB()
-            => new FeatureDefinitionPowerPoolBuilder(GambitResourcePoolName, GambitResourcePoolNameGuid,
-                4, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Dexterity, RuleDefinitions.RechargeRate.ShortRest,
-                new GuiPresentationBuilder("Feature/&GambitResourcePoolDescription", "Feature/&GambitResourcePoolTitle").Build()).AddToDB();
+        {
+            return new FeatureDefinitionPowerPoolBuilder(GambitResourcePoolName, GambitResourcePoolNameGuid,
+                           4, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Dexterity, RuleDefinitions.RechargeRate.ShortRest,
+                           new GuiPresentationBuilder("Feature/&GambitResourcePoolDescription", "Feature/&GambitResourcePoolTitle").Build()).AddToDB();
+        }
     }
 
     internal static class GambitResourcePoolAddBuilder
@@ -196,14 +204,31 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         private const string GambitResourcePoolAdd18Guid = "c7ced45a-572f-4af0-8ec5-2add074dd7c3";
 
         public static FeatureDefinitionPower CreateAndAddToDB(string name, string guid)
-            => new FeatureDefinitionPowerPoolModifierBuilder(name, guid,
-                1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Dexterity, TacticianFighterSubclassBuilder.GambitResourcePool,
-                new GuiPresentationBuilder("Feature/&GambitResourcePoolAddDescription", "Feature/&GambitResourcePoolAddTitle").Build()).AddToDB();
+        {
+            return new FeatureDefinitionPowerPoolModifierBuilder(name, guid,
+                           1, RuleDefinitions.UsesDetermination.Fixed, AttributeDefinitions.Dexterity, TacticianFighterSubclassBuilder.GambitResourcePool,
+                           new GuiPresentationBuilder("Feature/&GambitResourcePoolAddDescription", "Feature/&GambitResourcePoolAddTitle").Build()).AddToDB();
+        }
 
-        public static FeatureDefinitionPower GambitResourcePoolAdd() => CreateAndAddToDB(GambitResourcePoolAddName, GambitResourcePoolAddNameGuid);
-        public static FeatureDefinitionPower GambitResourcePoolAdd10() => CreateAndAddToDB(GambitResourcePoolAdd10Name, GambitResourcePoolAdd10Guid);
-        public static FeatureDefinitionPower GambitResourcePoolAdd15() => CreateAndAddToDB(GambitResourcePoolAdd15Name, GambitResourcePoolAdd15Guid);
-        public static FeatureDefinitionPower GambitResourcePoolAdd18() => CreateAndAddToDB(GambitResourcePoolAdd18Name, GambitResourcePoolAdd18Guid);
+        public static FeatureDefinitionPower GambitResourcePoolAdd()
+        {
+            return CreateAndAddToDB(GambitResourcePoolAddName, GambitResourcePoolAddNameGuid);
+        }
+
+        public static FeatureDefinitionPower GambitResourcePoolAdd10()
+        {
+            return CreateAndAddToDB(GambitResourcePoolAdd10Name, GambitResourcePoolAdd10Guid);
+        }
+
+        public static FeatureDefinitionPower GambitResourcePoolAdd15()
+        {
+            return CreateAndAddToDB(GambitResourcePoolAdd15Name, GambitResourcePoolAdd15Guid);
+        }
+
+        public static FeatureDefinitionPower GambitResourcePoolAdd18()
+        {
+            return CreateAndAddToDB(GambitResourcePoolAdd18Name, GambitResourcePoolAdd18Guid);
+        }
     }
 
     public static class TacticianFighterSubclassBuilder

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -246,6 +246,5 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         public static readonly FeatureDefinitionPowerSharedPool KnockDownPower = KnockDownPowerBuilder.CreateAndAddToDB();
         public static readonly FeatureDefinitionPowerSharedPool InspirePower = InspirePowerBuilder.CreateAndAddToDB();
         public static readonly FeatureDefinitionPowerSharedPool CounterStrikePower = CounterStrikePowerBuilder.CreateAndAddToDB();
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/Tactician.cs
@@ -14,11 +14,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = TacticianFighterSubclassBuilder.BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = TacticianFighterSubclassBuilder.BuildAndAddSubclass());
         }
     }
 

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -319,7 +319,9 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
         }
 
         public static ConditionDefinition CreateAndAddToDB()
-            => new ConditionMarkedByArcanistBuilder("ConditionMarkedByArcanist", GuidHelper.Create(Arcanist.RA_BASE_GUID, "ConditionMarkedByArcanist").ToString()).AddToDB();
+        {
+            return new ConditionMarkedByArcanistBuilder("ConditionMarkedByArcanist", GuidHelper.Create(Arcanist.RA_BASE_GUID, "ConditionMarkedByArcanist").ToString()).AddToDB();
+        }
 
         public static ConditionDefinition GetOrAdd()
         {

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -18,11 +18,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
         }
         internal override CharacterSubclassDefinition GetSubclass()
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass();
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass());
         }
 
         private const string RangerArcanistRangerSubclassName = "RangerArcanistRangerSubclass";
@@ -305,7 +301,6 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
                 .AddToDB();
         }
     }
-
 
     // Creates a dedicated builder for the marked by arcanist condition. This helps with GUID wonkiness on the fact that separate features interact with it.
     internal class ConditionMarkedByArcanistBuilder : BaseDefinitionBuilder<ConditionDefinition>

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -15,18 +15,12 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
 
         #region DcIncreaseAffinity
         private static FeatureDefinitionMagicAffinity _dcIncreaseAffinity;
-        private static FeatureDefinitionMagicAffinity DcIncreaseAffinity
-        {
-            get
-            {
-                return _dcIncreaseAffinity = _dcIncreaseAffinity ??
+        private static FeatureDefinitionMagicAffinity DcIncreaseAffinity => _dcIncreaseAffinity = _dcIncreaseAffinity ??
                     new FeatureDefinitionMagicAffinityBuilder(
                         "MagicAffinityRoguishConArtistDC",
                         GuidHelper.Create(SubclassNamespace, "MagicAffinityRoguishConArtistDC").ToString(),
                         GetSpellDCPresentation().Build())
                             .SetCastingModifiers(0, Main.Settings.OverrideRogueConArtistImprovedManipulationSpellDc, false, false, false).AddToDB();
-            }
-        }
         #endregion
 
         internal override FeatureDefinitionSubclassChoice GetSubclassChoiceList()

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -121,9 +121,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             public AdvantageBuilder(string name, string guid, ConditionDefinition original, GuiPresentation guiPresentation) : base(original, name, guid)
             {
                 Definition.SetGuiPresentation(guiPresentation);
-                Definition.SetField("specialInterruptions", (new List<RuleDefinitions.ConditionInterruption>() {
+                Definition.SetField("specialInterruptions", new List<RuleDefinitions.ConditionInterruption>() {
                     RuleDefinitions.ConditionInterruption.Attacked,
-                }));
+                });
                 Definition.SetAdditionalDamageWhenHit(true);
                 Definition.SetAdditionalDamageDieType(RuleDefinitions.DieType.D8);
                 Definition.SetAdditionalDamageDieNumber(3);

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -67,7 +67,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             }
 
             private static FeatureDefinitionAdditionalDamage CreateAndAddToDB(string name, string guid)
-                => new RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder(name, guid).AddToDB();
+            {
+                return new RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionAdditionalDamage ExploitVulnerabilities =
                 CreateAndAddToDB(ExploitVulnerabilitiesName, ExploitVulnerabilitiesGuid);
@@ -88,7 +90,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             }
 
             private static FeatureDefinitionProficiency CreateAndAddToDB(string name, string guid)
-                => new RogueSubclassThugProficienciesBuilder(name, guid).AddToDB();
+            {
+                return new RogueSubclassThugProficienciesBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionProficiency ThugProficiencies =
                 CreateAndAddToDB(RogueSubclassThugProficienciesName, RogueSubclassThugProficienciesGuid);
@@ -108,7 +112,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             }
 
             private static FeatureDefinitionActionAffinity CreateAndAddToDB(string name, string guid)
-                => new RogueSubclassThugBrutalMethodsBuilder(name, guid).AddToDB();
+            {
+                return new RogueSubclassThugBrutalMethodsBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionActionAffinity ThugBrutalMethods =
                 CreateAndAddToDB(RogueSubclassThugBrutalMethodsName, RogueSubclassThugBrutalMethodsGuid);
@@ -125,7 +131,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             }
 
             private static ActionDefinition CreateAndAddToDB(string name, string guid)
-                => new RogueSubclassThugBrutalMethodsActionBuilder(name, guid).AddToDB();
+            {
+                return new RogueSubclassThugBrutalMethodsActionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly ActionDefinition ThugBrutalMethodsAction
                 = CreateAndAddToDB(RogueSubclassThugBrutalMethodsActionName, RogueSubclassThugBrutalMethodsActionGuid);
@@ -149,7 +157,9 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             }
 
             private static FeatureDefinitionAbilityCheckAffinity CreateAndAddToDB(string name, string guid)
-                => new RogueSubclassThugOvercomeCompetitionBuilder(name, guid).AddToDB();
+            {
+                return new RogueSubclassThugOvercomeCompetitionBuilder(name, guid).AddToDB();
+            }
 
             internal static readonly FeatureDefinitionAbilityCheckAffinity ThugOvercomeCompetition =
                 CreateAndAddToDB(RogueSubclassThugOvercomeCompetitionName, RogueSubclassThugOvercomeCompetitionGuid);

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -43,7 +43,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 .SetGuiPresentation(guiPresentation)
                 .AddFeatureAtLevel(new RemoveGrantedFeatureBuilder(
                     featureName,
-                    GuidHelper.Create(Thug.SubclassNamespace, featureName).ToString(),
+                    GuidHelper.Create(SubclassNamespace, featureName).ToString(),
                     AdditionalDamageRogueSneakAttack,
                     1,
                     DatabaseHelper.CharacterClassDefinitions.Rogue).AddToDB(), 3)

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -63,7 +63,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             {
                 Definition.GuiPresentation.Title = "Feature/&KSRogueSubclassThugExploitVulnerabilitiesSneakAttackTitle";
                 Definition.GuiPresentation.Description = "Feature/&KSRogueSubclassThugExploitVulnerabilitiesSneakAttackDescription";
-                FeatureDefinitionAdditionalDamageExtensions.SetRequiredProperty(Definition, RuleDefinitions.AdditionalDamageRequiredProperty.None);
+                Definition.SetRequiredProperty(RuleDefinitions.AdditionalDamageRequiredProperty.None);
             }
 
             private static FeatureDefinitionAdditionalDamage CreateAndAddToDB(string name, string guid)
@@ -82,7 +82,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             {
                 Definition.GuiPresentation.Title = "Feature/&KSRogueSubclassThugProficienciesTitle";
                 Definition.GuiPresentation.Description = "Feature/&KSRogueSubclassThugProficienciesDescription";
-                FeatureDefinitionProficiencyExtensions.SetProficiencyType(Definition, RuleDefinitions.ProficiencyType.Armor);
+                Definition.SetProficiencyType(RuleDefinitions.ProficiencyType.Armor);
                 Definition.Proficiencies.Add("MediumArmorCategory");
                 Definition.Proficiencies.Add("ShieldCategory");
             }
@@ -121,7 +121,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
 
             private RogueSubclassThugBrutalMethodsActionBuilder(string name, string guid) : base(DatabaseHelper.ActionDefinitions.ShoveBonus, name, guid)
             {
-                ActionDefinitionExtensions.SetId(Definition, (ActionDefinitions.Id)THUG_BONUS_SHOVE_ACTION_ID);
+                Definition.SetId((ActionDefinitions.Id)THUG_BONUS_SHOVE_ACTION_ID);
             }
 
             private static ActionDefinition CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
@@ -15,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildBloodMagic()

--- a/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/BloodWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class BloodWitch
     {
-
         public static readonly Guid BLOODW_BASE_GUID = new Guid("c9f680ec-7c79-414f-b700-eebc11863105");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -89,7 +88,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +97,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +115,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
@@ -15,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildGreenMagic()

--- a/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/GreenWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class GreenWitch
     {
-
         public static readonly Guid GW_BASE_GUID = new Guid("5d595308-bcf8-4a9f-a9a0-d2ae85c243e7");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -89,7 +88,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +97,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +115,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
@@ -15,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildPurpleMagic()

--- a/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/PurpleWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class PurpleWitch
     {
-
         public static readonly Guid PW_BASE_GUID = new Guid("bb8a01e8-7997-4c44-8643-72ac15853b47");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -89,7 +88,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +97,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +115,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class RedWitch
     {
-
         public static readonly Guid RW_BASE_GUID = new Guid("3cc83deb-e681-4670-9340-33d08b61f599");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -89,7 +88,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +97,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         public static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +115,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/RedWitch.cs
@@ -15,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildRedMagic()

--- a/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
@@ -15,11 +15,7 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         internal CharacterSubclassDefinition GetSubclass(CharacterClassDefinition witchClass)
         {
-            if (Subclass == null)
-            {
-                Subclass = BuildAndAddSubclass(witchClass);
-            }
-            return Subclass;
+            return Subclass ?? (Subclass = BuildAndAddSubclass(witchClass));
         }
 
         private static void BuildWhiteMagic()

--- a/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
+++ b/SolastaCommunityExpansion/Subclasses/Witch/WhiteWitch.cs
@@ -8,7 +8,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 {
     internal class WhiteWitch
     {
-
         public static readonly Guid WW_BASE_GUID = new Guid("2d849694-5cc9-4333-944b-e40cc1e0d0fd");
         private CharacterSubclassDefinition Subclass;
         public static CharacterClassDefinition WitchClass { get; private set; }
@@ -89,7 +88,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
                     .SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                     .SetUniqueChoices(true)
                     .AddToDB();
-
         }
 
         private static void BuildProgression(CharacterSubclassDefinitionBuilder subclassBuilder)
@@ -99,7 +97,6 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
         private static CharacterSubclassDefinition BuildAndAddSubclass(CharacterClassDefinition witchClassDefinition)
         {
-
             WitchClass = witchClassDefinition;
 
             var subclassGuiPresentation = new GuiPresentationBuilder(
@@ -118,6 +115,5 @@ namespace SolastaCommunityExpansion.Subclasses.Witch
 
             return subclassBuilder.AddToDB();
         }
-
     }
 }

--- a/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
@@ -104,13 +104,7 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
                 weaponUseIntModifier, "PowerMeleeWizardArcaneWeapon", arcaneWeaponGui.Build());
             return enchantWeapon;
         }
-        internal static FeatureDefinitionPower EnchantWeapon
-        {
-            get
-            {
-                return _enchantWeapon = _enchantWeapon ?? BuildEnchantWeapon();
-            }
-        }
+        internal static FeatureDefinitionPower EnchantWeapon => _enchantWeapon = _enchantWeapon ?? BuildEnchantWeapon();
 
         public static void UpdateEnchantWeapon()
         {

--- a/SolastaCommunityExpansion/Subclasses/Wizard/LifeTransmuter.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/LifeTransmuter.cs
@@ -186,7 +186,6 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
             RuleDefinitions.TurnOccurenceType endOfEffect, string abilityScore, ConditionDefinition condition,
             string name, GuiPresentation guiPresentation)
         {
-
             EffectDescriptionBuilder effectDescriptionBuilder = new EffectDescriptionBuilder();
             effectDescriptionBuilder.SetTargetingData(RuleDefinitions.Side.Ally, rangeType, rangeParameter, targetType, 1, 0, itemSelectionType);
             effectDescriptionBuilder.SetCreatedByCharacter();

--- a/SolastaCommunityExpansion/Subclasses/Wizard/MasterManipulator.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/MasterManipulator.cs
@@ -14,14 +14,8 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
 
         #region DcIncreaseAffinity
         private static FeatureDefinitionMagicAffinity _dcIncreaseAffinity;
-        private static FeatureDefinitionMagicAffinity DcIncreaseAffinity
-        {
-            get
-            {
-                return _dcIncreaseAffinity = _dcIncreaseAffinity ??
+        private static FeatureDefinitionMagicAffinity DcIncreaseAffinity => _dcIncreaseAffinity = _dcIncreaseAffinity ??
                     BuildMagicAffinityModifiers(0, Main.Settings.OverrideWizardMasterManipulatorArcaneManipulationSpellDc, "MagicAffinityMasterManipulatorDC", GetSpellDCPresentation().Build());
-            }
-        }
         #endregion
 
         internal override FeatureDefinitionSubclassChoice GetSubclassChoiceList()

--- a/SolastaCommunityExpansion/Subclasses/Wizard/SpellMaster.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/SpellMaster.cs
@@ -36,16 +36,10 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
 
         #region Bonus recovery
         private static FeatureDefinitionPower _bonusRecovery;
-        internal static FeatureDefinitionPower BonusRecovery
-        {
-            get
-            {
-                return _bonusRecovery = _bonusRecovery ??
+        internal static FeatureDefinitionPower BonusRecovery => _bonusRecovery = _bonusRecovery ??
                     BuildSpellFormPower(
                         1 /* usePerRecharge */, RuleDefinitions.UsesDetermination.Fixed, RuleDefinitions.ActivationTime.Rest,
                         1 /* cost */, RuleDefinitions.RechargeRate.LongRest, "PowerSpellMasterBonusRecovery", SpellRecoveryGui);
-            }
-        }
         #endregion
 
         internal override FeatureDefinitionSubclassChoice GetSubclassChoiceList()

--- a/SolastaCommunityExpansion/Utils/SerializableDictionary.cs
+++ b/SolastaCommunityExpansion/Utils/SerializableDictionary.cs
@@ -5,6 +5,14 @@ using System.Xml.Serialization;
 
 namespace SolastaCommunityExpansion.Utils
 {
+    // Generic types should not contain static fields, or they get copied for every instance of the type
+    static class SerializableDictionary
+    {
+        public const string ItemTag = "item";
+        public const string KeyTag = "key";
+        public const string ValueTag = "value";
+    }
+
     /// <summary>
     /// Base on https://weblogs.asp.net/pwelter34/444961
     /// </summary>
@@ -17,10 +25,6 @@ namespace SolastaCommunityExpansion.Utils
     {
         // XmlSerializer.Deserialize() will create a new Object, and then call ReadXml()
         // So cannot use instance field, use class field
-
-        public const string ItemTag = "item";
-        public const string KeyTag = "key";
-        public const string ValueTag = "value";
 
         public XmlSchema GetSchema()
         {
@@ -40,15 +44,15 @@ namespace SolastaCommunityExpansion.Utils
             reader.ReadStartElement();
 
             // IsStartElement() will call MoveToContent()
-            while (reader.IsStartElement(ItemTag))
+            while (reader.IsStartElement(SerializableDictionary.ItemTag))
             {
-                reader.ReadStartElement(ItemTag);
+                reader.ReadStartElement(SerializableDictionary.ItemTag);
 
-                reader.ReadStartElement(KeyTag);
+                reader.ReadStartElement(SerializableDictionary.KeyTag);
                 TKey key = (TKey)keySerializer.Deserialize(reader);
                 reader.ReadEndElement();
 
-                reader.ReadStartElement(ValueTag);
+                reader.ReadStartElement(SerializableDictionary.ValueTag);
                 TValue value = (TValue)valueSerializer.Deserialize(reader);
                 reader.ReadEndElement();
 
@@ -66,13 +70,13 @@ namespace SolastaCommunityExpansion.Utils
 
             foreach (var kvp in this)
             {
-                writer.WriteStartElement(ItemTag);
+                writer.WriteStartElement(SerializableDictionary.ItemTag);
 
-                writer.WriteStartElement(KeyTag);
+                writer.WriteStartElement(SerializableDictionary.KeyTag);
                 keySerializer.Serialize(writer, kvp.Key);
                 writer.WriteEndElement();
 
-                writer.WriteStartElement(ValueTag);
+                writer.WriteStartElement(SerializableDictionary.ValueTag);
                 valueSerializer.Serialize(writer, kvp.Value);
                 writer.WriteEndElement();
 

--- a/SolastaCommunityExpansion/Utils/SerializableDictionary.cs
+++ b/SolastaCommunityExpansion/Utils/SerializableDictionary.cs
@@ -6,7 +6,7 @@ using System.Xml.Serialization;
 namespace SolastaCommunityExpansion.Utils
 {
     // Generic types should not contain static fields, or they get copied for every instance of the type
-    static class SerializableDictionary
+    internal static class SerializableDictionary
     {
         public const string ItemTag = "item";
         public const string KeyTag = "key";

--- a/SolastaCommunityExpansion/Viewers/CharacterViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/CharacterViewer.cs
@@ -1,5 +1,5 @@
-﻿using ModKit;
-using System.Linq;
+﻿using System.Linq;
+using ModKit;
 using UnityEngine;
 using UnityModManagerNet;
 using static SolastaCommunityExpansion.Viewers.Displays.CharacterDisplay;

--- a/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CharacterDisplay.cs
@@ -6,8 +6,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class CharacterDisplay
     {
-
-
         internal static void DisplayCharacter()
         {
             int intValue;
@@ -142,7 +140,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             if (Main.Settings.DisplayProgressionToggle)
             {
                 UI.Label("");
-
 
                 toggle = Main.Settings.EnablesAsiAndFeat;
                 if (UI.Toggle("Enable both ASI and feat", ref toggle, UI.AutoWidth()))

--- a/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
@@ -4,7 +4,6 @@ using SolastaCommunityExpansion.Subclasses.Rogue;
 using SolastaCommunityExpansion.Subclasses.Wizard;
 using System.Linq;
 
-
 namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class ClassesAndSubclassesDisplay
@@ -233,5 +232,4 @@ namespace SolastaCommunityExpansion.Viewers.Displays
             UI.Label("");
         }
     }
-
 }

--- a/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ClassesAndSubclassesDisplay.cs
@@ -1,8 +1,8 @@
-﻿using ModKit;
+﻿using System.Linq;
+using ModKit;
 using SolastaCommunityExpansion.Models;
 using SolastaCommunityExpansion.Subclasses.Rogue;
 using SolastaCommunityExpansion.Subclasses.Wizard;
-using System.Linq;
 
 namespace SolastaCommunityExpansion.Viewers.Displays
 {

--- a/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/CreditsDisplay.cs
@@ -1,5 +1,5 @@
-﻿using ModKit;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using ModKit;
 
 namespace SolastaCommunityExpansion.Viewers.Displays
 {

--- a/SolastaCommunityExpansion/Viewers/Displays/HotKeysDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/HotKeysDisplay.cs
@@ -8,7 +8,10 @@ namespace SolastaCommunityExpansion.Viewers.Displays
         {
             bool toggle;
 
-            string hk(char key) => "ctrl-shift-(".cyan() + key + ")".cyan();
+            string hk(char key)
+            {
+                return "ctrl-shift-(".cyan() + key + ")".cyan();
+            }
 
             #region Hotkeys
             UI.Label("");

--- a/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
@@ -1,6 +1,6 @@
-﻿using ModKit;
+﻿using System.Linq;
+using ModKit;
 using SolastaCommunityExpansion.Models;
-using System.Linq;
 using static SolastaCommunityExpansion.Viewers.Displays.Shared;
 
 namespace SolastaCommunityExpansion.Viewers.Displays

--- a/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/ItemsAndCraftingDisplay.cs
@@ -7,8 +7,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
 {
     internal static class ItemsAndCraftingDisplay
     {
-
-
         private static void AddUIForWeaponKey(string key)
         {
             bool toggle;

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -111,7 +111,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                     }
                 }
             }
-  
+
             UI.Label("");
 
             toggle = Main.Settings.DisplayHouseRulesToggle;

--- a/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
@@ -136,7 +136,7 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 var spellName = spellDefinition.Name;
                 var spellTitle = $"{spellDefinition.SpellLevel} - {spellDefinition.FormatTitle()}";
 
-                if (IsFromOtherModList.ElementAt(i))
+                if (IsFromOtherModList[i])
                 {
                     spellTitle = spellTitle.color(RGBA.brown);
                 }

--- a/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/SpellsDisplay.cs
@@ -1,8 +1,8 @@
-﻿using ModKit;
+﻿using System.Collections.Generic;
+using System.Linq;
+using ModKit;
 using SolastaCommunityExpansion.Models;
 using SolastaModApi.Infrastructure;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace SolastaCommunityExpansion.Viewers.Displays
 {

--- a/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
@@ -1,8 +1,8 @@
-﻿using ModKit;
-using SolastaCommunityExpansion.Models;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using ModKit;
+using SolastaCommunityExpansion.Models;
 using UnityEngine;
 using UnityModManagerNet;
 

--- a/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
@@ -137,7 +137,6 @@ namespace SolastaCommunityExpansion.Viewers
                     UI.Label($"CR: {monsterDefinition.ChallengeRating}".yellow(), UI.Width(72));
                 }
 
-
                 currentAttacksMonster.TryGetValue(monsterDefinition, out flip);
 
                 if (UI.DisclosureToggle($"Attacks ({monsterDefinition.AttackIterations.Count:0#})", ref flip, 132))

--- a/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
@@ -296,11 +296,11 @@ namespace SolastaCommunityExpansion.Viewers
                 {
                     if (EncountersSpawnContext.EncounterCharacters[index] is RulesetCharacterMonster rulesetCharacterMonster)
                     {
-                        DisplayMonsterStats(rulesetCharacterMonster.MonsterDefinition, "-", () => { EncountersSpawnContext.RemoveFromEncounter(index); });
+                        DisplayMonsterStats(rulesetCharacterMonster.MonsterDefinition, "-", () => EncountersSpawnContext.RemoveFromEncounter(index));
                     }
                     else if (EncountersSpawnContext.EncounterCharacters[index] is RulesetCharacterHero rulesetCharacterHero)
                     {
-                        DisplayHeroStats(rulesetCharacterHero, "-", () => { EncountersSpawnContext.RemoveFromEncounter(index); });
+                        DisplayHeroStats(rulesetCharacterHero, "-", () => EncountersSpawnContext.RemoveFromEncounter(index));
                     }
                 }
             }
@@ -316,7 +316,7 @@ namespace SolastaCommunityExpansion.Viewers
 
             foreach (var monsterDefinition in EncountersSpawnContext.GetMonsters())
             {
-                DisplayMonsterStats(monsterDefinition, "+", () => { EncountersSpawnContext.AddToEncounter(monsterDefinition); });
+                DisplayMonsterStats(monsterDefinition, "+", () => EncountersSpawnContext.AddToEncounter(monsterDefinition));
             }
         }
 
@@ -330,7 +330,7 @@ namespace SolastaCommunityExpansion.Viewers
 
                 foreach (var hero in EncountersSpawnContext.GetHeroes())
                 {
-                    DisplayHeroStats(hero, "+", () => { EncountersSpawnContext.AddToEncounter(hero); });
+                    DisplayHeroStats(hero, "+", () => EncountersSpawnContext.AddToEncounter(hero));
                 }
             }
         }

--- a/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/EncountersViewer.cs
@@ -20,11 +20,11 @@ namespace SolastaCommunityExpansion.Viewers
 
         private static bool showAttributes;
 
-        private static readonly Dictionary<MonsterDefinition, bool> currentFeaturesMonster = new Dictionary<MonsterDefinition, bool> { };
+        private static readonly Dictionary<MonsterDefinition, bool> currentFeaturesMonster = new Dictionary<MonsterDefinition, bool>();
 
-        private static readonly Dictionary<MonsterDefinition, bool> currentAttacksMonster = new Dictionary<MonsterDefinition, bool> { };
+        private static readonly Dictionary<MonsterDefinition, bool> currentAttacksMonster = new Dictionary<MonsterDefinition, bool>();
 
-        private static readonly Dictionary<RulesetCharacterHero, bool> currentItemsHeroes = new Dictionary<RulesetCharacterHero, bool> { };
+        private static readonly Dictionary<RulesetCharacterHero, bool> currentItemsHeroes = new Dictionary<RulesetCharacterHero, bool>();
 
         private static string SplitCamelCase(string str)
         {
@@ -70,7 +70,7 @@ namespace SolastaCommunityExpansion.Viewers
 
                 currentItemsHeroes.TryGetValue(hero, out flip);
 
-                if (UI.DisclosureToggle($"Inventory", ref flip, 132))
+                if (UI.DisclosureToggle("Inventory", ref flip, 132))
                 {
                     currentItemsHeroes.AddOrReplace<RulesetCharacterHero, bool>(hero, flip);
                 }
@@ -208,7 +208,7 @@ namespace SolastaCommunityExpansion.Viewers
                             UI.Label($"hit bonus: {attackIteration.MonsterAttackDefinition.ToHitBonus}".green(), UI.Width(108));
                             if (attackIteration.MonsterAttackDefinition.MaxUses < 0)
                             {
-                                UI.Label($"max uses: inf".green(), UI.Width(108));
+                                UI.Label("max uses: inf".green(), UI.Width(108));
                             }
                             else
                             {
@@ -216,7 +216,7 @@ namespace SolastaCommunityExpansion.Viewers
                             }
                             if (attackIteration.MonsterAttackDefinition.Magical)
                             {
-                                UI.Label($"MAGICAL".green(), UI.Width(108));
+                                UI.Label("MAGICAL".green(), UI.Width(108));
                             }
                         }
                     }

--- a/SolastaCommunityExpansion/Viewers/GameplayViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/GameplayViewer.cs
@@ -1,5 +1,5 @@
-﻿using ModKit;
-using System.Linq;
+﻿using System.Linq;
+using ModKit;
 using UnityEngine;
 using UnityModManagerNet;
 using static SolastaCommunityExpansion.Viewers.Displays.CampaignsAndLocationsDisplay;

--- a/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
@@ -153,9 +153,9 @@ namespace SolastaCommunityExpansion.Viewers
                 collectedString.Append("\n[line]\n");
                 collectedString.Append("[heading]Credits[/heading]\n[list]");
                 collectedString.Append("\n[*]Chris John Digital");
-                foreach (var kvp in Displays.CreditsDisplay.CreditsTable)
+                foreach (var kvp in CreditsTable)
                 {
-                    collectedString.Append("\n[*]" + kvp.Key + ": " + kvp.Value);
+                    collectedString.Append("\n[*]").Append(kvp.Key).Append(": ").Append(kvp.Value);
                 }
                 collectedString.Append("\n[/list]");
                 collectedString.Append("\nSource code on [url=https://github.com/ChrisPJohn/SolastaCommunityExpansion]GitHub[/url].");

--- a/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
+++ b/SolastaCommunityExpansion/Viewers/HelpAndCreditsViewer.cs
@@ -22,11 +22,9 @@ namespace SolastaCommunityExpansion.Viewers
             //AddDumpDescriptionToLogButton();
         }
 
-#pragma warning disable IDE0051 // Remove unused private members
-#pragma warning disable S1144 // Remove unused private members
+#pragma warning disable IDE0051, S1144, RCS1213 // Remove unused private members
         private static void AddDumpDescriptionToLogButton()
-#pragma warning restore IDE0051 // Remove unused private members
-#pragma warning restore S1144 // Remove unused private members
+#pragma warning restore IDE0051, S1144, RCS1213 // Remove unused private members
         {
             UI.ActionButton("Dump Description to Logs", () =>
             {


### PR DESCRIPTION
Pass 1:
Turn off warnings as errors for now until cleanup complete
Remove blank lines
Remove empty doc comments
Add static to class where necessary
Add const where necessary

Pass 2:
Add parentheses for clarity
Call method as extension method
Make builder instance properties readonly (easy ones)
Remove empty initializer (change {} to ())
Remove redundant .ToString()
Remove redundant parentheses
Rename local variables which hide fields with same name
Remove unnecessary interpolated string

Pass 3:
Optimize some LINQ calls
Simplify lazy initialization
Simplify logical negation
Use expression bodied lambda
Use readonly auto implemented property

Pass 4:
Use auto-implemented property
Use Count==0 instead of .Any()
User array index instead of ElementAt
Remove unnecessary null check
Avoid null refs

Pass 5:
Run VS cleanup - reorders usings, applies editor config preferences

Pass 6:
Simplify member access