### PR TITLE
CTRL-click only swaps main hand

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUi/Inventory/InventoryShortcutsPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Inventory/InventoryShortcutsPanelPatcher.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Inventory
+{
+    [HarmonyPatch(typeof(InventoryShortcutsPanel), "OnConfigurationSwitched")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class InventoryShortcutsPanel_OnConfigurationSwitched
+    {
+        private const int LIGHT_SOURCE = 2;
+
+        internal static void Prefix(InventoryShortcutsPanel __instance, int rank)
+        {
+            var isCtrlPressed = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            var characterInventory = __instance.GuiCharacter.RulesetCharacterHero.CharacterInventory;
+            var itemsConfigurations = characterInventory.WieldedItemsConfigurations;
+            var currentRank = characterInventory.CurrentConfiguration;
+
+            if (!Main.Settings.EnableCtrlClickOnlySwapsMainHand || !isCtrlPressed)
+            {
+                return;
+            }
+
+            if (!Main.Settings.EnableInventoryTertiaryEquipmentRow && (rank == LIGHT_SOURCE || currentRank == LIGHT_SOURCE))
+            {
+                return;
+            }
+
+            if (itemsConfigurations[rank].OffHandSlot.Disabled || itemsConfigurations[currentRank].OffHandSlot.Disabled)
+            {
+                return;
+            }
+
+            var equipedItem0 = itemsConfigurations[rank].OffHandSlot.EquipedItem;
+            var equipedItem1 = itemsConfigurations[currentRank].OffHandSlot.EquipedItem;
+
+            itemsConfigurations[rank].OffHandSlot.UnequipItem();
+            itemsConfigurations[currentRank].OffHandSlot.UnequipItem();
+            itemsConfigurations[rank].OffHandSlot.EquipItem(equipedItem1);
+            itemsConfigurations[currentRank].OffHandSlot.EquipItem(equipedItem0);
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
@@ -1,40 +1,60 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
-using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.Inventory
 {
-    [HarmonyPatch(typeof(InventoryShortcutsPanel), "OnConfigurationSwitched")]
+    [HarmonyPatch(typeof(RulesetInventory), "BuildSlots")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
-    internal static class InventoryShortcutsPanel_OnConfigurationSwitched
+    internal static class RulesetInventory_BuildSlots
     {
-        private const int LIGHT_SOURCE = 2;
-
-        internal static void Postfix(InventoryShortcutsPanel __instance, int rank)
+        internal static void Postfix(RulesetInventory __instance)
         {
-            var isCtrlPressed = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
-            var characterInventory = __instance.GuiCharacter.RulesetCharacterHero.CharacterInventory;
-
-            if (Main.Settings.EnableCtrlClickOnlySwapsMainHand && isCtrlPressed 
-                && rank < LIGHT_SOURCE && characterInventory.CurrentConfiguration < LIGHT_SOURCE)
+            if (!Main.Settings.EnableInventoryTertiaryEquipmentRow)
             {
-                var itemsConfigurations = characterInventory.WieldedItemsConfigurations;
-
-                if (itemsConfigurations.Count < 2 || itemsConfigurations[0].OffHandSlot.Disabled || itemsConfigurations[1].OffHandSlot.Disabled)
-                {
-                    return;
-                }
-
-                var equipedItem0 = itemsConfigurations[0].OffHandSlot.EquipedItem;
-                var equipedItem1 = itemsConfigurations[1].OffHandSlot.EquipedItem;
-
-                itemsConfigurations[0].OffHandSlot.UnequipItem();
-                itemsConfigurations[1].OffHandSlot.UnequipItem();
-                itemsConfigurations[0].OffHandSlot.EquipItem(equipedItem1);
-                itemsConfigurations[1].OffHandSlot.EquipItem(equipedItem0);
-
-                characterInventory.RefreshWieldedItemsConfigurations();
+                return;
             }
+
+            var tertiaryWieldedConfiguration = __instance.WieldedItemsConfigurations[EquipmentDefinitions.MaxWieldedItemsConfigurations - 1];
+
+            tertiaryWieldedConfiguration.MainHandSlot.Disabled = false;
+            tertiaryWieldedConfiguration.MainHandSlot.DisabledReason = RulesetInventorySlot.DisableReason.None;
+            tertiaryWieldedConfiguration.OffHandSlot.RestrictedItemTags.Clear();
+        }
+    }
+
+    [HarmonyPatch(typeof(RulesetInventory), "RefreshWieldedItemsConfigurations")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class RulesetInventory_RefreshWieldedItemsConfigurations
+    {
+        internal static void Postfix(RulesetInventory __instance)
+        {
+            if (!Main.Settings.EnableInventoryTertiaryEquipmentRow)
+            {
+                return;
+            }
+
+            var tertiaryWieldedConfiguration = __instance.WieldedItemsConfigurations[EquipmentDefinitions.MaxWieldedItemsConfigurations - 1];
+
+            tertiaryWieldedConfiguration.MainHandSlot.Disabled = false;
+            tertiaryWieldedConfiguration.MainHandSlot.ShadowedSlot = null;
+        }
+    }
+
+    [HarmonyPatch(typeof(RulesetInventory), "UpdateLightSourceConfigurations")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class RulesetInventory_UpdateLightSourceConfigurations
+    {
+        internal static void Postfix(RulesetInventory __instance)
+        {
+            if (!Main.Settings.EnableInventoryTertiaryEquipmentRow)
+            {
+                return;
+            }
+
+            var tertiaryWieldedConfiguration = __instance.WieldedItemsConfigurations[EquipmentDefinitions.MaxWieldedItemsConfigurations - 1];
+
+            tertiaryWieldedConfiguration.MainHandSlot.Disabled = false;
+            tertiaryWieldedConfiguration.MainHandSlot.ShadowedSlot = null;
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Inventory
+{
+    [HarmonyPatch(typeof(InventoryShortcutsPanel), "OnConfigurationSwitched")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class InventoryShortcutsPanel_OnConfigurationSwitched
+    {
+        private const int LIGHT_SOURCE = 2;
+
+        internal static void Postfix(InventoryShortcutsPanel __instance, int rank)
+        {
+            var isCtrlPressed = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            var characterInventory = __instance.GuiCharacter.RulesetCharacterHero.CharacterInventory;
+
+            if (Main.Settings.EnableCtrlClickOnlySwapsMainHand && isCtrlPressed 
+                && rank != characterInventory.CurrentConfiguration && rank < LIGHT_SOURCE && characterInventory.CurrentConfiguration < LIGHT_SOURCE)
+            {
+                var itemsConfigurations = characterInventory.WieldedItemsConfigurations;
+
+                if (itemsConfigurations.Count < 2 || itemsConfigurations[0].OffHandSlot.Disabled || itemsConfigurations[1].OffHandSlot.Disabled)
+                {
+                    return;
+                }
+
+                var equipedItem0 = itemsConfigurations[0].OffHandSlot.EquipedItem;
+                var equipedItem1 = itemsConfigurations[1].OffHandSlot.EquipedItem;
+
+                itemsConfigurations[0].OffHandSlot.UnequipItem();
+                itemsConfigurations[1].OffHandSlot.UnequipItem();
+                itemsConfigurations[0].OffHandSlot.EquipItem(equipedItem1);
+                itemsConfigurations[1].OffHandSlot.EquipItem(equipedItem0);
+
+                characterInventory.RefreshWieldedItemsConfigurations();
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Inventory/RulesetInventoryPatcher.cs
@@ -16,7 +16,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Inventory
             var characterInventory = __instance.GuiCharacter.RulesetCharacterHero.CharacterInventory;
 
             if (Main.Settings.EnableCtrlClickOnlySwapsMainHand && isCtrlPressed 
-                && rank != characterInventory.CurrentConfiguration && rank < LIGHT_SOURCE && characterInventory.CurrentConfiguration < LIGHT_SOURCE)
+                && rank < LIGHT_SOURCE && characterInventory.CurrentConfiguration < LIGHT_SOURCE)
             {
                 var itemsConfigurations = characterInventory.WieldedItemsConfigurations;
 

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -324,5 +324,6 @@ namespace SolastaCommunityExpansion
         public bool AltOnlyHighlightItemsInPartyFieldOfView { get; set; }
         public bool InvertAltBehaviorOnTooltips { get; set; }
         public bool EnableCtrlClickBypassMetamagicPanel { get; set; }
+        public bool EnableCtrlClickOnlySwapsMainHand { get; set; }
     }
 }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -301,6 +301,7 @@ namespace SolastaCommunityExpansion
 
         // Inventory and Items
         public bool EnableInventoryFilteringAndSorting { get; set; } = true;
+        public bool EnableInventoryTertiaryEquipmentRow { get; set; }
         public bool EnableInvisibleCrownOfTheMagister { get; set; }
         public string EmpressGarbAppearance { get; set; } = "Normal";
 

--- a/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/GameUiDisplay.cs
@@ -153,6 +153,13 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                     InventoryManagementContext.RefreshControlsVisibility();
                 }
 
+                toggle = Main.Settings.EnableInventoryTertiaryEquipmentRow;
+                if (UI.Toggle("Enable light source row as a tertiary equipment one", ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.EnableInventoryTertiaryEquipmentRow = toggle;
+                    InventoryManagementContext.RefreshControlsVisibility();
+                }
+
                 toggle = Main.Settings.EnableInvisibleCrownOfTheMagister;
                 if (UI.Toggle("Hide the " + "Crown of the Magister".orange() + " on game UI", ref toggle, UI.AutoWidth()))
                 {

--- a/SolastaCommunityExpansion/Viewers/Displays/HotKeysDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/HotKeysDisplay.cs
@@ -70,10 +70,18 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 Main.Settings.InvertAltBehaviorOnTooltips = toggle;
             }
 
+            UI.Label("");
+
             toggle = Main.Settings.EnableCtrlClickBypassMetamagicPanel;
             if (UI.Toggle("Enable " + "CTRL".cyan() + " click on spells to auto ignore " + "Sorcerer".orange() + " metamagic panel", ref toggle, UI.AutoWidth()))
             {
                 Main.Settings.EnableCtrlClickBypassMetamagicPanel = toggle;
+            }
+
+            toggle = Main.Settings.EnableCtrlClickOnlySwapsMainHand;
+            if (UI.Toggle("Enable " + "CTRL".cyan() + " click to keep off hand items when swapping wielded configurations", ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableCtrlClickOnlySwapsMainHand = toggle;
             }
             #endregion
 


### PR DESCRIPTION
CTRL-click when swapping weapon configurations will only swap main hand. This is in case you have a good shield and wanna only swap weapons keeping the same shield in hands. What really ends up happening is the off hand item moves from one wielded config to another...