### PR TITLE
Add Configure and builder type to BaseDefinitionBuilder: option3

### DIFF
--- a/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
@@ -102,7 +102,9 @@ namespace SolastaModApi
     ///     Base class builder for all classes derived from BaseDefinition
     /// </summary>
     /// <typeparam name="TDefinition"></typeparam>
-    public abstract class BaseDefinitionBuilder<TDefinition> : BaseDefinitionBuilder, IBaseDefinitionBuilder where TDefinition : BaseDefinition
+    public abstract class BaseDefinitionBuilder<TDefinition, TBuilder> : BaseDefinitionBuilder, IBaseDefinitionBuilder
+        where TBuilder : BaseDefinitionBuilder<TDefinition, TBuilder>
+        where TDefinition : BaseDefinition
     {
         #region Helpers
 
@@ -497,8 +499,7 @@ namespace SolastaModApi
 
         protected TDefinition Definition { get; }
 
-        internal TBuilder Configure<TBuilder>(Action<TDefinition> configureDefinition)
-            where TBuilder : BaseDefinitionBuilder<TDefinition>
+        internal TBuilder Configure(Action<TDefinition> configureDefinition)
         {
             Assert.IsNotNull(configureDefinition);
             configureDefinition.Invoke(Definition);

--- a/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
@@ -496,6 +496,14 @@ namespace SolastaModApi
         #endregion
 
         protected TDefinition Definition { get; }
+
+        internal TBuilder Configure<TBuilder>(Action<TDefinition> configureDefinition)
+            where TBuilder : BaseDefinitionBuilder<TDefinition>
+        {
+            Assert.IsNotNull(configureDefinition);
+            configureDefinition.Invoke(Definition);
+            return (TBuilder)this;
+        }
     }
 
     internal static class BaseDefinitionBuilderHelper

--- a/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
@@ -6,7 +6,7 @@ using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class ConditionDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : ConditionDefinition
+    public class ConditionDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition, ConditionDefinitionBuilder<TDefinition>> where TDefinition : ConditionDefinition
     {
         public ConditionDefinitionBuilder(string name, string guid, Action<TDefinition> modifyDefinition) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerBuilder.cs
@@ -4,7 +4,7 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower, FeatureDefinitionPowerBuilder>
     {
         public FeatureDefinitionPowerBuilder(string name, string guid, int usesPerRecharge, RuleDefinitions.UsesDetermination usesDetermination,
             string usesAbilityScoreName,

--- a/SolastaCommunityExpansion/Classes/Witch/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch/Witch.cs
@@ -376,10 +376,6 @@ namespace SolastaCommunityExpansion.Classes.Witch
                 .SetRecharge(RuleDefinitions.RechargeRate.AtWill)
                 .SetUsesFixed(1)
                 .SetEffect(abateEffectDescription)
-                .Configure<FeatureDefinitionPowerBuilder>(d =>
-                {
-
-                })
                 .AddToDB();
 
             // Apathy

--- a/SolastaCommunityExpansion/Classes/Witch/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch/Witch.cs
@@ -337,12 +337,15 @@ namespace SolastaCommunityExpansion.Classes.Witch
             var abateConditionDefinition = new ConditionDefinitionBuilder<ConditionDefinition>(
                 ConditionDefinitions.ConditionShocked, "ConditionAbate", WITCH_BASE_GUID)
                     .SetGuiPresentation("Abate", Category.Condition, ConditionDefinitions.ConditionShocked.GuiPresentation.SpriteReference)
-                    .AddToDB()
-                .SetConditionType(RuleDefinitions.ConditionType.Detrimental)
-                .SetDurationParameter(1)
-                .SetDurationType(RuleDefinitions.DurationType.Round)
-                .SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
-            abateConditionDefinition.ConditionTags.Add("Malediction");
+                    .Configure<ConditionDefinitionBuilder<ConditionDefinition>>(d =>
+                    {
+                        d.SetConditionType(RuleDefinitions.ConditionType.Detrimental);
+                        d.SetDurationParameter(1);
+                        d.SetDurationType(RuleDefinitions.DurationType.Round);
+                        d.SetTurnOccurence(RuleDefinitions.TurnOccurenceType.EndOfTurn);
+                        d.ConditionTags.Add("Malediction");
+                    })
+                    .AddToDB();
 
             var abateConditionForm = new ConditionForm()
                 .SetConditionDefinition(abateConditionDefinition);
@@ -373,6 +376,10 @@ namespace SolastaCommunityExpansion.Classes.Witch
                 .SetRecharge(RuleDefinitions.RechargeRate.AtWill)
                 .SetUsesFixed(1)
                 .SetEffect(abateEffectDescription)
+                .Configure<FeatureDefinitionPowerBuilder>(d =>
+                {
+
+                })
                 .AddToDB();
 
             // Apathy

--- a/SolastaCommunityExpansion/Classes/Witch/Witch.cs
+++ b/SolastaCommunityExpansion/Classes/Witch/Witch.cs
@@ -337,7 +337,7 @@ namespace SolastaCommunityExpansion.Classes.Witch
             var abateConditionDefinition = new ConditionDefinitionBuilder<ConditionDefinition>(
                 ConditionDefinitions.ConditionShocked, "ConditionAbate", WITCH_BASE_GUID)
                     .SetGuiPresentation("Abate", Category.Condition, ConditionDefinitions.ConditionShocked.GuiPresentation.SpriteReference)
-                    .Configure<ConditionDefinitionBuilder<ConditionDefinition>>(d =>
+                    .Configure(d =>
                     {
                         d.SetConditionType(RuleDefinitions.ConditionType.Detrimental);
                         d.SetDurationParameter(1);


### PR DESCRIPTION
Compared to #734 #735 this doesn't require any type params when using .Configure, but does require updating 200+ references to BaseDefinitionBuilder to pass in the parent class type.
I think I prefer option 2.