### PR TITLE
fix twf

### DIFF
--- a/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
+++ b/SolastaCommunityExpansion/Feats/FightingStlyeFeats.cs
@@ -23,6 +23,7 @@ namespace SolastaCommunityExpansion.Feats
             {
                 new FeatureDefinitionProficiencyBuilder("FeatFightingStyleTwoWeaponProficiency", GuidHelper.Create(FightingStyleFeatsNamespace, "FeatFightingStyleTwoWeaponProficiency").ToString(),
                     RuleDefinitions.ProficiencyType.FightingStyle, new List<string>(){"TwoWeapon"}, twoWeaponPresentation.Build()).AddToDB(),
+                DatabaseHelper.FeatureDefinitionAttackModifiers.AttackModifierFightingStyleTwoWeapon,
             }, twoWeaponPresentation.Build());
             feats.Add(twoWeapon.AddToDB());
 


### PR DESCRIPTION
Fixes the Two Weapon Fighting style feat to correctly add ability modifier damage to off-hand weapon attacks by importing the core two weapon fighting style modifier feature into the feat.