### PR TITLE
Suggested improvement/simplification

### DIFF
--- a/SolastaCommunityExpansion/Builders/Category.cs
+++ b/SolastaCommunityExpansion/Builders/Category.cs
@@ -12,6 +12,7 @@
         Blueprint,
         CharacterFamily,
         Class,
+        CommunityExpansion,
         Condition,
         CraftyFeats,
         DamageAffinity,

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -236,6 +236,11 @@ namespace SolastaCommunityExpansion
         public bool DebugShowTADefinitionsWithMissingGuiPresentation { get; set; }
         public bool DebugLogDefinitionCreation { get; set; }
         public bool DebugLogFieldInitialization { get; set; }
+        public bool DebugDisableVerifyDefinitionNameIsNotInUse { get; set; }
+        public List<string> KnownDuplicateDefinitionNames { get; } = new()
+        {
+            "SummonProtectorConstruct"
+        };
 #if DEBUG
         public bool DebugShowCEDefinitionsWithMissingGuiPresentation { get; set; } = true;
         public bool DebugLogCEDefinitionsToFile { get; set; } = true;


### PR DESCRIPTION
Putting this up for consideration/discussion:

1) ensure all future definitions have a unique name, then we can
2) add simplified constructors that create a definition from name only

