### PR TITLE
Change CancelCursor patch to send Id.Cancel to appropriate screen

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUi/Location/CursorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/CursorPatcher.cs
@@ -23,7 +23,7 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                     __instance is not CursorLocationExplorationDefault)
                 {
                     GuiScreen screen = Gui.CurrentLocationScreen ?? Gui.GuiService.GetScreen<UserLocationEditorScreen>();
-                    if (screen != null)
+                    if (screen != null && screen.Visible)
                     {
                         Main.Log($"Cancelling {screen.GetType().Name} cursor");
                         screen.HandleInput(InputCommands.Id.Cancel);

--- a/SolastaCommunityExpansion/Patches/GameUi/Location/CursorPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Location/CursorPatcher.cs
@@ -22,7 +22,12 @@ namespace SolastaCommunityExpansion.Patches.GameUi.Location
                     __instance is not CursorLocationEditorDefault &&
                     __instance is not CursorLocationExplorationDefault)
                 {
-                    ServiceRepository.GetService<ICursorService>()?.DeactivateCursor();
+                    GuiScreen screen = Gui.CurrentLocationScreen ?? Gui.GuiService.GetScreen<UserLocationEditorScreen>();
+                    if (screen != null)
+                    {
+                        Main.Log($"Cancelling {screen.GetType().Name} cursor");
+                        screen.HandleInput(InputCommands.Id.Cancel);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Using DeactivateCursor doesn't invoke the appropriate code.  Command.Id.Cancel does.