### PR TITLE
Move BaseDefinitionBuilder to DefinitionBuilder

### DIFF
--- a/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
@@ -37,8 +37,6 @@ namespace SolastaModApi
         /// </summary>
         /// <param name="name"></param>
         /// <param name="createGuiPresentation"></param>
-        /// 
-
         protected BaseDefinitionBuilder(string name, bool createGuiPresentation = true) : base(name, createGuiPresentation) { }
 
         /// <summary>
@@ -47,7 +45,6 @@ namespace SolastaModApi
         /// <param name="original"></param>
         /// <param name="name"></param>
         /// <param name="createGuiPresentation"></param>
-
         protected BaseDefinitionBuilder(TDefinition original, string name, bool createGuiPresentation = true) : base(original, name, createGuiPresentation) { }
 
         /// <summary>

--- a/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Api/BaseDefinitionBuilder.cs
@@ -1,169 +1,14 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using HarmonyLib;
-using SolastaCommunityExpansion;
 using SolastaCommunityExpansion.Builders;
-using SolastaModApi.Diagnostics;
-using SolastaModApi.Infrastructure;
-using UnityEngine;
 
 namespace SolastaModApi
 {
-    public abstract class BaseDefinitionBuilder
-    {
-        protected BaseDefinitionBuilder()
-        {
-        }
-
-        // NOTE: CreateGuid uses .ToString() which results in a guid of form b503ccb3-faac-4730-804c-d537bb61a582
-        public static string CreateGuid(Guid guid, string name)
-        {
-            return GuidHelper.Create(guid, name).ToString();
-        }
-
-        [Conditional("DEBUG")]
-        protected static void LogDefinition(string msg)
-        {
-            if (Main.Settings.DebugLogDefinitionCreation)
-            {
-                Main.Log(msg);
-            }
-        }
-
-        protected static void VerifyDefinitionNameIsNotInUse(string definitionTypeName, string definitionName)
-        {
-            if (Main.Settings.DebugDisableVerifyDefinitionNameIsNotInUse)
-            {
-                return;
-            }
-
-            // Verify name has not been used previously
-            // 1) get all names used in all TA databases (at this point) ignoring existing duplicates 
-            // 2) check 'name' hasn't been used already, but ignore names we know already have duplicates
-
-            if (Main.Settings.KnownDuplicateDefinitionNames.Contains(definitionName))
-            {
-                return;
-            }
-
-            if (definitionNames.TryGetValue(definitionName, out (string typeName, bool isCeDef) item))
-            {
-                var msg = Environment.NewLine +
-                    $"Adding definition of type '{definitionTypeName}' and name '{definitionName}'." +
-                    Environment.NewLine +
-                    $"A definition of type '{item.typeName} is already registered using the same name for a {(item.isCeDef ? "CE definition" : "Non-CE definition")}.";
-
-#if DEBUG
-                throw new SolastaModApiException(msg);
-#else
-                Main.Log(msg);
-#endif
-            }
-
-            definitionNames.Add(definitionName, (definitionTypeName, true));
-        }
-
-        private static Dictionary<string, (string typeName, bool isCeDef)> definitionNames { get; } = GetAllDefinitionNames();
-
-        private static Dictionary<string, (string typeName, bool isCeDef)> GetAllDefinitionNames()
-        {
-            var definitions = new Dictionary<string, (string typeName, bool isCeDef)>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var db in (Dictionary<Type, object>)AccessTools.Field(typeof(DatabaseRepository), "databases").GetValue(null))
-            {
-                foreach (var bd in (IEnumerable)db.Value)
-                {
-                    // Ignore duplicates in other (TA, other mods loaded first) definition names
-                    definitions.TryAdd(((BaseDefinition)bd).Name, (bd.GetType().Name, false));
-                }
-            }
-
-            return definitions;
-        }
-
-        protected const string CENamePrefix = "_CE_";
-        protected static readonly Guid CENamespaceGuid = new("4ce4cabe-0d35-4419-86ef-13ce1bef32fd");
-    }
-
-    // Used to allow extension methods in other mods to set GuiPresentation 
-    // Adding SetGuiPresentation as a public method causes name clash issues.
-    // Ok, could have used a different name...
-    public interface IBaseDefinitionBuilder
-    {
-        void SetGuiPresentation(GuiPresentation presentation);
-        string Name { get; }
-    }
-
     /// <summary>
-    ///     Base class builder for all classes derived from BaseDefinition
+    ///     Base class builder for all classes derived from BaseDefinition.  For public use by other mods.
     /// </summary>
     /// <typeparam name="TDefinition"></typeparam>
-    public abstract class BaseDefinitionBuilder<TDefinition> : BaseDefinitionBuilder, IBaseDefinitionBuilder where TDefinition : BaseDefinition
+    public abstract class BaseDefinitionBuilder<TDefinition> : DefinitionBuilder<TDefinition> where TDefinition : BaseDefinition
     {
-        #region Helpers
-
-        // Explicit implementation not visible by default so doesn't clash with other extension methods
-        void IBaseDefinitionBuilder.SetGuiPresentation(GuiPresentation presentation)
-        {
-            Definition.GuiPresentation = presentation;
-        }
-
-        // NOTE: don't use Definition?. which bypasses Unity object lifetime check
-        string IBaseDefinitionBuilder.Name => Definition ? (Definition.Name ?? string.Empty) : string.Empty;
-
-        private void InitializeCollectionFields()
-        {
-            Assert.IsNotNull(Definition);
-
-            InitializeCollectionFields(Definition.GetType());
-
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
-            void InitializeCollectionFields(Type type)
-            {
-                if (type == null || type == typeof(object) || type == typeof(BaseDefinition) || type == typeof(UnityEngine.Object))
-                {
-                    return;
-                }
-
-                // Reflection will only return private fields declared on this type, not base classes
-                foreach (var field in type
-                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-                    .Where(f => f.FieldType.IsGenericType)
-                    .Where(f => f.GetValue(Definition) == null))
-                {
-                    try
-                    {
-                        LogFieldInitialization($"Initializing field {field.Name} on Type={Definition.GetType().Name}, Name={Definition.Name}");
-
-                        field.SetValue(Definition, Activator.CreateInstance(field.FieldType));
-                    }
-                    catch (Exception ex)
-                    {
-                        Main.Error(ex);
-                    }
-                }
-
-                // So travel down the hierarchy
-                InitializeCollectionFields(type.BaseType);
-
-                [Conditional("DEBUG")]
-                static void LogFieldInitialization(string message)
-                {
-                    if (Main.Settings.DebugLogFieldInitialization)
-                    {
-                        Main.Log(message);
-                    }
-                }
-            }
-#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
-        }
-
-        #endregion
-
         #region Constructors
 
         /// <summary>
@@ -172,10 +17,8 @@ namespace SolastaModApi
         /// </summary>
         /// <param name="name">The name assigned to the definition (mandatory)</param>
         /// <param name="namespaceGuid">The base or namespace guid from which to generate a guid for this definition, based on baseGuid+name (mandatory)</param>
-        protected BaseDefinitionBuilder(string name, Guid namespaceGuid) :
-            this(name, null, namespaceGuid, true)
-        {
-        }
+        [Obsolete("Legacy support only.  Please use BaseDefinitionBuilder('name') for future development.")]
+        protected BaseDefinitionBuilder(string name, Guid namespaceGuid) : base(name, namespaceGuid) { }
 
         /// <summary>
         /// Create a new instance of TDefinition.  Assign the supplied guid as the definition guid.
@@ -183,11 +26,8 @@ namespace SolastaModApi
         /// </summary>
         /// <param name="name">The name assigned to the definition (mandatory)</param>
         /// <param name="definitionGuid">The guid for this definition (mandatory)</param>
-        protected BaseDefinitionBuilder(string name, string definitionGuid) :
-            this(name, definitionGuid, Guid.Empty, false)
-        {
-            Preconditions.IsNotNullOrWhiteSpace(definitionGuid, nameof(definitionGuid));
-        }
+        [Obsolete("Legacy support only.  Please use BaseDefinitionBuilder('name') for future development.")]
+        protected BaseDefinitionBuilder(string name, string definitionGuid) : base(name, definitionGuid) { }
 
         /// <summary>
         /// TODO: ... Create definition given 'name' only.
@@ -195,74 +35,20 @@ namespace SolastaModApi
         /// Guid = CreateGuid(name, CENamespaceGuid)
         /// GuiPresentation = CommunityExpansion/&{name}Title, CommunityExpansion/&{name}Description, but can be overridden.
         /// </summary>
-        /// <param name="original"></param>
         /// <param name="name"></param>
         /// <param name="createGuiPresentation"></param>
-        protected BaseDefinitionBuilder(string name, bool createGuiPresentation = true)
-            : this(CENamePrefix + name, null, CENamespaceGuid, true)
-        {
-            // If we know 'name' is unique across all dbs for definitions created by CE or mods using CE we can auto-generate
-            // the guid and the GuiPresentation
-            if (createGuiPresentation)
-            {
-                Definition.GuiPresentation = GuiPresentationBuilder.Build(name, Category.CommunityExpansion);
-            }
-        }
+        /// 
+
+        protected BaseDefinitionBuilder(string name, bool createGuiPresentation = true) : base(name, createGuiPresentation) { }
 
         /// <summary>
-        /// TODO: ...
+        /// TODO: ... comment
         /// </summary>
         /// <param name="original"></param>
         /// <param name="name"></param>
         /// <param name="createGuiPresentation"></param>
-        protected BaseDefinitionBuilder(TDefinition original, string name, bool createGuiPresentation = true)
-            : this(original, CENamePrefix + name, null, CENamespaceGuid, true)
-        {
-            // If we know 'name' is unique across all dbs for definitions created by CE or mods using CE we can auto-generate
-            // the guid and the GuiPresentation
-            if (createGuiPresentation)
-            {
-                Definition.GuiPresentation = GuiPresentationBuilder.Build(name, Category.CommunityExpansion);
-            }
-        }
 
-        // TODO: two very similar ctors - worth combining?
-        private BaseDefinitionBuilder(string name, string definitionGuid, Guid namespaceGuid, bool useNamespaceGuid)
-        {
-            Preconditions.IsNotNullOrWhiteSpace(name, nameof(name));
-
-            Definition = ScriptableObject.CreateInstance<TDefinition>();
-            Definition.name = name;
-
-            VerifyDefinitionNameIsNotInUse(Definition.GetType().Name, name);
-
-            InitializeCollectionFields();
-
-            if (useNamespaceGuid)
-            {
-                if (namespaceGuid == Guid.Empty)
-                {
-                    throw new SolastaModApiException("The namespace guid supplied is Guid.Empty.");
-                }
-
-                // create guid from namespace+name
-                Definition.SetField("guid", CreateGuid(namespaceGuid, name));
-
-                LogDefinition($"New-Creating definition: ({name}, namespace={namespaceGuid}, guid={Definition.GUID})");
-            }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(definitionGuid))
-                {
-                    throw new SolastaModApiException("The guid supplied is null or empty.");
-                }
-
-                // assign guid
-                Definition.SetField("guid", definitionGuid);
-
-                LogDefinition($"New-Creating definition: ({name}, guid={Definition.GUID})");
-            }
-        }
+        protected BaseDefinitionBuilder(TDefinition original, string name, bool createGuiPresentation = true) : base(original, name, createGuiPresentation) { }
 
         /// <summary>
         /// Create clone and rename. Automatically generate a guid from baseGuid plus name.
@@ -270,10 +56,8 @@ namespace SolastaModApi
         /// <param name="original">The definition being copied.</param>
         /// <param name="name">The name assigned to the definition (mandatory).</param>
         /// <param name="namespaceGuid">The base or namespace guid from which to generate a guid for this definition, based on baseGuid+name (mandatory).</param>
-        protected BaseDefinitionBuilder(TDefinition original, string name, Guid namespaceGuid) :
-            this(original, name, null, namespaceGuid, true)
-        {
-        }
+        [Obsolete("Legacy support only.  Please use BaseDefinitionBuilder(original, 'name') for future development.")]
+        protected BaseDefinitionBuilder(TDefinition original, string name, Guid namespaceGuid) : base(original, name, namespaceGuid) { }
 
         /// <summary>
         /// Create clone and rename. Assign the supplied guid as the definition guid.
@@ -282,239 +66,15 @@ namespace SolastaModApi
         /// <param name="original">The definition being copied.</param>
         /// <param name="name">The name assigned to the definition (mandatory).</param>
         /// <param name="definitionGuid">The guid for this definition (mandatory).</param>
-        protected BaseDefinitionBuilder(TDefinition original, string name, string definitionGuid) :
-            this(original, name, definitionGuid, Guid.Empty, false)
-        {
-        }
-
-        // TODO: two very similar ctors - worth combining?
-        private BaseDefinitionBuilder(TDefinition original, string name, string definitionGuid, Guid namespaceGuid, bool useNamespaceGuid)
-        {
-            Preconditions.IsNotNull(original, nameof(original));
-            Preconditions.IsNotNullOrWhiteSpace(name, nameof(name));
-
-            var originalName = original.name;
-            var originalGuid = original.GUID;
-
-            Definition = UnityEngine.Object.Instantiate(original);
-            Definition.name = name;
-
-            VerifyDefinitionNameIsNotInUse(Definition.GetType().Name, name);
-
-            InitializeCollectionFields();
-
-            if (useNamespaceGuid)
-            {
-                if (namespaceGuid == Guid.Empty)
-                {
-                    throw new ArgumentException("Please supply a non-empty Guid", nameof(namespaceGuid));
-                }
-
-                // create guid from namespace+name
-                Definition.SetField("guid", CreateGuid(namespaceGuid, name));
-
-                LogDefinition($"New-Cloning definition: original({originalName}, {originalGuid}) => ({name}, namespace={namespaceGuid}, {Definition.GUID})");
-            }
-            else
-            {
-                // directly assign guid
-                Definition.SetField("guid", definitionGuid);
-
-                LogDefinition($"New-Cloning definition: original({originalName}, {originalGuid}) => ({name}, {Definition.GUID})");
-            }
-        }
+        [Obsolete("Legacy support only.  Please use BaseDefinitionBuilder(original, 'name') for future development.")]
+        protected BaseDefinitionBuilder(TDefinition original, string name, string definitionGuid) : base(original, name, definitionGuid) { }
 
         /// <summary>
         /// Take ownership of a definition without changing the name or guid.
         /// </summary>
         /// <param name="original">The definition</param>
-        protected BaseDefinitionBuilder(TDefinition original)
-        {
-            Preconditions.IsNotNull(original, nameof(original));
-            Definition = original;
-        }
+        protected BaseDefinitionBuilder(TDefinition original) : base(original) { }
 
         #endregion
-
-        #region Add to dbs
-        /// <summary>
-        /// Add the TDefinition to every compatible database
-        /// </summary>
-        /// <param name="assertIfDuplicate"></param>
-        /// <returns></returns>
-        /// <exception cref="SolastaModApiException"></exception>
-        public TDefinition AddToDB(bool assertIfDuplicate = true)
-        {
-            Preconditions.IsNotNull(Definition, nameof(Definition));
-            Preconditions.IsNotNullOrWhiteSpace(Definition.Name, nameof(Definition.Name));
-            Preconditions.IsNotNullOrWhiteSpace(Definition.GUID, nameof(Definition.GUID));
-
-            if (!Guid.TryParse(Definition.GUID, out Guid guid))
-            {
-                throw new SolastaModApiException($"The string in Definition.GUID '{Definition.GUID}' is not a GUID.");
-            }
-
-            VerifyGuiPresentation();
-
-            // Get all base types for the target definition.  The definition needs to be added to all matching databases.
-            // e.g. ConditionAffinityBlindnessImmunity is added to dbs: FeatureDefinitionConditionAffinity, FeatureDefinitionAffinity, FeatureDefinition
-            var types = GetBaseTypes(Definition.GetType());
-
-            var addedToAnyDB = false;
-
-            foreach (var type in types)
-            {
-                if (AddToDB(type))
-                {
-                    addedToAnyDB = true;
-                }
-            }
-
-            if (!addedToAnyDB)
-            {
-                throw new SolastaModApiException(
-                    $"Unable to locate any database(s) matching definition type='{Definition.GetType().FullName}', name='{Definition.name}', guid='{Definition.GUID}'.");
-            }
-
-            LogDefinition($"Added to db: name={Definition.Name}, guid={Definition.GUID}");
-
-            return Definition;
-
-            bool AddToDB(Type type)
-            {
-                // attempt to get database matching the target type
-                var getDatabaseMethodInfoGeneric =
-                    BaseDefinitionBuilderHelper.GetDatabaseMethodInfo.MakeGenericMethod(type);
-
-                var db = getDatabaseMethodInfoGeneric.Invoke(null, null);
-
-                if (db == null)
-                {
-                    return false;
-                }
-
-                var dbType = db.GetType();
-
-                if (assertIfDuplicate)
-                {
-                    if (dbHasElement(Definition.name))
-                    {
-                        throw new SolastaModApiException(
-                            $"The definition with name '{Definition.name}' already exists in database '{type.Name}' by name.");
-                    }
-
-                    if (dbHasElementByGuid(Definition.GUID))
-                    {
-                        throw new SolastaModApiException(
-                            $"The definition with name '{Definition.name}' and guid '{Definition.GUID}' already exists in database '{type.Name}' by GUID.");
-                    }
-                }
-
-                addToDB();
-
-                return true;
-
-                void addToDB()
-                {
-                    var methodInfo = dbType.GetMethod("Add");
-
-                    if (methodInfo == null)
-                    {
-                        throw new SolastaModApiException($"Could not locate the 'Add' method for {dbType.FullName}.");
-                    }
-
-                    methodInfo.Invoke(db, new object[] { Definition });
-                }
-
-                bool dbHasElement(string name)
-                {
-                    var methodInfo = dbType.GetMethod("HasElement");
-
-                    if (methodInfo == null)
-                    {
-                        throw new SolastaModApiException(
-                            $"Could not locate the 'HasElement' method for {dbType.FullName}.");
-                    }
-
-                    return (bool)methodInfo.Invoke(db, new object[] { name });
-                }
-
-                bool dbHasElementByGuid(string guid)
-                {
-                    var methodInfo = dbType.GetMethod("HasElementByGuid");
-
-                    if (methodInfo == null)
-                    {
-                        throw new SolastaModApiException(
-                            $"Could not locate the 'HasElementByGuid' method for {dbType.FullName}.");
-                    }
-
-                    return (bool)methodInfo.Invoke(db, new object[] { guid });
-                }
-            }
-
-            // Get list of base types down to but not including BaseDefinition.  
-            IEnumerable<Type> GetBaseTypes(Type t)
-            {
-                if (t.BaseType != typeof(object) && t != typeof(BaseDefinition))
-                {
-                    return Enumerable.Repeat(t, 1).Concat(GetBaseTypes(t.BaseType));
-                }
-                else
-                {
-                    return Enumerable.Empty<Type>();
-                }
-            }
-
-            void VerifyGuiPresentation()
-            {
-                if (Definition.GuiPresentation == null)
-                {
-                    Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation, setting to NoContent.");
-
-                    Definition.GuiPresentation = GuiPresentationBuilder.NoContent;
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(Definition.GuiPresentation.Title))
-                    {
-                        Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation.Title, setting to NoContent.");
-
-                        Definition.GuiPresentation.Title = GuiPresentationBuilder.NoContentTitle;
-                    }
-
-                    if (string.IsNullOrEmpty(Definition.GuiPresentation.Description))
-                    {
-                        Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation.Description, setting to NoContent.");
-
-                        Definition.GuiPresentation.Description = GuiPresentationBuilder.NoContentDescription;
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        protected TDefinition Definition { get; }
-
-        internal TBuilder Configure<TBuilder>(Action<TDefinition> configureDefinition)
-            where TBuilder : BaseDefinitionBuilder<TDefinition>
-        {
-            Assert.IsNotNull(configureDefinition);
-            configureDefinition.Invoke(Definition);
-
-            if (typeof(TBuilder) != GetType())
-            {
-                throw new SolastaModApiException($"Error in Configure. TBuilder={typeof(TBuilder).Name}, this={GetType().Name}");
-            }
-
-            return (TBuilder)this;
-        }
-    }
-
-    internal static class BaseDefinitionBuilderHelper
-    {
-        public static readonly MethodInfo GetDatabaseMethodInfo =
-            typeof(DatabaseRepository).GetMethod("GetDatabase", BindingFlags.Public | BindingFlags.Static);
     }
 }

--- a/SolastaCommunityExpansion/Builders/CancelConditionPowerBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CancelConditionPowerBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    internal class CancelConditionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class CancelConditionPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         public CancelConditionPowerBuilder(string name, string guid, GuiPresentation presentation, ConditionDefinition condition) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterClassDefinitionBuilder.cs
@@ -10,7 +10,7 @@ using static CharacterClassDefinition;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public sealed class CharacterClassDefinitionBuilder : BaseDefinitionBuilder<CharacterClassDefinition>
+    public sealed class CharacterClassDefinitionBuilder : DefinitionBuilder<CharacterClassDefinition>
     {
         #region Constructors
         private CharacterClassDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/CharacterSubclassDefinitionBuilder.cs
@@ -4,7 +4,7 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class CharacterSubclassDefinitionBuilder : BaseDefinitionBuilder<CharacterSubclassDefinition>
+    public class CharacterSubclassDefinitionBuilder : DefinitionBuilder<CharacterSubclassDefinition>
     {
         public CharacterSubclassDefinitionBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public abstract class ConditionDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : ConditionDefinition
+    public abstract class ConditionDefinitionBuilder<TDefinition> : DefinitionBuilder<TDefinition> where TDefinition : ConditionDefinition
     {
         protected ConditionDefinitionBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/ConditionDefinitionBuilder.cs
@@ -49,22 +49,22 @@ namespace SolastaCommunityExpansion.Builders
 
     public class ConditionDefinitionBuilder : ConditionDefinitionBuilder<ConditionDefinition>
     {
-        private ConditionDefinitionBuilder(string name, string guid)
+        protected ConditionDefinitionBuilder(string name, string guid)
             : base(name, guid)
         {
         }
 
-        private ConditionDefinitionBuilder(string name, Guid guidNamespace)
+        protected ConditionDefinitionBuilder(string name, Guid guidNamespace)
             : base(name, guidNamespace)
         {
         }
 
-        private ConditionDefinitionBuilder(ConditionDefinition original, string name, string guid)
+        protected ConditionDefinitionBuilder(ConditionDefinition original, string name, string guid)
             : base(original, name, guid)
         {
         }
 
-        private ConditionDefinitionBuilder(ConditionDefinition original, string name, Guid guidNamespace)
+        protected ConditionDefinitionBuilder(ConditionDefinition original, string name, Guid guidNamespace)
             : base(original, name, guidNamespace)
         {
         }

--- a/SolastaCommunityExpansion/Builders/DefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/DefinitionBuilder.cs
@@ -1,0 +1,518 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using SolastaModApi;
+using SolastaModApi.Diagnostics;
+using SolastaModApi.Infrastructure;
+using UnityEngine;
+
+namespace SolastaCommunityExpansion.Builders
+{
+    public abstract class DefinitionBuilder
+    {
+        protected DefinitionBuilder()
+        {
+        }
+
+        // NOTE: CreateGuid uses .ToString() which results in a guid of form b503ccb3-faac-4730-804c-d537bb61a582
+        public static string CreateGuid(Guid guid, string name)
+        {
+            return GuidHelper.Create(guid, name).ToString();
+        }
+
+        [Conditional("DEBUG")]
+        protected static void LogDefinition(string msg)
+        {
+            if (Main.Settings.DebugLogDefinitionCreation)
+            {
+                Main.Log(msg);
+            }
+        }
+
+        protected static void VerifyDefinitionNameIsNotInUse(string definitionTypeName, string definitionName)
+        {
+            if (Main.Settings.DebugDisableVerifyDefinitionNameIsNotInUse)
+            {
+                return;
+            }
+
+            // Verify name has not been used previously
+            // 1) get all names used in all TA databases (at this point) ignoring existing duplicates 
+            // 2) check 'name' hasn't been used already, but ignore names we know already have duplicates
+
+            if (Main.Settings.KnownDuplicateDefinitionNames.Contains(definitionName))
+            {
+                return;
+            }
+
+            if (definitionNames.TryGetValue(definitionName, out var item))
+            {
+                var msg = Environment.NewLine +
+                    $"Adding definition of type '{definitionTypeName}' and name '{definitionName}'." +
+                    Environment.NewLine +
+                    $"A definition of type '{item.typeName} is already registered using the same name for a {(item.isCeDef ? "CE definition" : "Non-CE definition")}.";
+
+#if DEBUG
+                throw new SolastaModApiException(msg);
+#else
+                Main.Log(msg);
+#endif
+            }
+
+            definitionNames.Add(definitionName, (definitionTypeName, true));
+        }
+
+        private static Dictionary<string, (string typeName, bool isCeDef)> definitionNames { get; } = GetAllDefinitionNames();
+
+        private static Dictionary<string, (string typeName, bool isCeDef)> GetAllDefinitionNames()
+        {
+            var definitions = new Dictionary<string, (string typeName, bool isCeDef)>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var db in (Dictionary<Type, object>)AccessTools.Field(typeof(DatabaseRepository), "databases").GetValue(null))
+            {
+                foreach (var bd in (IEnumerable)db.Value)
+                {
+                    // Ignore duplicates in other (TA, other mods loaded first) definition names
+                    definitions.TryAdd(((BaseDefinition)bd).Name, (bd.GetType().Name, false));
+                }
+            }
+
+            return definitions;
+        }
+
+        protected const string CENamePrefix = "_CE_";
+        protected static readonly Guid CENamespaceGuid = new("4ce4cabe-0d35-4419-86ef-13ce1bef32fd");
+    }
+
+    // Used to allow extension methods in other mods to set GuiPresentation 
+    // Adding SetGuiPresentation as a public method causes name clash issues.
+    // Ok, could have used a different name...
+    internal interface IDefinitionBuilder
+    {
+        void SetGuiPresentation(GuiPresentation presentation);
+        string Name { get; }
+    }
+
+    /// <summary>
+    ///     Base class builder for all classes derived from BaseDefinition (for internal use only)
+    /// </summary>
+    /// <typeparam name="TDefinition"></typeparam>
+    public abstract class DefinitionBuilder<TDefinition> : DefinitionBuilder, IDefinitionBuilder where TDefinition : BaseDefinition
+    {
+        #region Helpers
+
+        // Explicit implementation not visible by default so doesn't clash with other extension methods
+        void IDefinitionBuilder.SetGuiPresentation(GuiPresentation presentation)
+        {
+            Definition.GuiPresentation = presentation;
+        }
+
+        // NOTE: don't use Definition?. which bypasses Unity object lifetime check
+        string IDefinitionBuilder.Name => Definition ? Definition.Name ?? string.Empty : string.Empty;
+
+        private void InitializeCollectionFields()
+        {
+            Assert.IsNotNull(Definition);
+
+            InitializeCollectionFields(Definition.GetType());
+
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+            void InitializeCollectionFields(Type type)
+            {
+                if (type == null || type == typeof(object) || type == typeof(BaseDefinition) || type == typeof(UnityEngine.Object))
+                {
+                    return;
+                }
+
+                // Reflection will only return private fields declared on this type, not base classes
+                foreach (var field in type
+                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                    .Where(f => f.FieldType.IsGenericType)
+                    .Where(f => f.GetValue(Definition) == null))
+                {
+                    try
+                    {
+                        LogFieldInitialization($"Initializing field {field.Name} on Type={Definition.GetType().Name}, Name={Definition.Name}");
+
+                        field.SetValue(Definition, Activator.CreateInstance(field.FieldType));
+                    }
+                    catch (Exception ex)
+                    {
+                        Main.Error(ex);
+                    }
+                }
+
+                // So travel down the hierarchy
+                InitializeCollectionFields(type.BaseType);
+
+                [Conditional("DEBUG")]
+                static void LogFieldInitialization(string message)
+                {
+                    if (Main.Settings.DebugLogFieldInitialization)
+                    {
+                        Main.Log(message);
+                    }
+                }
+            }
+#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Create a new instance of TDefinition.  Automatically generate a guid from namespaceGuid plus name.
+        /// Assign a GuiPresentation with a generated title key and description key.
+        /// </summary>
+        /// <param name="name">The name assigned to the definition (mandatory)</param>
+        /// <param name="namespaceGuid">The base or namespace guid from which to generate a guid for this definition, based on baseGuid+name (mandatory)</param>
+        private protected DefinitionBuilder(string name, Guid namespaceGuid) :
+            this(name, null, namespaceGuid, true)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of TDefinition.  Assign the supplied guid as the definition guid.
+        /// Assigns a GuiPresentation with a generated title key and description key.
+        /// </summary>
+        /// <param name="name">The name assigned to the definition (mandatory)</param>
+        /// <param name="definitionGuid">The guid for this definition (mandatory)</param>
+        private protected DefinitionBuilder(string name, string definitionGuid) :
+            this(name, definitionGuid, Guid.Empty, false)
+        {
+            Preconditions.IsNotNullOrWhiteSpace(definitionGuid, nameof(definitionGuid));
+        }
+
+        /// <summary>
+        /// TODO: ... Create definition given 'name' only.
+        /// Name = _CE_{name}
+        /// Guid = CreateGuid(name, CENamespaceGuid)
+        /// GuiPresentation = CommunityExpansion/&{name}Title, CommunityExpansion/&{name}Description, but can be overridden.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="createGuiPresentation"></param>
+        private protected DefinitionBuilder(string name, bool createGuiPresentation = true)
+            : this(CENamePrefix + name, null, CENamespaceGuid, true)
+        {
+            // If we know 'name' is unique across all dbs for definitions created by CE or mods using CE we can auto-generate
+            // the guid and the GuiPresentation
+            if (createGuiPresentation)
+            {
+                Definition.GuiPresentation = GuiPresentationBuilder.Build(name, Category.CommunityExpansion);
+            }
+        }
+
+        /// <summary>
+        /// TODO: ...
+        /// </summary>
+        /// <param name="original"></param>
+        /// <param name="name"></param>
+        /// <param name="createGuiPresentation"></param>
+        private protected DefinitionBuilder(TDefinition original, string name, bool createGuiPresentation = true)
+            : this(original, CENamePrefix + name, null, CENamespaceGuid, true)
+        {
+            // If we know 'name' is unique across all dbs for definitions created by CE or mods using CE we can auto-generate
+            // the guid and the GuiPresentation
+            if (createGuiPresentation)
+            {
+                Definition.GuiPresentation = GuiPresentationBuilder.Build(name, Category.CommunityExpansion);
+            }
+        }
+
+        // TODO: two very similar ctors - worth combining?
+        private DefinitionBuilder(string name, string definitionGuid, Guid namespaceGuid, bool useNamespaceGuid)
+        {
+            Preconditions.IsNotNullOrWhiteSpace(name, nameof(name));
+
+            Definition = ScriptableObject.CreateInstance<TDefinition>();
+            Definition.name = name;
+
+            VerifyDefinitionNameIsNotInUse(Definition.GetType().Name, name);
+
+            InitializeCollectionFields();
+
+            if (useNamespaceGuid)
+            {
+                if (namespaceGuid == Guid.Empty)
+                {
+                    throw new SolastaModApiException("The namespace guid supplied is Guid.Empty.");
+                }
+
+                // create guid from namespace+name
+                Definition.SetField("guid", CreateGuid(namespaceGuid, name));
+
+                LogDefinition($"New-Creating definition: ({name}, namespace={namespaceGuid}, guid={Definition.GUID})");
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(definitionGuid))
+                {
+                    throw new SolastaModApiException("The guid supplied is null or empty.");
+                }
+
+                // assign guid
+                Definition.SetField("guid", definitionGuid);
+
+                LogDefinition($"New-Creating definition: ({name}, guid={Definition.GUID})");
+            }
+        }
+
+        /// <summary>
+        /// Create clone and rename. Automatically generate a guid from baseGuid plus name.
+        /// </summary>
+        /// <param name="original">The definition being copied.</param>
+        /// <param name="name">The name assigned to the definition (mandatory).</param>
+        /// <param name="namespaceGuid">The base or namespace guid from which to generate a guid for this definition, based on baseGuid+name (mandatory).</param>
+        private protected DefinitionBuilder(TDefinition original, string name, Guid namespaceGuid) :
+            this(original, name, null, namespaceGuid, true)
+        {
+        }
+
+        /// <summary>
+        /// Create clone and rename. Assign the supplied guid as the definition guid.
+        /// Assigns a GuiPresentation with a generated title key and description key.
+        /// </summary>
+        /// <param name="original">The definition being copied.</param>
+        /// <param name="name">The name assigned to the definition (mandatory).</param>
+        /// <param name="definitionGuid">The guid for this definition (mandatory).</param>
+        private protected DefinitionBuilder(TDefinition original, string name, string definitionGuid) :
+            this(original, name, definitionGuid, Guid.Empty, false)
+        {
+        }
+
+        // TODO: two very similar ctors - worth combining?
+        private DefinitionBuilder(TDefinition original, string name, string definitionGuid, Guid namespaceGuid, bool useNamespaceGuid)
+        {
+            Preconditions.IsNotNull(original, nameof(original));
+            Preconditions.IsNotNullOrWhiteSpace(name, nameof(name));
+
+            var originalName = original.name;
+            var originalGuid = original.GUID;
+
+            Definition = UnityEngine.Object.Instantiate(original);
+            Definition.name = name;
+
+            VerifyDefinitionNameIsNotInUse(Definition.GetType().Name, name);
+
+            InitializeCollectionFields();
+
+            if (useNamespaceGuid)
+            {
+                if (namespaceGuid == Guid.Empty)
+                {
+                    throw new ArgumentException("Please supply a non-empty Guid", nameof(namespaceGuid));
+                }
+
+                // create guid from namespace+name
+                Definition.SetField("guid", CreateGuid(namespaceGuid, name));
+
+                LogDefinition($"New-Cloning definition: original({originalName}, {originalGuid}) => ({name}, namespace={namespaceGuid}, {Definition.GUID})");
+            }
+            else
+            {
+                // directly assign guid
+                Definition.SetField("guid", definitionGuid);
+
+                LogDefinition($"New-Cloning definition: original({originalName}, {originalGuid}) => ({name}, {Definition.GUID})");
+            }
+        }
+
+        /// <summary>
+        /// Take ownership of a definition without changing the name or guid.
+        /// </summary>
+        /// <param name="original">The definition</param>
+        private protected DefinitionBuilder(TDefinition original)
+        {
+            Preconditions.IsNotNull(original, nameof(original));
+            Definition = original;
+        }
+
+        #endregion
+
+        #region Add to dbs
+        /// <summary>
+        /// Add the TDefinition to every compatible database
+        /// </summary>
+        /// <param name="assertIfDuplicate"></param>
+        /// <returns></returns>
+        /// <exception cref="SolastaModApiException"></exception>
+        public TDefinition AddToDB(bool assertIfDuplicate = true)
+        {
+            Preconditions.IsNotNull(Definition, nameof(Definition));
+            Preconditions.IsNotNullOrWhiteSpace(Definition.Name, nameof(Definition.Name));
+            Preconditions.IsNotNullOrWhiteSpace(Definition.GUID, nameof(Definition.GUID));
+
+            if (!Guid.TryParse(Definition.GUID, out var guid))
+            {
+                throw new SolastaModApiException($"The string in Definition.GUID '{Definition.GUID}' is not a GUID.");
+            }
+
+            VerifyGuiPresentation();
+
+            // Get all base types for the target definition.  The definition needs to be added to all matching databases.
+            // e.g. ConditionAffinityBlindnessImmunity is added to dbs: FeatureDefinitionConditionAffinity, FeatureDefinitionAffinity, FeatureDefinition
+            var types = GetBaseTypes(Definition.GetType());
+
+            var addedToAnyDB = false;
+
+            foreach (var type in types)
+            {
+                if (AddToDB(type))
+                {
+                    addedToAnyDB = true;
+                }
+            }
+
+            if (!addedToAnyDB)
+            {
+                throw new SolastaModApiException(
+                    $"Unable to locate any database(s) matching definition type='{Definition.GetType().FullName}', name='{Definition.name}', guid='{Definition.GUID}'.");
+            }
+
+            LogDefinition($"Added to db: name={Definition.Name}, guid={Definition.GUID}");
+
+            return Definition;
+
+            bool AddToDB(Type type)
+            {
+                // attempt to get database matching the target type
+                var getDatabaseMethodInfoGeneric =
+                    BaseDefinitionBuilderHelper.GetDatabaseMethodInfo.MakeGenericMethod(type);
+
+                var db = getDatabaseMethodInfoGeneric.Invoke(null, null);
+
+                if (db == null)
+                {
+                    return false;
+                }
+
+                var dbType = db.GetType();
+
+                if (assertIfDuplicate)
+                {
+                    if (dbHasElement(Definition.name))
+                    {
+                        throw new SolastaModApiException(
+                            $"The definition with name '{Definition.name}' already exists in database '{type.Name}' by name.");
+                    }
+
+                    if (dbHasElementByGuid(Definition.GUID))
+                    {
+                        throw new SolastaModApiException(
+                            $"The definition with name '{Definition.name}' and guid '{Definition.GUID}' already exists in database '{type.Name}' by GUID.");
+                    }
+                }
+
+                addToDB();
+
+                return true;
+
+                void addToDB()
+                {
+                    var methodInfo = dbType.GetMethod("Add");
+
+                    if (methodInfo == null)
+                    {
+                        throw new SolastaModApiException($"Could not locate the 'Add' method for {dbType.FullName}.");
+                    }
+
+                    methodInfo.Invoke(db, new object[] { Definition });
+                }
+
+                bool dbHasElement(string name)
+                {
+                    var methodInfo = dbType.GetMethod("HasElement");
+
+                    if (methodInfo == null)
+                    {
+                        throw new SolastaModApiException(
+                            $"Could not locate the 'HasElement' method for {dbType.FullName}.");
+                    }
+
+                    return (bool)methodInfo.Invoke(db, new object[] { name });
+                }
+
+                bool dbHasElementByGuid(string guid)
+                {
+                    var methodInfo = dbType.GetMethod("HasElementByGuid");
+
+                    if (methodInfo == null)
+                    {
+                        throw new SolastaModApiException(
+                            $"Could not locate the 'HasElementByGuid' method for {dbType.FullName}.");
+                    }
+
+                    return (bool)methodInfo.Invoke(db, new object[] { guid });
+                }
+            }
+
+            // Get list of base types down to but not including BaseDefinition.  
+            IEnumerable<Type> GetBaseTypes(Type t)
+            {
+                if (t.BaseType != typeof(object) && t != typeof(BaseDefinition))
+                {
+                    return Enumerable.Repeat(t, 1).Concat(GetBaseTypes(t.BaseType));
+                }
+                else
+                {
+                    return Enumerable.Empty<Type>();
+                }
+            }
+
+            void VerifyGuiPresentation()
+            {
+                if (Definition.GuiPresentation == null)
+                {
+                    Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation, setting to NoContent.");
+
+                    Definition.GuiPresentation = GuiPresentationBuilder.NoContent;
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(Definition.GuiPresentation.Title))
+                    {
+                        Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation.Title, setting to NoContent.");
+
+                        Definition.GuiPresentation.Title = GuiPresentationBuilder.NoContentTitle;
+                    }
+
+                    if (string.IsNullOrEmpty(Definition.GuiPresentation.Description))
+                    {
+                        Main.Log($"Verify GuiPresentation: {Definition.GetType().Name}({Definition.Name}) has no GuiPresentation.Description, setting to NoContent.");
+
+                        Definition.GuiPresentation.Description = GuiPresentationBuilder.NoContentDescription;
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        protected TDefinition Definition { get; }
+
+        internal TBuilder Configure<TBuilder>(Action<TDefinition> configureDefinition)
+            where TBuilder : DefinitionBuilder<TDefinition>
+        {
+            Assert.IsNotNull(configureDefinition);
+            configureDefinition.Invoke(Definition);
+
+            if (typeof(TBuilder) != GetType())
+            {
+                throw new SolastaModApiException($"Error in Configure. TBuilder={typeof(TBuilder).Name}, this={GetType().Name}");
+            }
+
+            return (TBuilder)this;
+        }
+    }
+
+    internal static class BaseDefinitionBuilderHelper
+    {
+        public static readonly MethodInfo GetDatabaseMethodInfo =
+            typeof(DatabaseRepository).GetMethod("GetDatabase", BindingFlags.Public | BindingFlags.Static);
+    }
+}

--- a/SolastaCommunityExpansion/Builders/EffectProxyDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/EffectProxyDefinitionBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class EffectProxyDefinitionBuilder : BaseDefinitionBuilder<EffectProxyDefinition>
+    public class EffectProxyDefinitionBuilder : DefinitionBuilder<EffectProxyDefinition>
     {
         public EffectProxyDefinitionBuilder(string name, string guid) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/FeatDefinitionBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public sealed class FeatDefinitionBuilder : BaseDefinitionBuilder<FeatDefinition>
+    public sealed class FeatDefinitionBuilder : DefinitionBuilder<FeatDefinition>
     {
         private FeatDefinitionBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAbilityCheckAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAbilityCheckAffinityBuilder.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
+    public sealed class FeatureDefinitionAbilityCheckAffinityBuilder : DefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
     {
         private FeatureDefinitionAbilityCheckAffinityBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionActionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionActionAffinityBuilder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionActionAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+    public sealed class FeatureDefinitionActionAffinityBuilder : DefinitionBuilder<FeatureDefinitionActionAffinity>
     {
         /*        private FeatureDefinitionActionAffinityBuilder(string name, string guid)
                     : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAdditionalActionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAdditionalActionBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionAdditionalActionBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalAction>
+    public sealed class FeatureDefinitionAdditionalActionBuilder : DefinitionBuilder<FeatureDefinitionAdditionalAction>
     {
         private FeatureDefinitionAdditionalActionBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAdditionalDamageBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAdditionalDamageBuilder.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using UnityEngine.AddressableAssets;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public class FeatureDefinitionAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+    public class FeatureDefinitionAdditionalDamageBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
     {
         /*
         private FeatureDefinitionAdditionalDamageBuilder(string name, string guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAttributeModifierBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAttributeModifierBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using static FeatureDefinitionAttributeModifier;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionAttributeModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+    public sealed class FeatureDefinitionAttributeModifierBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
     {
         private FeatureDefinitionAttributeModifierBuilder(FeatureDefinitionAttributeModifier original, string name, string guid)
             : base(original, name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAutoPreparedSpellsBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionAutoPreparedSpellsBuilder.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using static FeatureDefinitionAutoPreparedSpells;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionAutoPreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+    public sealed class FeatureDefinitionAutoPreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
         /*
         private FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionBonusCantripsBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionBonusCantripsBuilder.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionBonusCantripsBuilder : BaseDefinitionBuilder<FeatureDefinitionBonusCantrips>
+    public sealed class FeatureDefinitionBonusCantripsBuilder : DefinitionBuilder<FeatureDefinitionBonusCantrips>
     {
         /*        private FeatureDefinitionBonusCantripsBuilder(string name, string guid)
                     : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionBuilder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionBuilder<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : FeatureDefinition
+    public sealed class FeatureDefinitionBuilder<TDefinition> : DefinitionBuilder<TDefinition> where TDefinition : FeatureDefinition
     {
         #region Standard constructors
         private FeatureDefinitionBuilder(string name, string guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionCastSpellBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionCastSpellBuilder.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Diagnostics;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionCastSpellBuilder : BaseDefinitionBuilder<FeatureDefinitionCastSpell>
+    public sealed class FeatureDefinitionCastSpellBuilder : DefinitionBuilder<FeatureDefinitionCastSpell>
     {
         public enum CasterProgression
         {

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionConditionAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionConditionAffinityBuilder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionConditionAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionConditionAffinity>
+    public sealed class FeatureDefinitionConditionAffinityBuilder : DefinitionBuilder<FeatureDefinitionConditionAffinity>
     {
         private FeatureDefinitionConditionAffinityBuilder(FeatureDefinitionConditionAffinity original, string name, Guid namespaceGuid)
             : base(original, name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionConditionalPowerBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionConditionalPowerBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionConditionalPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionConditionalPower>
+    public sealed class FeatureDefinitionConditionalPowerBuilder : DefinitionBuilder<FeatureDefinitionConditionalPower>
     {
         private FeatureDefinitionConditionalPowerBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionDamageAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionDamageAffinityBuilder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionDamageAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionDamageAffinity>
+    public sealed class FeatureDefinitionDamageAffinityBuilder : DefinitionBuilder<FeatureDefinitionDamageAffinity>
     {
         /*        private FeatureDefinitionDamageAffinityBuilder(string name, string guid)
                     : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionDieRollModifierBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionDieRollModifierBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionDieRollModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionDieRollModifier>
+    public sealed class FeatureDefinitionDieRollModifierBuilder : DefinitionBuilder<FeatureDefinitionDieRollModifier>
     {
         private FeatureDefinitionDieRollModifierBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionFeatureSetBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionFeatureSetBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    public sealed class FeatureDefinitionFeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         /*        private FeatureDefinitionFeatureSetBuilder(string name, string guid)
                     : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionMagicAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionMagicAffinityBuilder.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public class FeatureDefinitionMagicAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionMagicAffinity>
+    public class FeatureDefinitionMagicAffinityBuilder : DefinitionBuilder<FeatureDefinitionMagicAffinity>
     {
         // TODO this is not yet complete, also I'm unsure the current groupings are the best set.
         public FeatureDefinitionMagicAffinityBuilder(string name, string guid, GuiPresentation guiPresentation)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionOnAttackHitEffectBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionOnAttackHitEffectBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionOnAttackHitEffectBuilder : BaseDefinitionBuilder<FeatureDefinitionOnAttackHitEffect>
+    public sealed class FeatureDefinitionOnAttackHitEffectBuilder : DefinitionBuilder<FeatureDefinitionOnAttackHitEffect>
     {
         private FeatureDefinitionOnAttackHitEffectBuilder(string name, Guid namespaceGuid)
             : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPointPoolBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPointPoolBuilder.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionPointPoolBuilder : BaseDefinitionBuilder<FeatureDefinitionPointPool>
+    public sealed class FeatureDefinitionPointPoolBuilder : DefinitionBuilder<FeatureDefinitionPointPool>
     {
         /*        private FeatureDefinitionPointPoolBuilder(FeatureDefinitionPointPool original, string name, string guid)
                     : base(original, name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerBuilder.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    public class FeatureDefinitionPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         public FeatureDefinitionPowerBuilder(string name, string guid, int usesPerRecharge, RuleDefinitions.UsesDetermination usesDetermination,
             string usesAbilityScoreName,

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerSharedPoolBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionPowerSharedPoolBuilder.cs
@@ -1,5 +1,5 @@
-﻿using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
@@ -8,7 +8,7 @@ namespace SolastaCommunityExpansion.Builders.Features
      * Note if you want to use a modifier for the power pool later you should set uses determination
      * to fixed or ability bonus plus fixed.
      */
-    public class FeatureDefinitionPowerPoolBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    public class FeatureDefinitionPowerPoolBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         public FeatureDefinitionPowerPoolBuilder(string name, string guid, int usesPerRecharge,
             RuleDefinitions.UsesDetermination usesDetermination, string usesAbilityScoreName,
@@ -35,7 +35,7 @@ namespace SolastaCommunityExpansion.Builders.Features
      * the hero and only one power for a given name+guid is added. Which means if you want to add a +1 modifier
      * at 4 different character levels you need to create 4 different FeatureDefinitionPowerPoolModifier.
      */
-    public class FeatureDefinitionPowerPoolModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionPowerPoolModifier>
+    public class FeatureDefinitionPowerPoolModifierBuilder : DefinitionBuilder<FeatureDefinitionPowerPoolModifier>
     {
         public FeatureDefinitionPowerPoolModifierBuilder(string name, string guid,
             int powerPoolModifier, RuleDefinitions.UsesDetermination usesDetermination,
@@ -57,7 +57,7 @@ namespace SolastaCommunityExpansion.Builders.Features
         }
     }
 
-    public class FeatureDefinitionPowerSharedPoolBuilder : BaseDefinitionBuilder<FeatureDefinitionPowerSharedPool>
+    public class FeatureDefinitionPowerSharedPoolBuilder : DefinitionBuilder<FeatureDefinitionPowerSharedPool>
     {
         public FeatureDefinitionPowerSharedPoolBuilder(string name, string guid, FeatureDefinitionPower poolPower,
             RuleDefinitions.RechargeRate recharge,

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionProficiencyBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionProficiencyBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionProficiencyBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+    public sealed class FeatureDefinitionProficiencyBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
     {
 /*        private FeatureDefinitionProficiencyBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionRemoveGrantedFeatureBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionRemoveGrantedFeatureBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders.Features
@@ -13,7 +12,7 @@ namespace SolastaCommunityExpansion.Builders.Features
     // Replace a class feature - We need to inform the feature to be removed, the level and the class
     // Replace a subclass feature - We need to inform the feature to be removed, the level, the class and the subclass
     //
-    public sealed class RemoveGrantedFeatureBuilder : BaseDefinitionBuilder<FeatureDefinitionRemoveGrantedFeature>
+    public sealed class RemoveGrantedFeatureBuilder : DefinitionBuilder<FeatureDefinitionRemoveGrantedFeature>
     {
         public RemoveGrantedFeatureBuilder(string name, string guid, FeatureDefinition featureToRemove, int classLevel, CharacterClassDefinition characterClass, CharacterSubclassDefinition characterSubclass = null)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSavingThrowAffinityBuilder.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Infrastructure;
 using static FeatureDefinitionSavingThrowAffinity;
 using static SolastaModApi.DatabaseHelper.SchoolOfMagicDefinitions;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public class FeatureDefinitionSavingThrowAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
+    public class FeatureDefinitionSavingThrowAffinityBuilder : DefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
     {
         #region Constructors
         public FeatureDefinitionSavingThrowAffinityBuilder(string name, string guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSubclassChoiceBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSubclassChoiceBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionSubclassChoiceBuilder : BaseDefinitionBuilder<FeatureDefinitionSubclassChoice>
+    public sealed class FeatureDefinitionSubclassChoiceBuilder : DefinitionBuilder<FeatureDefinitionSubclassChoice>
     {
         #region Constructors
         private FeatureDefinitionSubclassChoiceBuilder(string name, string guid)

--- a/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSummoningAffinityBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/Features/FeatureDefinitionSummoningAffinityBuilder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders.Features
 {
-    public sealed class FeatureDefinitionSummoningAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
+    public sealed class FeatureDefinitionSummoningAffinityBuilder : DefinitionBuilder<FeatureDefinitionSummoningAffinity>
     {
 /*        private FeatureDefinitionSummoningAffinityBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/GuiPresentationBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/GuiPresentationBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using UnityEngine;
@@ -111,9 +110,9 @@ namespace SolastaCommunityExpansion.Builders
         /// Set the provided GuiPresentation instance on the definition owned by the builder.
         /// </summary>
         public static TBuilder SetGuiPresentation<TBuilder>(this TBuilder builder, GuiPresentation guiPresentation)
-            where TBuilder : IBaseDefinitionBuilder
+            where TBuilder : IDefinitionBuilder
         {
-            ((IBaseDefinitionBuilder)builder).SetGuiPresentation(guiPresentation);
+            ((IDefinitionBuilder)builder).SetGuiPresentation(guiPresentation);
             return builder;
         }
 
@@ -121,7 +120,7 @@ namespace SolastaCommunityExpansion.Builders
         /// Create and set a GuiPresentation from the provided title, description and AssetReferenceSprite.
         /// </summary>
         public static TBuilder SetGuiPresentation<TBuilder>(this TBuilder builder, string title, string description, AssetReferenceSprite sprite = null)
-            where TBuilder : IBaseDefinitionBuilder
+            where TBuilder : IDefinitionBuilder
         {
             return SetGuiPresentation(builder, GuiPresentationBuilder.Build(title, description, sprite));
         }
@@ -133,7 +132,7 @@ namespace SolastaCommunityExpansion.Builders
         /// </summary>
         public static TBuilder SetGuiPresentation<TBuilder>(this TBuilder builder,
                 string name, Category category, AssetReferenceSprite sprite = null, int sortOrder = 0)
-            where TBuilder : IBaseDefinitionBuilder
+            where TBuilder : IDefinitionBuilder
         {
             return SetGuiPresentation(builder, GuiPresentationBuilder.Build(name, category, sprite, sortOrder));
         }
@@ -146,10 +145,10 @@ namespace SolastaCommunityExpansion.Builders
         /// <typeparam name="TBuilder"></typeparam>
         public static TBuilder SetGuiPresentation<TBuilder>(this TBuilder builder,
                 Category category, AssetReferenceSprite sprite = null, int sortOrder = 0)
-            where TBuilder : IBaseDefinitionBuilder
+            where TBuilder : IDefinitionBuilder
         {
             return SetGuiPresentation(builder,
-                GuiPresentationBuilder.Build(((IBaseDefinitionBuilder)builder).Name, category, sprite, sortOrder));
+                GuiPresentationBuilder.Build(((IDefinitionBuilder)builder).Name, category, sprite, sortOrder));
         }
 
         // TODO: More SetGuiPresentation/Generate(...) overloads as required
@@ -158,9 +157,9 @@ namespace SolastaCommunityExpansion.Builders
         /// Create a GuiPresentation with Title=Feature/&amp;NoContentTitle, Description=Feature/&amp;NoContentDescription.
         /// </summary>
         public static TBuilder SetGuiPresentationNoContent<TBuilder>(this TBuilder builder, bool hidden = false)
-            where TBuilder : IBaseDefinitionBuilder
+            where TBuilder : IDefinitionBuilder
         {
-            ((IBaseDefinitionBuilder)builder).SetGuiPresentation(
+            ((IDefinitionBuilder)builder).SetGuiPresentation(
                 hidden ? GuiPresentationBuilder.NoContentHidden : GuiPresentationBuilder.NoContent);
             return builder;
         }

--- a/SolastaCommunityExpansion/Builders/ItemDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/ItemDefinitionBuilder.cs
@@ -7,7 +7,7 @@ using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class ItemDefinitionBuilder : BaseDefinitionBuilder<ItemDefinition>
+    public class ItemDefinitionBuilder : DefinitionBuilder<ItemDefinition>
     {
         public ItemDefinitionBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/LootPackDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/LootPackDefinitionBuilder.cs
@@ -1,8 +1,6 @@
-﻿using SolastaModApi;
-
-namespace SolastaCommunityExpansion.Builders
+﻿namespace SolastaCommunityExpansion.Builders
 {
-    public class LootPackDefinitionBuilder : BaseDefinitionBuilder<LootPackDefinition>
+    public class LootPackDefinitionBuilder : DefinitionBuilder<LootPackDefinition>
     {
         protected LootPackDefinitionBuilder(LootPackDefinition original, string name, string guid) : base(original, name, guid)
         {

--- a/SolastaCommunityExpansion/Builders/MonsterAttackDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/MonsterAttackDefinitionBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class MonsterAttackDefinitionBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
+    public class MonsterAttackDefinitionBuilder : DefinitionBuilder<MonsterAttackDefinition>
     {
         public MonsterAttackDefinitionBuilder(string name, string guid) :
             base(name, guid)

--- a/SolastaCommunityExpansion/Builders/MonsterDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/MonsterDefinitionBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using TA.AI;
@@ -12,7 +11,7 @@ using static RuleDefinitions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class MonsterDefinitionBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    public class MonsterDefinitionBuilder : DefinitionBuilder<MonsterDefinition>
     {
         public MonsterDefinitionBuilder(string name, string guid)
             : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/RecipeDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/RecipeDefinitionBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class RecipeDefinitionBuilder : BaseDefinitionBuilder<RecipeDefinition>
+    public class RecipeDefinitionBuilder : DefinitionBuilder<RecipeDefinition>
     {
         public RecipeDefinitionBuilder(string name, string guid) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/Builders/SpellDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/SpellDefinitionBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public sealed class SpellDefinitionBuilder : BaseDefinitionBuilder<SpellDefinition>
+    public sealed class SpellDefinitionBuilder : DefinitionBuilder<SpellDefinition>
     {
         #region Constructors
         private SpellDefinitionBuilder(string name, string guid) : base(name, guid)

--- a/SolastaCommunityExpansion/Builders/SpellListDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/SpellListDefinitionBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public sealed class SpellListDefinitionBuilder : BaseDefinitionBuilder<SpellListDefinition>
+    public sealed class SpellListDefinitionBuilder : DefinitionBuilder<SpellListDefinition>
     {
         private SpellListDefinitionBuilder(SpellListDefinition original, string name, Guid guidNamespace)
             : base(original, name, guidNamespace)

--- a/SolastaCommunityExpansion/Builders/TreasureTableDefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/TreasureTableDefinitionBuilder.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
 
 namespace SolastaCommunityExpansion.Builders
 {
-    public class TreasureTableDefinitionBuilder : BaseDefinitionBuilder<TreasureTableDefinition>
+    public class TreasureTableDefinitionBuilder : DefinitionBuilder<TreasureTableDefinition>
     {
         protected TreasureTableDefinitionBuilder(TreasureTableDefinition original, string name, string guid) : base(original, name, guid)
         {

--- a/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/FeatureHelpers.cs
@@ -14,7 +14,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
     internal static class FeatureHelpers
     {
         // TODO Most of theese builders should likely get moved/merged with the CE builders.
-        public class FeatureDefinitionPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        public class FeatureDefinitionPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             public FeatureDefinitionPowerBuilder(string name, string guid, int usesPerRecharge, RuleDefinitions.UsesDetermination usesDetermination,
                 string usesAbilityScoreName, RuleDefinitions.ActivationTime activationTime, int costPerUse, RuleDefinitions.RechargeRate recharge,
@@ -45,7 +45,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionProficiencyBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+        public class FeatureDefinitionProficiencyBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
         {
             public FeatureDefinitionProficiencyBuilder(string name, string guid, RuleDefinitions.ProficiencyType type,
                 GuiPresentation guiPresentation, params string[] proficiencies) :
@@ -62,7 +62,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        public class FeatureDefinitionAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             public FeatureDefinitionAttackModifierBuilder(string name, string guid, RuleDefinitions.AttackModifierMethod attackRollModifierMethod,
                 int attackRollModifier, string attackRollAbilityScore, RuleDefinitions.AttackModifierMethod damageRollModifierMethod,
@@ -82,7 +82,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionAttributeModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+        public class FeatureDefinitionAttributeModifierBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
         {
             public FeatureDefinitionAttributeModifierBuilder(string name, string guid, AttributeModifierOperation modifierType,
                 string attribute, int amount, GuiPresentation guiPresentation) : base(name, guid)
@@ -94,7 +94,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionMagicAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionMagicAffinity>
+        public class FeatureDefinitionMagicAffinityBuilder : DefinitionBuilder<FeatureDefinitionMagicAffinity>
         {
             public FeatureDefinitionMagicAffinityBuilder(string name, string guid, RuleDefinitions.ConcentrationAffinity concentrationAffinity,
                 int threshold, GuiPresentation guiPresentation) : base(name, guid)
@@ -137,7 +137,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionPointPoolBuilder : BaseDefinitionBuilder<FeatureDefinitionPointPool>
+        public class FeatureDefinitionPointPoolBuilder : DefinitionBuilder<FeatureDefinitionPointPool>
         {
             public FeatureDefinitionPointPoolBuilder(string name, string guid, HeroDefinitions.PointsPoolType poolType, int poolAmount,
                 bool uniqueChoices, GuiPresentation guiPresentation, params string[] choices) :
@@ -156,7 +156,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class ConditionDefinitionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        public class ConditionDefinitionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             public ConditionDefinitionBuilder(string name, string guid, RuleDefinitions.DurationType durationType, int durationParameter,
                 bool silent, GuiPresentation guiPresentation, params FeatureDefinition[] conditionFeatures) :
@@ -186,7 +186,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionSavingThrowAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
+        public class FeatureDefinitionSavingThrowAffinityBuilder : DefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
         {
             public FeatureDefinitionSavingThrowAffinityBuilder(string name, string guid, IEnumerable<string> abilityScores,
                 RuleDefinitions.CharacterSavingThrowAffinity affinityType,
@@ -220,7 +220,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
+        public class FeatureDefinitionAbilityCheckAffinityBuilder : DefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
         {
             // TODO: convert tuples to ()
             public FeatureDefinitionAbilityCheckAffinityBuilder(string name, string guid, IEnumerable<Tuple<string, string>> abilityProficiencyPairs,
@@ -246,7 +246,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionCraftingAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionCraftingAffinity>
+        public class FeatureDefinitionCraftingAffinityBuilder : DefinitionBuilder<FeatureDefinitionCraftingAffinity>
         {
             public FeatureDefinitionCraftingAffinityBuilder(string name, string guid, IEnumerable<ToolTypeDefinition> toolTypes,
                 float durationMultiplier, bool doubleProficiencyBonus, GuiPresentation guiPresentation) : base(name, guid)
@@ -265,7 +265,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionAutoPreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+        public class FeatureDefinitionAutoPreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
         {
             public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid, IEnumerable<AutoPreparedSpellsGroup> autospelllists,
                 CharacterClassDefinition characterclass, GuiPresentation guiPresentation) : base(name, guid)
@@ -276,7 +276,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class RestActivityDefinitionBuilder : BaseDefinitionBuilder<RestActivityDefinition>
+        public class RestActivityDefinitionBuilder : DefinitionBuilder<RestActivityDefinition>
         {
             public RestActivityDefinitionBuilder(string name, string guid, RestDefinitions.RestStage restStage, RuleDefinitions.RestType restType,
                 RestActivityDefinition.ActivityCondition condition, string functor, string stringParameter, GuiPresentation guiPresentation) : base(name, guid)
@@ -290,7 +290,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionMovementAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionMovementAffinity>
+        public class FeatureDefinitionMovementAffinityBuilder : DefinitionBuilder<FeatureDefinitionMovementAffinity>
         {
             public FeatureDefinitionMovementAffinityBuilder(string name, string guid, bool addBase,
                 int speedAdd, float speedMult, GuiPresentation guiPresentation) : base(name, guid)
@@ -303,7 +303,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionHealingModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionHealingModifier>
+        public class FeatureDefinitionHealingModifierBuilder : DefinitionBuilder<FeatureDefinitionHealingModifier>
         {
             public FeatureDefinitionHealingModifierBuilder(string name, string guid, int healingBonusDiceNumber, RuleDefinitions.DieType healingBonusDiceType,
             RuleDefinitions.LevelSourceType addLevel, GuiPresentation guiPresentation) : base(name, guid)
@@ -315,7 +315,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionBonusCantripsBuilder : BaseDefinitionBuilder<FeatureDefinitionBonusCantrips>
+        public class FeatureDefinitionBonusCantripsBuilder : DefinitionBuilder<FeatureDefinitionBonusCantrips>
         {
             public FeatureDefinitionBonusCantripsBuilder(string name, string guid, IEnumerable<SpellDefinition> cantrips, GuiPresentation guiPresentation) : base(name, guid)
             {
@@ -324,7 +324,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionEquipmentAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionEquipmentAffinity>
+        public class FeatureDefinitionEquipmentAffinityBuilder : DefinitionBuilder<FeatureDefinitionEquipmentAffinity>
         {
             public FeatureDefinitionEquipmentAffinityBuilder(string name, string guid, float carryingCapacityMultiplier,
                 float additionalCarryingCapacity, GuiPresentation guiPresentation) : base(name, guid)
@@ -335,7 +335,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             }
         }
 
-        public class FeatureDefinitionAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+        public class FeatureDefinitionAdditionalDamageBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
         {
             public FeatureDefinitionAdditionalDamageBuilder(string name, string guid, string notificationTag, RuleDefinitions.FeatureLimitedUsage limitedUsage,
                 RuleDefinitions.AdditionalDamageValueDetermination damageValueDetermination,
@@ -544,7 +544,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer
             return diceByRank;
         }
 
-        public class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+        public class FeatureDefinitionFeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
         {
             public FeatureDefinitionFeatureSetBuilder(string name, string guid, IEnumerable<FeatureDefinition> featureSet,
                 FeatureDefinitionFeatureSet.FeatureSetMode mode, int defaultSelection, bool uniqueChoices,

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructFlame.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructFlame.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using UnityEngine.AddressableAssets;
@@ -9,7 +10,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		FlameArtilleryBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtilleryBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class FlameArtilleryBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string FlameArtilleryName = "FlameArtillery";
         private const string FlameArtilleryGuid = "3a93be16-4398-47cb-9c1c-4ec56903bd2f";
@@ -76,7 +77,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		FlameArtillery_2Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtillery2Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class FlameArtillery2Builder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string FlameArtillery_2Name = "FlameArtillery_2";
         private const string FlameArtillery_2Guid = "2ba003a5-718a-4eea-a0f8-33fa79884cb1";
@@ -103,7 +104,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		FlameArtilleryConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtilleryConstructBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class FlameArtilleryConstructBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string FlameArtilleryConstructName = "FlameArtilleryConstruct";
         private const string FlameArtilleryConstructGuid = "26631741-1de8-4f4c-871e-0d71a2ed8c4b";
@@ -172,7 +173,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly MonsterDefinition FlameArtilleryConstruct = CreateAndAddToDB(FlameArtilleryConstructName, FlameArtilleryConstructGuid);
     }
 
-    internal class FlameArtilleryConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class FlameArtilleryConstruct9Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string FlameArtilleryConstruct_9Name = "FlameArtilleryConstruct_9";
         private const string FlameArtilleryConstruct_9Guid = "3445274f-9668-4606-8a91-4c6a420a7c30";
@@ -197,7 +198,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		FlameArtilleryConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class FlameArtilleryConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class FlameArtilleryConstruct15Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string FlameArtilleryConstruct_15Name = "FlameArtilleryConstruct_15";
         private const string FlameArtilleryConstruct_15Guid = "8c4ff931-4a17-4de4-8571-6c94e8327e8e";
@@ -221,7 +222,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonFlameArtillerySpellConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonFlameArtillerySpellConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonFlameArtillerySpellConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonFlameArtilleryConstructName = "SummonFlameArtilleryConstruct";
         private const string SummonFlameArtilleryConstructGuid = "785ca8dc-27a3-4805-88fd-6d013631bbbb";
@@ -252,7 +253,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonFlameArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonFlameArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonFlameArtillerySpellConstruct9Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonFlameArtilleryConstruct_9Name = "SummonFlameArtilleryConstruct_9";
         private const string SummonFlameArtilleryConstruct_9Guid = "4aaaf381-c54c-4285-9045-6a4d69aa37c9";
@@ -276,7 +277,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonFlameArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonFlameArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonFlameArtillerySpellConstruct15Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonFlameArtilleryConstruct_15Name = "SummonFlameArtilleryConstruct_15";
         private const string SummonFlameArtilleryConstruct_15Guid = "68aba04a-07c5-4b83-bda7-db08cec2dec8";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructForce.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructForce.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
@@ -10,7 +11,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ForceArtilleryConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ForceArtilleryConstructBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ForceArtilleryConstructBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string ForceArtilleryConstructName = "ForceArtilleryConstruct";
         private const string ForceArtilleryConstructGuid = "91cc706f-97b7-47d9-a46e-89b251fd5efe";
@@ -89,7 +90,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ForceArtilleryConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ForceArtilleryConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ForceArtilleryConstruct9Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string ForceArtilleryConstruct_9Name = "ForceArtilleryConstruct_9";
         private const string ForceArtilleryConstruct_9Guid = "1a479ea4-0f72-4847-bd0b-54b2ded48057";
@@ -117,7 +118,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ForceArtilleryConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ForceArtilleryConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ForceArtilleryConstruct15Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string ForceArtilleryConstruct_15Name = "ForceArtilleryConstruct_15";
         private const string ForceArtilleryConstruct_15Guid = "e7d49f53-cb44-4348-82d7-b8b561861448";
@@ -142,7 +143,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonForceArtillerySpellConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonForceArtillerySpellConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonForceArtillerySpellConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonForceArtilleryConstructName = "SummonForceArtilleryConstruct";
         private const string SummonForceArtilleryConstructGuid = "c584b73c-9fa8-453f-90ad-944b8d1b5b05";
@@ -173,7 +174,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonForceArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonForceArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonForceArtillerySpellConstruct9Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonForceArtilleryConstruct_9Name = "SummonForceArtilleryConstruct_9";
         private const string SummonForceArtilleryConstruct_9Guid = "f1e8d7e1-44d9-4a82-ac23-5e0013b40650";
@@ -200,7 +201,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonForceArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonForceArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonForceArtillerySpellConstruct15Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonForceArtilleryConstruct_15Name = "SummonForceArtilleryConstruct_15";
         private const string SummonForceArtilleryConstruct_15Guid = "b529386c-defa-4c39-a03c-09a08a104cc6";
@@ -222,7 +223,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly SpellDefinition SummonForceArtilleryConstruct15 = CreateAndAddToDB(SummonForceArtilleryConstruct_15Name, SummonForceArtilleryConstruct_15Guid);
     }
 
-    internal class ForceArtilleryAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
+    internal class ForceArtilleryAttackBuilder : DefinitionBuilder<MonsterAttackDefinition>
     {
         private const string ForceArtilleryAttackName = "ForceArtilleryAttack";
         private const string ForceArtilleryAttackGuid = "39c5b7ef-47f9-462c-9f24-accaee85d325";
@@ -323,7 +324,7 @@ Web
         public static readonly MonsterAttackDefinition ForceArtilleryAttack = CreateAndAddToDB(ForceArtilleryAttackName, ForceArtilleryAttackGuid);
     }
 
-    internal class ForceArtilleryAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+    internal class ForceArtilleryAdditionalDamageBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
     {
         private const string ForceArtilleryAdditionalDamageName = "ForceArtilleryAdditionalDamage";
         private const string ForceArtilleryAdditionalDamageGuid = "2e726b2e-052f-482f-a869-721851fcb407";
@@ -350,7 +351,7 @@ Web
         public static readonly FeatureDefinitionAdditionalDamage ForceArtilleryAdditionalDamage = CreateAndAddToDB(ForceArtilleryAdditionalDamageName, ForceArtilleryAdditionalDamageGuid);
     }
 
-    internal class ForceArtilleryProjectileBuilder : BaseDefinitionBuilder<ItemDefinition>
+    internal class ForceArtilleryProjectileBuilder : DefinitionBuilder<ItemDefinition>
     {
         private const string ForceArtilleryProjectileName = "ForceArtilleryProjectile";
         private const string ForceArtilleryProjectileGuid = "b30b1971-6ad6-4ea2-af5b-998043415f04";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructShared.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructShared.cs
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ArtilleryConstructlevel03FeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class ArtilleryConstructlevel03FeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ArtilleryConstructlevel03FeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ArtilleryConstructlevel03FeatureSet";
         private const string Guid = "59f857e6-7b06-4c2b-a241-b73c42d64c23";
@@ -152,7 +152,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ArtilleryConstructlevel09FeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class ArtilleryConstructlevel09FeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ArtilleryConstructlevel09FeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ArtilleryConstructlevel09FeatureSet";
         private const string Guid = "a1e9557c-c1a9-4912-9fea-1a16c4124331";
@@ -281,7 +281,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ArtilleryConstructlevel15FeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class ArtilleryConstructlevel15FeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ArtilleryConstructlevel15FeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ArtilleryConstructlevel15FeatureSet";
         private const string Guid = "50c91d16-1a84-494a-ba72-dd4879955f2f";
@@ -425,7 +425,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SelfDestructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SelfDestructBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SelfDestructBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string SelfDestructName = "SelfDestruct";
         private const string SelfDestructGuid = "68ecf3d9-f718-4c62-921c-f30df3708312";
@@ -517,7 +517,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SelfDestructionConditionBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SelfDestructionConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class SelfDestructionConditionBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string SelfDestructionConditionName = "SelfDestructionCondition";
         private const string SelfDestructionConditionGuid = "c96984f4-0370-4775-ab8b-3ee6db0c8806";
@@ -567,7 +567,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		HalfCoverShieldBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class HalfCoverShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class HalfCoverShieldBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string HalfCoverShieldName = "HalfCoverShield";
         private const string HalfCoverShieldGuid = "0fd3ccb3-0f15-4766-8eb8-32042838ce6d";
@@ -622,7 +622,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		HalfCoverShieldConditionBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class HalfCoverShieldConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class HalfCoverShieldConditionBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string HalfCoverShieldConditionName = "HalfCoverShieldCondition";
         private const string HalfCoverShieldConditionGuid = "c160a20e-4714-478a-8bbb-6df5526728a9";
@@ -648,7 +648,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		HalfCoverShieldAttributeBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class HalfCoverShieldAttributeBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+    internal class HalfCoverShieldAttributeBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
     {
         private const string HalfCoverShieldAttributeName = "HalfCoverShieldAttribute";
         private const string HalfCoverShieldAttributeGuid = "4dd6548f-4d7f-4bbf-b120-70a17f79f8e0";
@@ -675,7 +675,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonArtillerySpellConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonArtillerySpellConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonArtillerySpellConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonArtillerySpellConstructName = "SummonArtillerySpellConstruct";
         private const string SummonArtillerySpellConstructGuid = "214dab9d-f40e-424f-8730-b41acdae26ec";
@@ -713,7 +713,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonArtillerySpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonArtillerySpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonArtillerySpellConstruct9Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonArtillerySpellConstruct_9Name = "SummonArtillerySpellConstruct_9";
         private const string SummonArtillerySpellConstruct_9Guid = "9ad29b43-5207-46e8-bbc9-7b8138b2912f";
@@ -743,7 +743,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonArtillerySpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonArtillerySpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonArtillerySpellConstruct15Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonArtillerySpellConstruct_15Name = "SummonArtillerySpellConstruct_15";
         private const string SummonArtillerySpellConstruct_15Guid = "f0038039-423b-4265-b0cf-2eab2450f982";
@@ -769,7 +769,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly SpellDefinition SummonArtillerySpellConstruct15 = CreateAndAddToDB(SummonArtillerySpellConstruct_15Name, SummonArtillerySpellConstruct_15Guid);
     }
 
-    internal class SummoningAffinityTinkererArtilleryConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
+    internal class SummoningAffinityTinkererArtilleryConstructBuilder : DefinitionBuilder<FeatureDefinitionSummoningAffinity>
     {
         private const string Name = "SummoningAffinityTinkererArtilleryConstruct";
         private const string Guid = "edae2ec0-f871-4918-855a-117bd428d51e";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructTempHP.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ArtilleryConstructTempHP.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 
@@ -8,7 +9,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		TempHPShieldBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class TempHPShieldBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string TempHPShieldName = "TempHPShield";
         private const string TempHPShieldGuid = "9ca27524-0b49-479e-b11d-085e00e77b8f";
@@ -70,7 +71,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		TempHPShieldConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldConstructBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class TempHPShieldConstructBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string TempHPShieldConstructName = "TempHPShieldConstruct";
         private const string TempHPShieldConstructGuid = "65223373-24a2-4596-b778-75e6f197b73f";
@@ -146,7 +147,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		TempHPShieldConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldConstruct9Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class TempHPShieldConstruct9Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string TempHPShieldConstruct_9Name = "TempHPShieldConstruct_9";
         private const string TempHPShieldConstruct_9Guid = "75f8541a-65c3-4226-9c42-a80dd76b04cd";
@@ -170,7 +171,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		TempHPShieldConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class TempHPShieldConstruct15Builder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class TempHPShieldConstruct15Builder : DefinitionBuilder<MonsterDefinition>
     {
         private const string TempHPShieldConstruct_15Name = "TempHPShieldConstruct_15";
         private const string TempHPShieldConstruct_15Guid = "243d5f04-2106-4c20-a3f2-38484ecc345c";
@@ -194,7 +195,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonTempHPShieldSpellConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonTempHPShieldSpellConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonTempHPShieldSpellConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonTempHPShieldConstructName = "SummonTempHPShieldConstruct";
         private const string SummonTempHPShieldConstructGuid = "db9e7e8e-b749-4b46-9ba3-60a7bf221b0b";
@@ -225,7 +226,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonTempHPShieldSpellConstruct_9Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonTempHPShieldSpellConstruct9Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonTempHPShieldSpellConstruct9Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonTempHPShieldConstruct_9Name = "SummonTempHPShieldConstruct_9";
         private const string SummonTempHPShieldConstruct_9Guid = "f1e88575-40ca-4f4e-9447-616058e213a4";
@@ -250,7 +251,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonTempHPShieldSpellConstruct_15Builder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonTempHPShieldSpellConstruct15Builder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonTempHPShieldSpellConstruct15Builder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonTempHPShieldConstruct_15Name = "SummonTempHPShieldConstruct_15";
         private const string SummonTempHPShieldConstruct_15Guid = "84ddce96-ec58-4141-933d-371080d611d2";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/BattleSmithBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/BattleSmithBuilder.cs
@@ -124,7 +124,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
             return battleSmith.AddToDB();
         }
 
-        private sealed class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        private sealed class FeatureDefinitionAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             public FeatureDefinitionAttackModifierBuilder(string name, string guid,
             AbilityScoreReplacement abilityReplacement, string additionalAttackTag,

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ConstructCantripsAndArtificialServant.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ConstructCantripsAndArtificialServant.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
@@ -9,7 +10,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     ////***********************************		TinkererConstructFamilyBuilder		*************************************************************
     ////*****************************************************************************************************************************************
 
-    internal class TinkererConstructFamilyBuilder : BaseDefinitionBuilder<CharacterFamilyDefinition>
+    internal class TinkererConstructFamilyBuilder : DefinitionBuilder<CharacterFamilyDefinition>
     {
         private const string TinkererConstructFamilyName = "TinkererConstruct";
         private const string TinkererConstructFamilyGuid = "ab9d8ea6-3cc2-4c36-939a-b9a43bad023e";
@@ -31,7 +32,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		AddConstructCantripsBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class AddConstructCantripsBuilder : BaseDefinitionBuilder<FeatureDefinitionBonusCantrips>
+    internal class AddConstructCantripsBuilder : DefinitionBuilder<FeatureDefinitionBonusCantrips>
     {
         private const string Name = "AddConstructCantrips";
         private const string Guid = "942183c0-e581-464a-afe4-cc00a9cd9c26";
@@ -58,7 +59,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		MendingConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class MendingConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class MendingConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string Name = "MendingConstruct";
         private const string Guid = "92de3dbf-4b57-46d3-aebf-0f7819b0ac2d";
@@ -108,7 +109,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		DismissConstructBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class DismissConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class DismissConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string Name = "DismissConstruct";
         private const string Guid = "8003917a-9c90-4748-bb2f-f32b7edf8844";
@@ -180,7 +181,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ArtificialServantBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ArtificialServantBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ArtificialServantBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string ArtificialServantName = "ArtificialServant";
         private const string ArtificialServantGuid = "fce9181c-f62c-4b33-b0df-fff4fe3ceab2";
@@ -257,7 +258,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ArtificialServantAttacksListBuilder		*******************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ArtificialServantAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
+    internal class ArtificialServantAttackBuilder : DefinitionBuilder<MonsterAttackDefinition>
     {
         private const string ArtificialServantAttacksListName = "ArtificialServantAttacksList";
         private const string ArtificialServantAttacksListGuid = "86840282-4d84-44b7-a4fd-6bf6b598f776";
@@ -310,7 +311,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
 
         public static readonly MonsterAttackDefinition ArtificialServantAttack = CreateAndAddToDB(ArtificialServantAttacksListName, ArtificialServantAttacksListGuid);
     }
-    internal class CancelFlyingConditionBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class CancelFlyingConditionBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string Name = "CancelFlyingConditionArtificialServant";
         private const string Guid = "15bff3c5-632e-451f-8c46-1511ed4cf805";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ProtectorConstruct.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ProtectorConstruct.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ProtectorConstructFeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstructFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ProtectorConstructFeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ProtectorConstructFeatureSet";
         private const string Guid = "9b699719-0d02-4949-ad94-cff6a05f36c7";
@@ -36,7 +36,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly FeatureDefinitionFeatureSet ProtectorConstructFeatureSet = CreateAndAddToDB(Name, Guid);
     }
 
-    public class ProtectorConstructLevel3AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+    public class ProtectorConstructLevel3AutopreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
         private const string Name = "ProtectorConstructLevel3AutopreparedSpells";
         private const string Guid = "25403813-58eb-47f4-b5ee-b7956cc02ccf";
@@ -66,7 +66,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummoningAffinityTinkererConstructBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummoningAffinityTinkererConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionSummoningAffinity>
+    internal class SummoningAffinityTinkererConstructBuilder : DefinitionBuilder<FeatureDefinitionSummoningAffinity>
     {
         private const string Name = "SummoningAffinityTinkererConstruct";
         private const string Guid = "0dbd3d80-96ce-4cf9-8ffa-597f1ea84c3b";
@@ -123,7 +123,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonProtectorConstructBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonProtectorPowerConstructBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SummonProtectorPowerConstructBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string SummonProtectorConstructName = "SummonProtectorConstruct";
         private const string SummonProtectorConstructNameGuid = "20b5ab3e-5124-4d08-9907-347f2f1284d4";
@@ -161,7 +161,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonProtectorPowerConstruct_UpgradeBuilder		***************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonProtectorPowerConstructUpgradeBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SummonProtectorPowerConstructUpgradeBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string Name = "SummonProtectorPowerConstruct_Upgrade";
         private const string Guid = "34c307e9-5883-438c-9130-1f286b9cdafc";
@@ -188,7 +188,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SummonProtectorSpellConstructBuilder		***************************************************
     //*****************************************************************************************************************************************
 
-    internal class SummonProtectorSpellConstructBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonProtectorSpellConstructBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string SummonProtectorConstructName = "SummonProtectorConstruct";
         private const string SummonProtectorConstructNameGuid = "60f2462e-b801-48ee-a543-c69771e3917c";
@@ -225,7 +225,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     // need a new featuredefintionAutopreparedSpells list with the summon upgrade spell for the two different subclasses
     // as features can be added at any lvl and it's 1st lvl spell
     //
-    internal class SummonProtectorSpellConstructUpgradeBuilder : BaseDefinitionBuilder<SpellDefinition>
+    internal class SummonProtectorSpellConstructUpgradeBuilder : DefinitionBuilder<SpellDefinition>
     {
         private const string Name = "SummonProtectorConstruct_Upgrade";
         private const string Guid = "ccd2a793-e566-4c1e-9588-ac36b578ae89";
@@ -246,7 +246,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly SpellDefinition SummonProtectorConstructUpgrade = CreateAndAddToDB(Name, Guid);
     }
 
-    public class ProtectorConstructLevel15AutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+    public class ProtectorConstructLevel15AutopreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
         private const string Name = "ProtectorConstructLevel15AutopreparedSpells";
         private const string Guid = "4515c27b-f17b-4262-9e8c-a19c251f666e";
@@ -280,7 +280,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ProtectorConstructUpgradeFeatureSetBuilder		***********************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstructUpgradeFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ProtectorConstructUpgradeFeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string Name = "ProtectorConstructUpgradeFeatureSet";
         private const string Guid = "59bc566d-5204-4e53-89cb-eebc537ae6ab";
@@ -307,7 +307,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ProtectorConstructBuilder		***************************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstructBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ProtectorConstructBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string ProtectorConstructName = "ProtectorConstruct";
         private const string ProtectorConstructNameGuid = "db1cd36f-7dc7-454f-baeb-143cd9dd374f";
@@ -379,7 +379,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ProtectorConstruct_UpgradeBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstructUpgradeBuilder : BaseDefinitionBuilder<MonsterDefinition>
+    internal class ProtectorConstructUpgradeBuilder : DefinitionBuilder<MonsterDefinition>
     {
         private const string Name = "ProtectorConstruct_Upgrade";
         private const string Guid = "c6f711d8-9b83-497f-8e90-6440776cf644";
@@ -405,7 +405,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		ProtectorConstructAttacksBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class ProtectorConstructAttackBuilder : BaseDefinitionBuilder<MonsterAttackDefinition>
+    internal class ProtectorConstructAttackBuilder : DefinitionBuilder<MonsterAttackDefinition>
     {
         private const string ProtectorConstructAttacksName = "ProtectorConstructAttacks";
         private const string ProtectorConstructAttacksGuid = "dad5a3f6-3b44-4476-85fc-d5235b9ad9cd";
@@ -462,7 +462,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SelfRepairBuilder		***********************************************************************
     //*****************************************************************************************************************************************
 
-    internal class SelfRepairBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SelfRepairBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string SelfRepairName = "SelfRepair";
         private const string SelfRepairNameGuid = "68db5cab-6fc9-4795-88a6-f89d81b0e4ef";
@@ -510,7 +510,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		RetributionBuilder		***********************************************************************
     //*****************************************************************************************************************************************
 
-    internal class RetributionBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class RetributionBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string RetributionName = "Retribution";
         private const string RetributionNameGuid = "1fc63d9f-263c-4642-b75c-f7684ca6dd3d";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ScoutSentinelSubClass.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/Subclasses/ScoutSentinelSubClass.cs
@@ -137,7 +137,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         }
     }
 
-    internal class ScoutSentinelFeatureSet03Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSet03Builder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level03Name = "ScoutSentinelFeatureSet_level03";
         private const string ScoutSentinelFeatureSet_level03Guid = "a6560212-c665-49fd-94b7-378512e68edb";
@@ -165,7 +165,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet03 = CreateAndAddToDB(ScoutSentinelFeatureSet_level03Name, ScoutSentinelFeatureSet_level03Guid);
     }
 
-    internal class ScoutSentinelFeatureSet05Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSet05Builder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level05Name = "ScoutSentinelFeatureSet_level05";
         private const string ScoutSentinelFeatureSet_level05Guid = "a881c02a-7add-426b-a2d4-1f3994d12fa9";
@@ -187,7 +187,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet05 = CreateAndAddToDB(ScoutSentinelFeatureSet_level05Name, ScoutSentinelFeatureSet_level05Guid);
     }
 
-    internal class ScoutSentinelFeatureSet09Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSet09Builder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level09Name = "ScoutSentinelFeatureSet_level09";
         private const string ScoutSentinelFeatureSet_level09Guid = "87e8b110-4590-4791-b31c-b8bba5f362b1";
@@ -223,7 +223,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly FeatureDefinitionFeatureSet ScoutSentinelFeatureSet09 = CreateAndAddToDB(ScoutSentinelFeatureSet_level09Name, ScoutSentinelFeatureSet_level09Guid);
     }
 
-    internal class ScoutSentinelFeatureSet15Builder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    internal class ScoutSentinelFeatureSet15Builder : DefinitionBuilder<FeatureDefinitionFeatureSet>
     {
         private const string ScoutSentinelFeatureSet_level15Name = "ScoutSentinelFeatureSet_level15";
         private const string ScoutSentinelFeatureSet_level15Guid = "69a9ba53-4949-47ec-9693-467d053e4646";
@@ -332,7 +332,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SubclassAutopreparedSpellsBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    public class ScoutSentinelAutopreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+    public class ScoutSentinelAutopreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
     {
         private const string SubclassAutopreparedSpellsName = "SubclassAutopreparedSpells";
         private const string SubclassAutopreparedSpellsGuid = "c5f03caa-7078-4da7-b166-00f292fcebfc";
@@ -409,7 +409,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SubclassProficienciesBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class SubclassProficienciesBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+    internal class SubclassProficienciesBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
     {
         private const string SubclassProficienciesName = "SubclassProficiencies";
         private const string SubclassProficienciesGuid = "1923caf6-672b-475a-bcdf-50d535ce65d1";
@@ -433,7 +433,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		SubclassMovementAffinitiesBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class SubclassMovementAffinitiesBuilder : BaseDefinitionBuilder<FeatureDefinitionMovementAffinity>
+    internal class SubclassMovementAffinitiesBuilder : DefinitionBuilder<FeatureDefinitionMovementAffinity>
     {
         private const string SubclassMovementAffinitiesName = "SubclassMovementAffinities";
         private const string SubclassMovementAffinitiesGuid = "14ef799a-edc6-4749-866b-9a6afc26d4fa";
@@ -457,7 +457,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		UseArmorWeaponsAsFocusBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class UseArmorWeaponsAsFocusBuilder : BaseDefinitionBuilder<FeatureDefinitionMagicAffinity>
+    internal class UseArmorWeaponsAsFocusBuilder : DefinitionBuilder<FeatureDefinitionMagicAffinity>
     {
         private const string UseArmorWeaponsAsFocusName = "UseArmorWeaponsAsFocus";
         private const string UseArmorWeaponsAsFocusGuid = "55a4d71f-2b9d-4df6-abf1-c0cc6682eb9d";
@@ -483,7 +483,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		IntToAttackAndDamageBuilder		*******************************************************
     //*****************************************************************************************************************************************
 
-    internal class IntToAttackAndDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+    internal class IntToAttackAndDamageBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
     {
         private const string IntToAttackAndDamageName = "IntToAttackAndDamage";
         private const string IntToAttackAndDamageGuid = "ebb243f7-382c-4caf-9d7f-40c80dab4623";
@@ -514,7 +514,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //***********************************		Sentinel Suit Weapon           		*******************************************
     //*************************************************************************************************************************
 
-    internal class SentinelSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
+    internal class SentinelSuitWeaponBuilder : DefinitionBuilder<ItemDefinition>
     {
         private const string SentinelSuitWeaponName = "SentinelSuitWeapon";
         private const string SentinelSuitWeaponGuid = "c86a1f25-3364-42bc-92b8-64f1358cbf15";
@@ -651,7 +651,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ItemDefinition SentinelSuitWeapon = CreateAndAddToDB(SentinelSuitWeaponName, SentinelSuitWeaponGuid);
     }
 
-    internal class ThunderShieldBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class ThunderShieldBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string ThunderShieldName = "ThunderShield";
         private const string ThunderShieldGuid = "f5ca9b23-0326-4b26-86e7-33ebcc061faf";
@@ -711,7 +711,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly FeatureDefinitionPower ThunderShield = CreateAndAddToDB(ThunderShieldName, ThunderShieldGuid);
     }
 
-    internal class ThunderStruckConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ThunderStruckConditionBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string ThunderStruckName = "ThunderStruck";
         private const string ThunderStruckGuid = "63e2091c-4186-43d5-a099-7c8ca97224d6";
@@ -746,7 +746,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ConditionDefinition ThunderStruck = CreateAndAddToDB(ThunderStruckName, ThunderStruckGuid);
     }
 
-    internal class ThunderStruckDisadvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
+    internal class ThunderStruckDisadvantageCombatAffintityBuilder : DefinitionBuilder<FeatureDefinitionCombatAffinity>
     {
         private const string ThunderStruckDisadvantageName = "ThunderStruckDisadvantage";
         private const string ThunderStruckDisadvantageGuid = "276daa3c-3ef2-4ea8-938f-f006d2721467";
@@ -763,7 +763,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
 
         public static readonly FeatureDefinitionCombatAffinity Disadvantage = CreateAndAddToDB(ThunderStruckDisadvantageName, ThunderStruckDisadvantageGuid);
     }
-    internal class ThunderStruckBalancingAdvantageConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ThunderStruckBalancingAdvantageConditionBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string ThunderStruckBalancingAdvantageName = "ThunderStruckBalancingAdvantage";
         private const string ThunderStruckBalancingAdvantageGuid = "0b2b4bee-21b0-46c7-9504-1374bd226cb0";
@@ -792,7 +792,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ConditionDefinition ThunderStruckBalancingAdvantage = CreateAndAddToDB(ThunderStruckBalancingAdvantageName, ThunderStruckBalancingAdvantageGuid);
     }
 
-    internal class BalancingAdvantageCombatAffintityBuilder : BaseDefinitionBuilder<FeatureDefinitionCombatAffinity>
+    internal class BalancingAdvantageCombatAffintityBuilder : DefinitionBuilder<FeatureDefinitionCombatAffinity>
     {
         private const string BalancingAdvantageName = "BalancingAdvantage";
         private const string BalancingAdvantageGuid = "9dc28618-3adb-497d-930d-2a01bcac42d5";
@@ -810,7 +810,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
 
         public static readonly FeatureDefinitionCombatAffinity BalancingAdvantage = CreateAndAddToDB(BalancingAdvantageName, BalancingAdvantageGuid);
     }
-    internal class UsingitemPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+    internal class UsingitemPowerBuilder : DefinitionBuilder<FeatureDefinitionActionAffinity>
     {
         private const string UsingitemPowerName = "UsingitemPower";
         private const string UsingitemPowerGuid = "39f8cb05-5475-456a-a9b2-022b6e07850b";
@@ -836,7 +836,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //************************************************      Scout Suit Weapon        *******************************************************
     //**************************************************************************************************************************************
 
-    internal class ScoutSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
+    internal class ScoutSuitWeaponBuilder : DefinitionBuilder<ItemDefinition>
     {
         private const string ScoutSuitWeaponName = "ScoutSuitWeapon";
         private const string ScoutSuitWeaponGuid = "21f90fad-b039-4efe-bee8-5afd44453664";
@@ -945,7 +945,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ItemDefinition ScoutSuitWeapon = CreateAndAddToDB(ScoutSuitWeaponName, ScoutSuitWeaponGuid);
     }
 
-    internal class LightningSpearAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+    internal class LightningSpearAdditionalDamageBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
     {
         private const string LightningSpearAdditionalDamageName = "LightningSpearAdditionalDamage";
         private const string LightningSpearAdditionalDamageGuid = "52d19882-ca63-422d-aece-d80f806859a8";
@@ -970,7 +970,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
 
         public static readonly FeatureDefinitionAdditionalDamage LightningSpearAdditionalDamage = CreateAndAddToDB(LightningSpearAdditionalDamageName, LightningSpearAdditionalDamageGuid);
     }
-    internal class LightningCloakMovementAffinitiesBuilder : BaseDefinitionBuilder<FeatureDefinitionMovementAffinity>
+    internal class LightningCloakMovementAffinitiesBuilder : DefinitionBuilder<FeatureDefinitionMovementAffinity>
     {
         private const string LightningCloakMovementAffinitiesName = "LightningCloakMovementAffinities";
         private const string LightningCloakMovementAffinitiesGuid = "9a098f7c-0286-4a04-ba42-23b7dfc45e7b";
@@ -989,7 +989,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
 
         public static readonly FeatureDefinitionMovementAffinity LightningCloakMovementAffinities = CreateAndAddToDB(LightningCloakMovementAffinitiesName, LightningCloakMovementAffinitiesGuid);
     }
-    internal class LightningCloakAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
+    internal class LightningCloakAbilityCheckAffinityBuilder : DefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
     {
         private const string LightningCloakAbilityCheckAffinityName = "LightningCloakAbilityCheckAffinity";
         private const string LightningCloakAbilityCheckAffinityGuid = "160e74ef-1596-4b68-8a5b-48b65b155b26";
@@ -1018,7 +1018,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //*************************************************************************************************************************
     //***********************************		Improved Sentinel Suit Weapon   		****************************************
     //*************************************************************************************************************************
-    internal class ImprovedSentinelSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
+    internal class ImprovedSentinelSuitWeaponBuilder : DefinitionBuilder<ItemDefinition>
     {
         private const string ImprovedSentinelSuitWeaponName = "ImprovedSentinelSuitWeapon";
         private const string ImprovedSentinelSuitWeaponGuid = "f65108aa-1f69-4b08-b170-5fffd8444606";
@@ -1051,7 +1051,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ItemDefinition ImprovedSentinelSuitWeapon = CreateAndAddToDB(ImprovedSentinelSuitWeaponName, ImprovedSentinelSuitWeaponGuid);
     }
 
-    internal class GauntletsGrappleBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class GauntletsGrappleBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string GauntletsGrappleName = "GauntletsGrapple";
         private const string GauntletsGrappleGuid = "71b309c2-1f8b-4df4-955e-3f8504bc381e";
@@ -1132,7 +1132,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
     //**************************************************************************************************************************************
     //******************************************       Improved Scout Suit Weapon        ***************************************************
     //**************************************************************************************************************************************
-    internal class ImprovedScoutSuitWeaponBuilder : BaseDefinitionBuilder<ItemDefinition>
+    internal class ImprovedScoutSuitWeaponBuilder : DefinitionBuilder<ItemDefinition>
     {
         private const string ImprovedScoutSuitWeaponName = "ImprovedScoutSuitWeapon";
         private const string ImprovedScoutSuitWeaponGuid = "c2ebf9a1-5c45-4f70-ba6c-c791cd607ea7";
@@ -1200,7 +1200,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ItemDefinition ImprovedScoutSuitWeapon = CreateAndAddToDB(ImprovedScoutSuitWeaponName, ImprovedScoutSuitWeaponGuid);
     }
 
-    internal class DisadvantageOnAttackByEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class DisadvantageOnAttackByEnemyBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string DisadvantageOnAttackByEnemyName = "DisadvantageOnAttackByEnemy";
         private const string DisadvantageOnAttackByEnemyGuid = "94bbcf4e-c376-4804-a157-2a5a5dd003e9";
@@ -1220,7 +1220,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ConditionDefinition DisadvantageOnAttackByEnemy = CreateAndAddToDB(DisadvantageOnAttackByEnemyName, DisadvantageOnAttackByEnemyGuid);
     }
 
-    internal class AdvantageAttackOnEnemyBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class AdvantageAttackOnEnemyBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string AdvantageAttackOnEnemyName = "AdvantageAttackOnEnemy";
         private const string AdvantageAttackOnEnemyGuid = "e10ff259-0294-4814-86de-327eaa1486a6";
@@ -1240,7 +1240,7 @@ namespace SolastaCommunityExpansion.Classes.Tinkerer.Subclasses
         public static readonly ConditionDefinition AdvantageAttackOnEnemy = CreateAndAddToDB(AdvantageAttackOnEnemyName, AdvantageAttackOnEnemyGuid);
     }
 
-    internal class ExtraDamageOnAttackConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ExtraDamageOnAttackConditionBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private const string ExtraDamageOnAttackConditionName = "ExtraDamageOnAttackCondition";
         private const string ExtraDamageOnAttackConditionGuid = "2a9bc931-adb9-4751-8770-3a1367920a57";

--- a/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
+++ b/SolastaCommunityExpansion/Classes/Tinkerer/TinkererSpellList.cs
@@ -7,7 +7,7 @@ using static SolastaModApi.DatabaseHelper.SpellDefinitions;
 
 namespace SolastaCommunityExpansion.Classes.Tinkerer
 {
-    internal sealed class TinkererSpellList : BaseDefinitionBuilder<SpellListDefinition>
+    internal sealed class TinkererSpellList : DefinitionBuilder<SpellListDefinition>
     {
         private TinkererSpellList(string name, string guid, GuiPresentation guiPresentation) : base(name, guid)
         {

--- a/SolastaCommunityExpansion/CustomFeatureDefinitions/CustomFightingStyle.cs
+++ b/SolastaCommunityExpansion/CustomFeatureDefinitions/CustomFightingStyle.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
@@ -27,7 +27,7 @@ namespace SolastaCommunityExpansion.CustomFeatureDefinitions
         }
     }
 
-    public class CustomizableFightingStyleBuilder : BaseDefinitionBuilder<CustomizableFightingStyle>
+    public class CustomizableFightingStyleBuilder : DefinitionBuilder<CustomizableFightingStyle>
     {
         public CustomizableFightingStyleBuilder(string name, string guid,
             IEnumerable<FeatureDefinition> features, GuiPresentation guiPresentation) : base(name, guid)

--- a/SolastaCommunityExpansion/Feats/AcehighFeats.cs
+++ b/SolastaCommunityExpansion/Feats/AcehighFeats.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using static FeatureDefinitionSavingThrowAffinity;
@@ -30,7 +31,7 @@ namespace SolastaCommunityExpansion.Feats
             PowerAttackTwoHandedAttackModifierBuilder.PowerAttackTwoHandedAttackModifier.SetDamageRollModifier(2 * Main.Settings.FeatPowerAttackModifier);
         }
 
-        internal class PowerAttackPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        internal class PowerAttackPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string PowerAttackPowerName = "PowerAttack";
             private const string PowerAttackPowerNameGuid = "0a3e6a7d-4628-4189-b91d-d7146d774bb6";
@@ -76,7 +77,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatureDefinitionPower PowerAttackPower = CreateAndAddToDB(PowerAttackPowerName, PowerAttackPowerNameGuid);
         }
 
-        internal class PowerAttackTwoHandedPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        internal class PowerAttackTwoHandedPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string PowerAttackTwoHandedPowerName = "PowerAttackTwoHanded";
             private const string PowerAttackTwoHandedPowerNameGuid = "b45b8467-7caa-428e-b4b5-ba3c4a153f07";
@@ -122,7 +123,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatureDefinitionPower PowerAttackTwoHandedPower = CreateAndAddToDB(PowerAttackTwoHandedPowerName, PowerAttackTwoHandedPowerNameGuid);
         }
 
-        internal class PowerAttackOneHandedAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        internal class PowerAttackOneHandedAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             private const string PowerAttackAttackModifierName = "PowerAttackAttackModifier";
             private const string PowerAttackAttackModifierNameGuid = "87286627-3e62-459d-8781-ceac1c3462e6";
@@ -149,7 +150,7 @@ namespace SolastaCommunityExpansion.Feats
                 = CreateAndAddToDB(PowerAttackAttackModifierName, PowerAttackAttackModifierNameGuid);
         }
 
-        internal class PowerAttackTwoHandedAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        internal class PowerAttackTwoHandedAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             private const string PowerAttackTwoHandedAttackModifierName = "PowerAttackTwoHandedAttackModifier";
             private const string PowerAttackTwoHandedAttackModifierNameGuid = "b1b05940-7558-4f03-98d1-01f616b5ae25";
@@ -175,7 +176,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatureDefinitionAttackModifier PowerAttackTwoHandedAttackModifier = CreateAndAddToDB(PowerAttackTwoHandedAttackModifierName, PowerAttackTwoHandedAttackModifierNameGuid);
         }
 
-        internal class PowerAttackConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class PowerAttackConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string PowerAttackConditionName = "PowerAttackCondition";
             private const string PowerAttackConditionNameGuid = "c125b7b9-e668-4c6f-a742-63c065ad2292";
@@ -201,7 +202,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly ConditionDefinition PowerAttackCondition = CreateAndAddToDB(PowerAttackConditionName, PowerAttackConditionNameGuid);
         }
 
-        internal class PowerAttackTwoHandedConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class PowerAttackTwoHandedConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string PowerAttackTwoHandedConditionName = "PowerAttackTwoHandedCondition";
             private const string PowerAttackTwoHandedConditionNameGuid = "7d0eecbd-9ad8-4915-a3f7-cfa131001fe6";
@@ -227,7 +228,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly ConditionDefinition PowerAttackTwoHandedCondition = CreateAndAddToDB(PowerAttackTwoHandedConditionName, PowerAttackTwoHandedConditionNameGuid);
         }
 
-        internal class PowerAttackFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
+        internal class PowerAttackFeatBuilder : DefinitionBuilder<FeatDefinition>
         {
             private const string PowerAttackFeatName = "PowerAttackFeat";
             private const string PowerAttackFeatNameGuid = "88f1fb27-66af-49c6-b038-a38142b1083e";
@@ -251,7 +252,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatDefinition PowerAttackFeat = CreateAndAddToDB(PowerAttackFeatName, PowerAttackFeatNameGuid);
         }
 
-        internal class RecklessFuryFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
+        internal class RecklessFuryFeatBuilder : DefinitionBuilder<FeatDefinition>
         {
             private const string RecklessFuryFeatName = "RecklessFuryFeat";
             private const string RecklessFuryFeatNameGuid = "78c5fd76-e25b-499d-896f-3eaf84c711d8";
@@ -275,7 +276,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatDefinition RecklessFuryFeat = CreateAndAddToDB(RecklessFuryFeatName, RecklessFuryFeatNameGuid);
         }
 
-        internal class RagePowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        internal class RagePowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string RagePowerName = "AHRagePower";
             private const string RagePowerNameGuid = "a46c1722-7825-4a81-bca1-392b51cd7d97";
@@ -325,7 +326,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatureDefinitionPower RagePower = CreateAndAddToDB(RagePowerName, RagePowerNameGuid);
         }
 
-        internal class RageFeatConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class RageFeatConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string RageFeatConditionName = "AHRageFeatCondition";
             private const string RageFeatConditionNameGuid = "2f34fb85-6a5d-4a4e-871b-026872bc24b8";
@@ -355,7 +356,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly ConditionDefinition RageFeatCondition = CreateAndAddToDB(RageFeatConditionName, RageFeatConditionNameGuid);
         }
 
-        internal class RageStrengthSavingThrowAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
+        internal class RageStrengthSavingThrowAffinityBuilder : DefinitionBuilder<FeatureDefinitionSavingThrowAffinity>
         {
             private const string RageStrengthSavingThrowAffinityName = "AHRageStrengthSavingThrowAffinity";
             private const string RageStrengthSavingThrowAffinityNameGuid = "17d26173-7353-4087-a295-96e1ec2e6cd4";
@@ -383,7 +384,7 @@ namespace SolastaCommunityExpansion.Feats
             public static readonly FeatureDefinitionSavingThrowAffinity RageStrengthSavingThrowAffinity = CreateAndAddToDB(RageStrengthSavingThrowAffinityName, RageStrengthSavingThrowAffinityNameGuid);
         }
 
-        internal class RageDamageBonusAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        internal class RageDamageBonusAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             private const string RageDamageBonusAttackModifierName = "AHRageDamageBonusAttackModifier";
             private const string RageDamageBonusAttackModifierNameGuid = "7bc1a47e-9519-4a37-a89a-10bcfa83e48a";

--- a/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ElAntoniousFeats.cs
@@ -17,7 +17,7 @@ namespace SolastaCommunityExpansion.Feats
         }
     }
 
-    internal class DualFlurryFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
+    internal class DualFlurryFeatBuilder : DefinitionBuilder<FeatDefinition>
     {
         public static readonly Guid DualFlurryGuid = new("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
         private const string DualFlurryFeatName = "DualFlurryFeat";
@@ -74,7 +74,7 @@ namespace SolastaCommunityExpansion.Feats
         }
     }
 
-    internal class ConditionDualFlurryApplyBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionDualFlurryApplyBuilder : DefinitionBuilder<ConditionDefinition>
     {
         protected ConditionDualFlurryApplyBuilder(string name, string guid) : base(DatabaseHelper.ConditionDefinitions.ConditionSurged, name, guid)
         {
@@ -104,7 +104,7 @@ namespace SolastaCommunityExpansion.Feats
         }
     }
 
-    internal class ConditionDualFlurryGrantBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionDualFlurryGrantBuilder : DefinitionBuilder<ConditionDefinition>
     {
         protected ConditionDualFlurryGrantBuilder(string name, string guid) : base(DatabaseHelper.ConditionDefinitions.ConditionSurged, name, guid)
         {
@@ -145,7 +145,7 @@ namespace SolastaCommunityExpansion.Feats
         }
     }
 
-    internal class TorchbearerFeatBuilder : BaseDefinitionBuilder<FeatDefinition>
+    internal class TorchbearerFeatBuilder : DefinitionBuilder<FeatDefinition>
     {
         private static readonly Guid TorchbearerGuid = new("03C523EB-91B9-4F1B-A697-804D1BC2D6DD");
         private const string TorchbearerFeatName = "TorchbearerFeat";

--- a/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
+++ b/SolastaCommunityExpansion/FightingStyles/Pugilist.cs
@@ -20,7 +20,7 @@ namespace SolastaCommunityExpansion.FightingStyles
                 DatabaseHelper.FeatureDefinitionFightingStyleChoices.FightingStyleRanger,};
         }
 
-        private sealed class FeatureDefinitionAdditionalDamageBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+        private sealed class FeatureDefinitionAdditionalDamageBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
         {
             internal FeatureDefinitionAdditionalDamageBuilder(string name, string guid, string notificationTag, RuleDefinitions.FeatureLimitedUsage limitedUsage,
             RuleDefinitions.AdditionalDamageValueDetermination damageValueDetermination,

--- a/SolastaCommunityExpansion/Level20/Features/AttributeModifierFighterIndomitableBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/AttributeModifierFighterIndomitableBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionAttributeModifiers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class AttributeModifierFighterIndomitableBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+    internal class AttributeModifierFighterIndomitableBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
     {
         private const string AttributeModifierFighterIndomitableAddName = "ZSAttributeModifierFighterIndomitableAdd";
         private const string AttributeModifierFighterIndomitableAddGuid = "8a2f09cafd7b47d886cb0ce098c4f477";

--- a/SolastaCommunityExpansion/Level20/Features/IndomitableMightBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/IndomitableMightBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class IndomitableMightBuilder : BaseDefinitionBuilder<IndomitableMight>
+    internal class IndomitableMightBuilder : DefinitionBuilder<IndomitableMight>
     {
         private const string IndomitableMightName = "ZSBarbarianIndomitableMight";
         private const string IndomitableMightGuid = "2a0e9082-c81d-4d02-800a-92f04fbe85dc";

--- a/SolastaCommunityExpansion/Level20/Features/PowerClericDivineInterventionImprovementBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerClericDivineInterventionImprovementBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class PowerClericDivineInterventionImprovementBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class PowerClericDivineInterventionImprovementBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string PowerClericDivineInterventionImprovementClericName = "ZSPowerClericDivineInterventionImprovementCleric";
         private const string PowerClericDivineInterventionImprovementClericGuid = "cc4303e4-114e-43aa-a7ee-e197c9f8ef40";

--- a/SolastaCommunityExpansion/Level20/Features/PowerClericTurnUndeadBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerClericTurnUndeadBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class PowerClericTurnUndeadBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class PowerClericTurnUndeadBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string PowerClericTurnUndead14Name = "ZSPowerClericTurnUndead14";
         private const string PowerClericTurnUndead14Guid = "1258a27f594542e1b9df6f9d36a50fbe";

--- a/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerFighterActionSurge2Builder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class PowerFighterActionSurge2Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class PowerFighterActionSurge2Builder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string PowerFighterActionSurgeName = "ZSPowerFighterActionSurge2";
         private const string PowerFighterActionSurgeGuid = "a20a3955a66142e5ba9d2580a71b6c36";

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfCourage18Builder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal sealed class PowerPaladinAuraOfCourage18Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal sealed class PowerPaladinAuraOfCourage18Builder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private static FeatureDefinitionPower _instance;
 

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinAuraOfProtection18Builder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal sealed class PowerPaladinAuraOfProtection18Builder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal sealed class PowerPaladinAuraOfProtection18Builder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private static FeatureDefinitionPower _instance;
 

--- a/SolastaCommunityExpansion/Level20/Features/PowerPaladinCleansingTouchBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PowerPaladinCleansingTouchBuilder.cs
@@ -4,7 +4,7 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class PowerPaladinCleansingTouchBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class PowerPaladinCleansingTouchBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string PowerPaladinCleansingTouchName = "ZSPowerPaladinCleansingTouch";
         private const string PowerPaladinCleansingTouchGuid = "71861ca1-61ed-4344-bb26-ef21232adddd";

--- a/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
@@ -1,9 +1,9 @@
-﻿using SolastaCommunityExpansion.CustomFeatureDefinitions;
-using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
+using SolastaCommunityExpansion.CustomFeatureDefinitions;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class PrimalChampionBuilder : BaseDefinitionBuilder<PrimalChampion>
+    internal class PrimalChampionBuilder : DefinitionBuilder<PrimalChampion>
     {
         private const string PrimalChampionName = "ZSPrimalChampion";
         private const string PrimalChampionGuid = "118a5ea1-8a19-4bee-9db1-7a2464c8e7b5";

--- a/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueBlindSenseBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueBlindSenseBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionSenses;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class ProficiencyRogueBlindSenseBuilder : BaseDefinitionBuilder<FeatureDefinitionSense>
+    internal class ProficiencyRogueBlindSenseBuilder : DefinitionBuilder<FeatureDefinitionSense>
     {
         private const string ProficiencyRogueBlindSenseName = "ZSProficiencyRogueBlindSense";
         private const string ProficiencyRogueBlindSensedGuid = "30c27691f42f4705985c638d38fadc21";

--- a/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueSlipperyMindBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/ProficiencyRogueSlipperyMindBuilder.cs
@@ -1,9 +1,9 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionProficiencys;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class ProficiencyRogueSlipperyMindBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+    internal class ProficiencyRogueSlipperyMindBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
     {
         private const string ProficiencyRogueSlipperyMindName = "ZSProficiencyRogueSlipperyMind";
         private const string ProficiencyRogueSlipperyMindGuid = "b7eb00f96e13495ea4af1389fafca546";

--- a/SolastaCommunityExpansion/Level20/Features/RangerFeralSensesBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/RangerFeralSensesBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionSenses;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class RangerFeralSensesBuilder : BaseDefinitionBuilder<FeatureDefinitionSense>
+    internal class RangerFeralSensesBuilder : DefinitionBuilder<FeatureDefinitionSense>
     {
         private const string RangerFeralSensesName = "ZSRangerFeralSenses";
         private const string RangerFeralSensesGuid = "0e3207505ac04a499477ca1185287117";

--- a/SolastaCommunityExpansion/Level20/Features/RangerVanishActionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/RangerVanishActionBuilder.cs
@@ -1,10 +1,10 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using static SolastaModApi.DatabaseHelper.ActionDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionActionAffinitys;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class RangerVanishActionBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+    internal class RangerVanishActionBuilder : DefinitionBuilder<FeatureDefinitionActionAffinity>
     {
         private const string RangerVanishActionName = "ZSAdditionalActionVanish";
         private const string RangerVanishActionGuid = "83711ec64d8c47bfa91053a00a1d0a83";

--- a/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/SorcerousRestorationBuilder.cs
@@ -4,7 +4,7 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.Level20.Features
 {
-    internal class SorcerousRestorationBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+    internal class SorcerousRestorationBuilder : DefinitionBuilder<FeatureDefinitionPower>
     {
         private const string SorcerousRestorationName = "ZSSorcerousRestoration";
         private const string SorcerousRestorationGuid = "a524f8eb-8d30-4614-819d-a8f7df84f73e";
@@ -36,7 +36,7 @@ namespace SolastaCommunityExpansion.Level20.Features
             _ = RestActivityBuilder.RestActivityRestoration;
         }
 
-        private sealed class RestActivityBuilder : BaseDefinitionBuilder<RestActivityDefinition>
+        private sealed class RestActivityBuilder : DefinitionBuilder<RestActivityDefinition>
         {
             private const string SorcerousRestorationRestName = "ZSSorcerousRestorationRest";
             private const string SorcerousRestorationRestGuid = "5ee0315b-43b6-4dd9-8dd4-1eeded1cdb0e";

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
@@ -16,7 +17,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class ItemOptionsContext
     {
-        private sealed class WandIdentifyBuilder : BaseDefinitionBuilder<ItemDefinition>
+        private sealed class WandIdentifyBuilder : DefinitionBuilder<ItemDefinition>
         {
             private WandIdentifyBuilder(string name, string guid, string title, string description, ItemDefinition original) : base(original, name, guid)
             {
@@ -53,7 +54,7 @@ namespace SolastaCommunityExpansion.Models
                 WandMagicMissile);
         }
 
-        private sealed class FocusDefinitionBuilder : BaseDefinitionBuilder<ItemDefinition>
+        private sealed class FocusDefinitionBuilder : DefinitionBuilder<ItemDefinition>
         {
             private FocusDefinitionBuilder(
                 string name,

--- a/SolastaCommunityExpansion/Models/LevelDownContext.cs
+++ b/SolastaCommunityExpansion/Models/LevelDownContext.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Multiclass.Models;
-using SolastaModApi;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.RestActivityDefinitions;
 
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class LevelDownContext
     {
-        internal class RestActivityLevelDownBuilder : BaseDefinitionBuilder<RestActivityDefinition>
+        internal class RestActivityLevelDownBuilder : DefinitionBuilder<RestActivityDefinition>
         {
             private const string LevelDownName = "ZSLevelDown";
             private const string LevelDownGuid = "fdb4d86eaef942d1a22dbf1fb5a7299f";

--- a/SolastaCommunityExpansion/Models/RespecContext.cs
+++ b/SolastaCommunityExpansion/Models/RespecContext.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using UnityEngine;
@@ -13,7 +13,7 @@ namespace SolastaCommunityExpansion.Models
     {
         internal const RestActivityDefinition.ActivityCondition ActivityConditionCanRespec = (RestActivityDefinition.ActivityCondition)(-1001);
 
-        public class RestActivityRespecBuilder : BaseDefinitionBuilder<RestActivityDefinition>
+        public class RestActivityRespecBuilder : DefinitionBuilder<RestActivityDefinition>
         {
             private const string RespecName = "ZSRespec";
             private const string RespecGuid = "40824029eb224fb581f0d4e5989b6735";

--- a/SolastaCommunityExpansion/Models/TelemaCampaignContext.cs
+++ b/SolastaCommunityExpansion/Models/TelemaCampaignContext.cs
@@ -1,4 +1,4 @@
-﻿using SolastaModApi;
+﻿using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Extensions;
 using static SolastaModApi.DatabaseHelper.CampaignDefinitions;
 using static SolastaModApi.DatabaseHelper.CharacterTemplateDefinitions;
@@ -7,7 +7,7 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class TelemaCampaignContext
     {
-        private sealed class TelemaCampaignUnleashedBuilder : BaseDefinitionBuilder<CampaignDefinition>
+        private sealed class TelemaCampaignUnleashedBuilder : DefinitionBuilder<CampaignDefinition>
         {
             private const string TelemaDemoUnleashedName = "TelemaDemoUnleashed";
             private const string TelemaDemoUnleashedGuid = "397df3dcfcd444f09df11d05034ec52e";

--- a/SolastaCommunityExpansion/Multiclass/CustomDefinitions/ArmorProficiencies.cs
+++ b/SolastaCommunityExpansion/Multiclass/CustomDefinitions/ArmorProficiencies.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using SolastaModApi;
+using SolastaCommunityExpansion.Builders;
 using SolastaModApi.Infrastructure;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionProficiencys;
 
@@ -40,7 +40,7 @@ namespace SolastaCommunityExpansion.Multiclass.CustomDefinitions
     //        .AddToDB();
     //}
 
-    internal class ArmorProficiencyMulticlassBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+    internal class ArmorProficiencyMulticlassBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
     {
         private const string BarbarianArmorProficiencyMulticlassName = "BarbarianArmorProficiencyMulticlass";
         private const string BarbarianArmorProficiencyMulticlassGuid = "5dffec907a424fccbfec103344421b51";

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -387,7 +387,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class ReverseGravityConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class ReverseGravityConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHReverseGravitySpellcondition";
             private const string Guid = "809f1cef-6bdc-4b5a-93bf-275af8ab0b36";
@@ -839,7 +839,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class FeeblemindConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class FeeblemindConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHFeeblemindSpellcondition";
             private const string Guid = "965a09b2-cb22-452b-b93c-2bccdcda4871";
@@ -867,7 +867,7 @@ namespace SolastaCommunityExpansion.Spells
             internal static readonly ConditionDefinition FeeblemindCondition = CreateAndAddToDB(Name, Guid);
         }
 
-        internal class FeeblemindIntAttributeModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+        internal class FeeblemindIntAttributeModifierBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
         {
             private const string Name = "DHFeeblemindIntSpellAttributeModifier";
             private const string Guid = "a2a16bda-e7b1-4a87-9f0e-3e4c21870fd8";
@@ -892,7 +892,7 @@ namespace SolastaCommunityExpansion.Spells
             internal static readonly FeatureDefinitionAttributeModifier FeeblemindIntAttributeModifier = CreateAndAddToDB(Name, Guid);
         }
 
-        internal class FeeblemindChaAttributeModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttributeModifier>
+        internal class FeeblemindChaAttributeModifierBuilder : DefinitionBuilder<FeatureDefinitionAttributeModifier>
         {
             private const string Name = "DHFeeblemindChaSpellAttributeModifier";
             private const string Guid = "6721abe1-19eb-4a8c-9702-2fdea2070464";
@@ -918,7 +918,7 @@ namespace SolastaCommunityExpansion.Spells
             internal static readonly FeatureDefinitionAttributeModifier FeeblemindCha_AttributeModifier = CreateAndAddToDB(Name, Guid);
         }
 
-        internal class FeeblemindActionAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+        internal class FeeblemindActionAffinityBuilder : DefinitionBuilder<FeatureDefinitionActionAffinity>
         {
             private const string Name = "DHFeeblemindSpellActionAffinity";
             private const string Guid = "749a9572-07f6-4678-9458-904c04b9ab22";
@@ -991,7 +991,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class HolyAuraConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class HolyAuraConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHHolyAuraSpellcondition";
             private const string Guid = "1808ca4b-8f46-41bf-a59c-0bcbd4f60248";
@@ -1019,7 +1019,7 @@ namespace SolastaCommunityExpansion.Spells
             internal static readonly ConditionDefinition HolyAuraCondition = CreateAndAddToDB(Name, Guid);
         }
 
-        internal class HolyAuraDamageAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionDamageAffinity>
+        internal class HolyAuraDamageAffinityBuilder : DefinitionBuilder<FeatureDefinitionDamageAffinity>
         {
             private const string Name = "DHHolyAuraSpellDamageAffinity";
             private const string Guid = "c83aceae-e4c4-4a9c-a83d-58ffebe92007";
@@ -1047,7 +1047,7 @@ namespace SolastaCommunityExpansion.Spells
             internal static readonly FeatureDefinitionDamageAffinity HolyAuraDamageAffinity = CreateAndAddToDB(Name, Guid);
         }
 
-        internal class HolyAuraBlindingPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        internal class HolyAuraBlindingPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string Name = "DHHolyAuraSpellBlindingPower";
             private const string Guid = "40366ca2-00a0-471a-b370-8c81f6283ce1";
@@ -1279,7 +1279,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class MindBlankConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class MindBlankConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHMindBlankSpellcondition";
             private const string Guid = "74f77a4c-b5cb-45d6-ac6d-d9fa2ebe3869";
@@ -1478,7 +1478,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class ForesightConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class ForesightConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHForesightSpellcondition";
             private const string Guid = "4615c639-95f2-4c04-b904-e79f5b916b68";
@@ -1810,7 +1810,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class TimeStopConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class TimeStopConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHTimeStopSpellCondition";
             private const string Guid = "f00e592f-61c3-4cbf-a800-97596e83028d";
@@ -1887,7 +1887,7 @@ namespace SolastaCommunityExpansion.Spells
                 .AddToDB();
         }
 
-        internal class WeirdConditionBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        internal class WeirdConditionBuilder : DefinitionBuilder<ConditionDefinition>
         {
             private const string Name = "DHWeirdSpellCondition";
             private const string Guid = "0f76e7e1-4490-4ee8-a13f-a4a967ba1c08";

--- a/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Barbarian/PathOfTheLight.cs
@@ -444,7 +444,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             public CharacterClassDefinition Class => CharacterClassDefinitions.Barbarian;
         }
 
-        private sealed class IlluminatingStrikeFeatureBuilder : BaseDefinitionBuilder<IlluminatingStrikeAdditionalDamage>
+        private sealed class IlluminatingStrikeFeatureBuilder : DefinitionBuilder<IlluminatingStrikeAdditionalDamage>
         {
             public IlluminatingStrikeFeatureBuilder(string name, string guid, string title, string description, ConditionDefinition illuminatedCondition) : base(name, guid)
             {
@@ -540,7 +540,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
         /// <summary>
         /// Builds the power that enables Illuminating Strike while you're raging.
         /// </summary>
-        private sealed class IlluminatingStrikeInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        private sealed class IlluminatingStrikeInitiatorBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             public IlluminatingStrikeInitiatorBuilder(string name, string guid, string title, string description, ConditionDefinition illuminatedCondition) : base(name, guid)
             {
@@ -619,7 +619,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
             public bool IsRechargeSilent => true;
         }
 
-        private sealed class IlluminatingBurstBuilder : BaseDefinitionBuilder<IlluminatingBurstPower>
+        private sealed class IlluminatingBurstBuilder : DefinitionBuilder<IlluminatingBurstPower>
         {
             public IlluminatingBurstBuilder(string name, string guid, string title, string description, ConditionDefinition illuminatedCondition, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
             {
@@ -744,7 +744,7 @@ namespace SolastaCommunityExpansion.Subclasses.Barbarian
         /// <summary>
         /// Builds the power that enables Illuminating Burst on the turn you enter a rage (by removing the condition disabling it).
         /// </summary>
-        private sealed class IlluminatingBurstInitiatorBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        private sealed class IlluminatingBurstInitiatorBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             public IlluminatingBurstInitiatorBuilder(string name, string guid, string title, string description, ConditionDefinition illuminatingBurstSuppressedCondition) : base(name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
+++ b/SolastaCommunityExpansion/Subclasses/Druid/CircleOfTheForestGuardian.cs
@@ -218,7 +218,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
 
         // A builder to help us build a custom damage affinity for our Bark Ward conditions
-        public class FeatureDefinitionDamageAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionDamageAffinity>
+        public class FeatureDefinitionDamageAffinityBuilder : DefinitionBuilder<FeatureDefinitionDamageAffinity>
         {
             public FeatureDefinitionDamageAffinityBuilder(string name, string guid, bool retaliateWhenHit, int retaliationRange,
                 FeatureDefinitionPower retaliationPower, RuleDefinitions.DamageAffinityType damageAffinityType, string damageType,
@@ -236,7 +236,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
     }
 
     // Creates a dedicated builder for the the three Bark Ward conditions
-    internal class ConditionBarkWardBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionBarkWardBuilder : DefinitionBuilder<ConditionDefinition>
     {
         protected ConditionBarkWardBuilder(string name, string guid) : base(DatabaseHelper.ConditionDefinitions.ConditionBarkskin, name, guid)
         {
@@ -262,7 +262,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
     }
 
-    internal class ConditionImprovedBarkWardBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionImprovedBarkWardBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private static FeatureDefinitionPower createImprovedBarkWardRetaliate()
         {
@@ -339,7 +339,7 @@ namespace SolastaCommunityExpansion.Subclasses.Druid
         }
     }
 
-    internal class ConditionSuperiorBarkWardBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionSuperiorBarkWardBuilder : DefinitionBuilder<ConditionDefinition>
     {
         private static FeatureDefinitionPower createSuperiorBarkWardRetaliate()
         {

--- a/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/RoyalKnight.cs
@@ -32,7 +32,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 .AddToDB();
         }
 
-        internal class RoyalEnvoyAbilityCheckAffinityBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
+        internal class RoyalEnvoyAbilityCheckAffinityBuilder : DefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
         {
             private const string RoyalEnvoyAbilityCheckName = "RoyalEnvoyAbilityCheckAffinity";
             private const string RoyalEnvoyAbilityCheckGuid = "b16f8b68-0dab-49e5-b1a2-6fdfd8836849";
@@ -56,7 +56,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 => CreateAndAddToDB(RoyalEnvoyAbilityCheckName, RoyalEnvoyAbilityCheckGuid);
         }
 
-        public class RoyalEnvoyFeatureBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+        public class RoyalEnvoyFeatureBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
         {
             private const string RoyalEnvoyFeatureName = "RoyalEnvoyFeature";
             private const string RoyalEnvoyFeatureGuid = "c8299685-d806-4e20-aff0-ca3dd4000e05";
@@ -79,7 +79,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 => CreateAndAddToDB(RoyalEnvoyFeatureName, RoyalEnvoyFeatureGuid);
         }
 
-        public class RallyingCryPowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        public class RallyingCryPowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string RallyingCryPowerName = "RallyingCryPower";
             private const string RallyingCryPowerGuid = "cabe94a7-7e51-4231-ae6d-e8e6e3954611";
@@ -118,7 +118,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
                 => CreateAndAddToDB(RallyingCryPowerName, RallyingCryPowerGuid);
         }
 
-        internal class InspiringSurgePowerBuilder : BaseDefinitionBuilder<FeatureDefinitionPower>
+        internal class InspiringSurgePowerBuilder : DefinitionBuilder<FeatureDefinitionPower>
         {
             private const string InspiringSurgePowerName = "InspiringSurgePower";
             private const string InspiringSurgePowerNameGuid = "c2930ad2-dd02-4ff3-bad8-46d93e328fbd";

--- a/SolastaCommunityExpansion/Subclasses/Fighter/SpellShield.cs
+++ b/SolastaCommunityExpansion/Subclasses/Fighter/SpellShield.cs
@@ -129,7 +129,7 @@ namespace SolastaCommunityExpansion.Subclasses.Fighter
             Subclass = spellShield.AddToDB();
         }
 
-        private sealed class SpellShieldRangedDeflection : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+        private sealed class SpellShieldRangedDeflection : DefinitionBuilder<FeatureDefinitionActionAffinity>
         {
             public SpellShieldRangedDeflection(FeatureDefinitionActionAffinity original, string name, string guid, GuiPresentation guiPresentation) : base(original, name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -110,7 +110,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
                 FeatureDefinitionFeatureSet.FeatureSetMode.Union, arcanistMagicGui).AddToDB();
         }
 
-        private sealed class FeatureDefinitionAutoPreparedSpellsBuilder : BaseDefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
+        private sealed class FeatureDefinitionAutoPreparedSpellsBuilder : DefinitionBuilder<FeatureDefinitionAutoPreparedSpells>
         {
             public FeatureDefinitionAutoPreparedSpellsBuilder(string name, string guid, List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> autospelllists,
                 CharacterClassDefinition characterclass, GuiPresentation guiPresentation) : base(name, guid)
@@ -121,7 +121,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
             }
         }
 
-        private sealed class FeatureDefinitionFeatureSetBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+        private sealed class FeatureDefinitionFeatureSetBuilder : DefinitionBuilder<FeatureDefinitionFeatureSet>
         {
             public FeatureDefinitionFeatureSetBuilder(string name, string guid, List<FeatureDefinition> features,
                 FeatureDefinitionFeatureSet.FeatureSetMode mode, GuiPresentation guiPresentation) : base(name, guid)
@@ -212,7 +212,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
                 new GuiPresentationBuilder("Feature/&ArcaneDetonationUpgradeTitle", "Feature/&ArcaneDetonationUpgradeDescription").Build()).AddToDB();
         }
 
-        private sealed class FeatureDefinitionBuilder : BaseDefinitionBuilder<FeatureDefinition>
+        private sealed class FeatureDefinitionBuilder : DefinitionBuilder<FeatureDefinition>
         {
             public FeatureDefinitionBuilder(string name, string guid, GuiPresentation guiPresentation) : base(name, guid)
             {
@@ -297,7 +297,7 @@ namespace SolastaCommunityExpansion.Subclasses.Ranger
     }
 
     // Creates a dedicated builder for the marked by arcanist condition. This helps with GUID wonkiness on the fact that separate features interact with it.
-    internal class ConditionMarkedByArcanistBuilder : BaseDefinitionBuilder<ConditionDefinition>
+    internal class ConditionMarkedByArcanistBuilder : DefinitionBuilder<ConditionDefinition>
     {
         protected ConditionMarkedByArcanistBuilder(string name, string guid) : base(DatabaseHelper.ConditionDefinitions.ConditionMarkedByBrandingSmite, name, guid)
         {

--- a/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/ConArtist.cs
@@ -107,7 +107,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
             Subclass = conArtist.AddToDB();
         }
 
-        public class AdvantageBuilder : BaseDefinitionBuilder<ConditionDefinition>
+        public class AdvantageBuilder : DefinitionBuilder<ConditionDefinition>
         {
             public AdvantageBuilder(string name, string guid, ConditionDefinition original, GuiPresentation guiPresentation) : base(original, name, guid)
             {

--- a/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
+++ b/SolastaCommunityExpansion/Subclasses/Rogue/Thug.cs
@@ -51,7 +51,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 .AddToDB();
         }
 
-        private sealed class RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder : BaseDefinitionBuilder<FeatureDefinitionAdditionalDamage>
+        private sealed class RogueSubclassThugExploitVulnerabilitiesSneakAttackBuilder : DefinitionBuilder<FeatureDefinitionAdditionalDamage>
         {
             private const string ExploitVulnerabilitiesName = "KSRogueSubclassThugExploitVulnerabilities";
             private static readonly string ExploitVulnerabilitiesGuid = GuidHelper.Create(SubclassNamespace, ExploitVulnerabilitiesName).ToString();
@@ -72,7 +72,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 CreateAndAddToDB(ExploitVulnerabilitiesName, ExploitVulnerabilitiesGuid);
         }
 
-        private sealed class RogueSubclassThugProficienciesBuilder : BaseDefinitionBuilder<FeatureDefinitionProficiency>
+        private sealed class RogueSubclassThugProficienciesBuilder : DefinitionBuilder<FeatureDefinitionProficiency>
         {
             private const string RogueSubclassThugProficienciesName = "KSRogueSubclassThugProficiencies";
             private static readonly string RogueSubclassThugProficienciesGuid = GuidHelper.Create(SubclassNamespace, RogueSubclassThugProficienciesName).ToString();
@@ -95,7 +95,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 CreateAndAddToDB(RogueSubclassThugProficienciesName, RogueSubclassThugProficienciesGuid);
         }
 
-        private sealed class RogueSubclassThugBrutalMethodsBuilder : BaseDefinitionBuilder<FeatureDefinitionActionAffinity>
+        private sealed class RogueSubclassThugBrutalMethodsBuilder : DefinitionBuilder<FeatureDefinitionActionAffinity>
         {
             private const string RogueSubclassThugBrutalMethodsName = "KSRogueSubclassThugBrutalMethods";
             private static readonly string RogueSubclassThugBrutalMethodsGuid = GuidHelper.Create(SubclassNamespace, RogueSubclassThugBrutalMethodsName).ToString();
@@ -117,7 +117,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 CreateAndAddToDB(RogueSubclassThugBrutalMethodsName, RogueSubclassThugBrutalMethodsGuid);
         }
 
-        private sealed class RogueSubclassThugBrutalMethodsActionBuilder : BaseDefinitionBuilder<ActionDefinition>
+        private sealed class RogueSubclassThugBrutalMethodsActionBuilder : DefinitionBuilder<ActionDefinition>
         {
             private const string RogueSubclassThugBrutalMethodsActionName = "KSRogueSubclassThugBrutalMethodsAction";
             private static readonly string RogueSubclassThugBrutalMethodsActionGuid = GuidHelper.Create(SubclassNamespace, RogueSubclassThugBrutalMethodsActionName).ToString();
@@ -136,7 +136,7 @@ namespace SolastaCommunityExpansion.Subclasses.Rogue
                 = CreateAndAddToDB(RogueSubclassThugBrutalMethodsActionName, RogueSubclassThugBrutalMethodsActionGuid);
         }
 
-        private sealed class RogueSubclassThugOvercomeCompetitionBuilder : BaseDefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
+        private sealed class RogueSubclassThugOvercomeCompetitionBuilder : DefinitionBuilder<FeatureDefinitionAbilityCheckAffinity>
         {
             private const string RogueSubclassThugOvercomeCompetitionName = "KSRogueSubclassThugOvercomeCompetition";
             private static readonly string RogueSubclassThugOvercomeCompetitionGuid = GuidHelper.Create(SubclassNamespace, RogueSubclassThugOvercomeCompetitionName).ToString();

--- a/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/ArcaneFighter.cs
@@ -166,7 +166,7 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
             return builder.AddToDB();
         }
 
-        private sealed class FeatureDefinitionAttackModifierBuilder : BaseDefinitionBuilder<FeatureDefinitionAttackModifier>
+        private sealed class FeatureDefinitionAttackModifierBuilder : DefinitionBuilder<FeatureDefinitionAttackModifier>
         {
             public FeatureDefinitionAttackModifierBuilder(string name, string guid,
             RuleDefinitions.AbilityScoreReplacement abilityReplacement, string additionalAttackTag,

--- a/SolastaCommunityExpansion/Subclasses/Wizard/SpellMaster.cs
+++ b/SolastaCommunityExpansion/Subclasses/Wizard/SpellMaster.cs
@@ -157,7 +157,7 @@ namespace SolastaCommunityExpansion.Subclasses.Wizard
             }
         }
 
-        private sealed class RestActivityDefinitionBuilder : BaseDefinitionBuilder<RestActivityDefinition>
+        private sealed class RestActivityDefinitionBuilder : DefinitionBuilder<RestActivityDefinition>
         {
             private RestActivityDefinitionBuilder(string name, Guid namespaceGuid) : base(name, namespaceGuid)
             {


### PR DESCRIPTION
DefinitionBuilder is for internal use only and has private protected ctors. 
It has to be public since presumably at least some derived builders should be public.
BaseDefinitionBuilder is for external use and delegates to DefinitionBuilder.
