### PR TITLE
Now only show square/round cylinder.  

### DIFF
--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SquareCylinder/GeometryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SquareCylinder/GeometryPatcher.cs
@@ -21,7 +21,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules.SquareCylinder
         {
             __instance.UpdateCubePosition_Regular(origin, edgeSize, adaptToGroundLevel, isValid);
 
-            if (!Main.Settings.EnableTargetTypeSquareCylinder)
+            if (!Main.Settings.UseHeightOneCylinderEffect)
             {
 #if DEBUG
                 var t = __instance.GetField<GeometricShape, MeshRenderer>("cubeRenderer").transform;
@@ -112,7 +112,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules.SquareCylinder
             MetricsDefinitions.GeometricShapeType ___shapeType, Vector3 ___origin, ref Bounds ___bounds,
             float ___geometricParameter, float ___geometricParameter2, bool ___hasMagneticTargeting, RuleDefinitions.RangeType ___rangeType)
         {
-            if (!Main.Settings.EnableTargetTypeSquareCylinder)
+            if (!Main.Settings.UseHeightOneCylinderEffect)
             {
 #if DEBUG
                 var min1 = ___bounds.min;
@@ -175,7 +175,7 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules.SquareCylinder
         {
             var __result = GeometryUtils.CubeContainsPoint_Regular(cubeOrigin, edgeSize, hasMagneticTargeting, point);
 
-            if (!Main.Settings.EnableTargetTypeSquareCylinder)
+            if (!Main.Settings.UseHeightOneCylinderEffect)
             {
                 Main.Log($"GeometryUtils_CubeContainsPoint_Regular (off): edge={edgeSize}, origin=({cubeOrigin.x}, {cubeOrigin.y}, {cubeOrigin.z}), point=({point.x}, {point.y}, {point.z}), result={__result}");
                 return __result;

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -199,7 +199,6 @@ namespace SolastaCommunityExpansion
         public bool EnableUpcastConjureElementalAndFey { get; set; }
         public bool FullyControlConjurations { get; set; }
         public bool OnlyShowMostPowerfulUpcastConjuredElementalOrFey { get; set; }
-        public bool UseCylinderForSpikeGrowth { get; set; }
         public bool UseHeightOneCylinderEffect { get; set; }
 
         // House

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -200,7 +200,7 @@ namespace SolastaCommunityExpansion
         public bool FullyControlConjurations { get; set; }
         public bool OnlyShowMostPowerfulUpcastConjuredElementalOrFey { get; set; }
         public bool UseCylinderForSpikeGrowth { get; set; }
-        public bool EnableTargetTypeSquareCylinder { get; set; }
+        public bool UseHeightOneCylinderEffect { get; set; }
 
         // House
         public bool AllowAnyClassToWearSylvanArmor { get; set; }

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -199,8 +199,7 @@ namespace SolastaCommunityExpansion
         public bool EnableUpcastConjureElementalAndFey { get; set; }
         public bool FullyControlConjurations { get; set; }
         public bool OnlyShowMostPowerfulUpcastConjuredElementalOrFey { get; set; }
-        public bool SpikeGrowthDoesNotAffectFlyingCreatures { get; set; }
-        public bool SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures { get; set; }
+        public bool UseCylinderForSpikeGrowth { get; set; }
         public bool EnableTargetTypeSquareCylinder { get; set; }
 
         // House

--- a/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
+++ b/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
@@ -10,16 +10,20 @@ namespace SolastaCommunityExpansion.Spells
         public static void Register()
         {
             AddBleedingToRestoration();
-            UseCylinderForSpikeGrowth();
-            UseSquareCylinder();
+            UseHeightOneCylinderEffect();
         }
 
-        internal static void UseCylinderForSpikeGrowth()
+        internal static void UseHeightOneCylinderEffect()
         {
+            // always applicable
+            ClearTargetParameter2ForTargetTypeCube();
+
+            ///////////////////////////////////////////////////////////
+            // Change SpikeGrowth to be height 1 round cylinder/sphere
             var spikeGrowthEffect = SpikeGrowth.EffectDescription;
             spikeGrowthEffect.SetTargetParameter(4);
 
-            if (Main.Settings.UseCylinderForSpikeGrowth)
+            if (Main.Settings.UseHeightOneCylinderEffect)
             {
                 // Set to Cylinder radius 4, height 1
                 spikeGrowthEffect.SetTargetType(RuleDefinitions.TargetType.Cylinder);
@@ -31,12 +35,6 @@ namespace SolastaCommunityExpansion.Spells
                 spikeGrowthEffect.SetTargetType(RuleDefinitions.TargetType.Sphere);
                 spikeGrowthEffect.SetTargetParameter2(0);
             }
-        }
-
-        internal static void UseSquareCylinder()
-        {
-            // always applicable
-            ClearTargetParameter2ForTargetTypeCube();
 
             // Spells with TargetType.Cube and defaults values of (tp, tp2)
             // Note that tp2 should be 0 for Cube and is ignored in game.
@@ -49,7 +47,9 @@ namespace SolastaCommunityExpansion.Spells
             // PetalStorm: (3, 2)
             // Slow: (8, 2)
 
-            if (Main.Settings.EnableTargetTypeSquareCylinder)
+            ///////////////////////////////////////////////////////////
+            // Change Black Tentacles, Entangle, Grease to be height 1 square cylinder/cube
+            if (Main.Settings.UseHeightOneCylinderEffect)
             {
                 // Setting height switches to square cylinder (if originally cube)
                 SetHeight(BlackTentacles, 1);

--- a/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
+++ b/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
@@ -10,40 +10,30 @@ namespace SolastaCommunityExpansion.Spells
         public static void Register()
         {
             AddBleedingToRestoration();
-            SpikeGrowthDoesNotAffectFlyingCreatures();
-            SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures();
+            UseCylinderForSpikeGrowth();
+            UseSquareCylinder();
         }
 
-        internal static void SpikeGrowthDoesNotAffectFlyingCreatures()
+        internal static void UseCylinderForSpikeGrowth()
         {
             var spikeGrowthEffect = SpikeGrowth.EffectDescription;
             spikeGrowthEffect.SetTargetParameter(4);
 
-            if (Main.Settings.SpikeGrowthDoesNotAffectFlyingCreatures)
+            if (Main.Settings.UseCylinderForSpikeGrowth)
             {
                 // Set to Cylinder radius 4, height 1
-                spikeGrowthEffect.EffectForms
-                    .Where(ef => ef.FormType == EffectForm.EffectFormType.Topology)
-                    .ToList()
-                    .ForEach(ef => ef.TopologyForm.SetImpactsFlyingCharacters(false));
-
                 spikeGrowthEffect.SetTargetType(RuleDefinitions.TargetType.Cylinder);
                 spikeGrowthEffect.SetTargetParameter2(1);
             }
             else
             {
                 // Restore default of Sphere radius 4
-                spikeGrowthEffect.EffectForms
-                    .Where(ef => ef.FormType == EffectForm.EffectFormType.Topology)
-                    .ToList()
-                    .ForEach(ef => ef.TopologyForm.SetImpactsFlyingCharacters(true));
-
                 spikeGrowthEffect.SetTargetType(RuleDefinitions.TargetType.Sphere);
                 spikeGrowthEffect.SetTargetParameter2(0);
             }
         }
 
-        internal static void SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures()
+        internal static void UseSquareCylinder()
         {
             // always applicable
             ClearTargetParameter2ForTargetTypeCube();
@@ -59,54 +49,24 @@ namespace SolastaCommunityExpansion.Spells
             // PetalStorm: (3, 2)
             // Slow: (8, 2)
 
-            if (!Main.Settings.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures)
+            if (Main.Settings.EnableTargetTypeSquareCylinder)
             {
-                RestoreDefinition(BlackTentacles);
-                RestoreDefinition(Entangle);
-                RestoreDefinition(Grease);
-                return;
+                // Setting height switches to square cylinder (if originally cube)
+                SetHeight(BlackTentacles, 1);
+                SetHeight(Entangle, 1);
+                SetHeight(Grease, 1);
+            }
+            else
+            {
+                // Setting height to 0 restores original behaviour
+                SetHeight(BlackTentacles, 0);
+                SetHeight(Entangle, 0);
+                SetHeight(Grease, 0);
             }
 
-            SetHeight(BlackTentacles);
-            SetHeight(Entangle);
-            SetHeight(Grease);
-
-            static void SetHeight(SpellDefinition sd, int height = 1)
+            static void SetHeight(SpellDefinition sd, int height)
             {
-                var effect = sd.EffectDescription;
-
-                effect.EffectForms
-                    .Where(ef => ef.FormType == EffectForm.EffectFormType.Topology)
-                    .ToList()
-                    .ForEach(ef => ef.TopologyForm.SetImpactsFlyingCharacters(false));
-
-                if (Main.Settings.EnableTargetTypeSquareCylinder)
-                {
-                    Main.Log($"Changing {sd.Name} to target type=Cube");
-                    effect.SetTargetType(RuleDefinitions.TargetType.Cube);
-                }
-                else
-                {
-                    Main.Log($"Changing {sd.Name} to target type=CylinderWithDiameter");
-                    effect.SetTargetType(RuleDefinitions.TargetType.CylinderWithDiameter);
-                }
-
-                effect.SetTargetParameter2(height);
-            }
-
-            static void RestoreDefinition(SpellDefinition sd)
-            {
-                var effect = sd.EffectDescription;
-
-                // Topology forms have ImpactsFlyingCharacters = true as default
-                effect.EffectForms
-                    .Where(ef => ef.FormType == EffectForm.EffectFormType.Topology)
-                    .ToList()
-                    .ForEach(ef => ef.TopologyForm.SetImpactsFlyingCharacters(true));
-
-                Main.Log($"Restoring {sd.Name} to target type=Cube");
-                effect.SetTargetType(RuleDefinitions.TargetType.Cube);
-                effect.SetTargetParameter2(0);
+                sd.EffectDescription.SetTargetParameter2(height);
             }
 
             static void ClearTargetParameter2ForTargetTypeCube()

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -101,28 +101,18 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                     }
                 }
 
-                toggle = Main.Settings.SpikeGrowthDoesNotAffectFlyingCreatures;
-                if (UI.Toggle("Spike Growth".orange() + " does not affect flying creatures flying higher than 1 cell", ref toggle, UI.AutoWidth()))
+                toggle = Main.Settings.UseCylinderForSpikeGrowth;
+                if (UI.Toggle("Display a height 1 cylinder when casting " + "Spike Growth".orange(), ref toggle, UI.AutoWidth()))
                 {
-                    Main.Settings.SpikeGrowthDoesNotAffectFlyingCreatures = toggle;
-                    HouseSpellTweaks.SpikeGrowthDoesNotAffectFlyingCreatures();
+                    Main.Settings.UseCylinderForSpikeGrowth = toggle;
+                    HouseSpellTweaks.UseCylinderForSpikeGrowth();
                 }
 
-                toggle = Main.Settings.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures;
-                if (UI.Toggle("Black Tentacles, Entangle, Grease".orange() + " do not affect flying creatures flying higher than 1 cell", ref toggle, UI.AutoWidth()))
+                toggle = Main.Settings.EnableTargetTypeSquareCylinder;
+                if (UI.Toggle("Display a height 1 square cylinder when casting " + "Black Tentacles, Entangle, Grease".orange(), ref toggle, UI.AutoWidth()))
                 {
-                    Main.Settings.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures = toggle;
-                    HouseSpellTweaks.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures();
-                }
-
-                if (Main.Settings.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures)
-                {
-                    toggle = Main.Settings.EnableTargetTypeSquareCylinder;
-                    if (UI.Toggle("+ Use a square area of effect for these spells ".italic() + "[A circular area requires less code changes but is non-SRD]".yellow().italic(), ref toggle, UI.AutoWidth()))
-                    {
-                        Main.Settings.EnableTargetTypeSquareCylinder = toggle;
-                        HouseSpellTweaks.SquareAreaOfEffectSpellsDoNotAffectFlyingCreatures();
-                    }
+                    Main.Settings.EnableTargetTypeSquareCylinder = toggle;
+                    HouseSpellTweaks.UseSquareCylinder();
                 }
             }
 

--- a/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Viewers/Displays/RulesDisplay.cs
@@ -100,20 +100,6 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                         Main.Settings.OnlyShowMostPowerfulUpcastConjuredElementalOrFey = toggle;
                     }
                 }
-
-                toggle = Main.Settings.UseCylinderForSpikeGrowth;
-                if (UI.Toggle("Display a height 1 cylinder when casting " + "Spike Growth".orange(), ref toggle, UI.AutoWidth()))
-                {
-                    Main.Settings.UseCylinderForSpikeGrowth = toggle;
-                    HouseSpellTweaks.UseCylinderForSpikeGrowth();
-                }
-
-                toggle = Main.Settings.EnableTargetTypeSquareCylinder;
-                if (UI.Toggle("Display a height 1 square cylinder when casting " + "Black Tentacles, Entangle, Grease".orange(), ref toggle, UI.AutoWidth()))
-                {
-                    Main.Settings.EnableTargetTypeSquareCylinder = toggle;
-                    HouseSpellTweaks.UseSquareCylinder();
-                }
             }
 
             UI.Label("");
@@ -169,6 +155,14 @@ namespace SolastaCommunityExpansion.Viewers.Displays
                 if (UI.Toggle("Quick cast light cantrip uses head or torso worn items first", ref toggle, UI.AutoWidth()))
                 {
                     Main.Settings.QuickCastLightCantripOnWornItemsFirst = toggle;
+                }
+
+                toggle = Main.Settings.UseHeightOneCylinderEffect;
+                if (UI.Toggle("Display a height 1 cylinder effect when casting " + "Black Tentacles, Entangle, Grease ".orange() +
+                    " (square cylinder), ".yellow() + "Spike Growth".orange() + " (round cylinder).".yellow(), ref toggle, UI.AutoWidth()))
+                {
+                    Main.Settings.UseHeightOneCylinderEffect = toggle;
+                    HouseSpellTweaks.UseHeightOneCylinderEffect();
                 }
 
                 UI.Label("");


### PR DESCRIPTION
TA has fixed Grease, Entangle, Black Tentacles so they don't affect flying creatures.
All we need to do is change the geometric cursor to show cylinder/square cylinder.