### PR TITLE
Change CENamespaceGuid to equal Settings.GUID

### DIFF
--- a/SolastaCommunityExpansion/Builders/DefinitionBuilder.cs
+++ b/SolastaCommunityExpansion/Builders/DefinitionBuilder.cs
@@ -89,7 +89,7 @@ namespace SolastaCommunityExpansion.Builders
             typeof(DatabaseRepository).GetMethod("GetDatabase", BindingFlags.Public | BindingFlags.Static);
 
         protected const string CENamePrefix = "_CE_";
-        protected internal static readonly Guid CENamespaceGuid = new("4ce4cabe-0d35-4419-86ef-13ce1bef32fd");
+        protected internal static readonly Guid CENamespaceGuid = new(Settings.GUID);
     }
 
     // Used to allow extension methods in other mods to set GuiPresentation 

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/Assets.txt
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/Assets.txt
@@ -42,7 +42,7 @@ ConditionCharm	ConditionDefinition	ConditionDefinition	bcbe10ad-80bc-5777-a157-0
 ConditionDisorient	ConditionDefinition	ConditionDefinition	6af55055-ba7b-504a-8a18-c904eeae27ea
 ConditionEvilEye	ConditionDefinition	ConditionDefinition	b8d95cb9-d3c2-5f3c-9bee-83975745dad0
 ConditionFrenzied	ConditionDefinition	ConditionDefinition	09a5ca8a-6f64-51f0-ae67-ec6da8c0204e
-ConditionHelpPower	ConditionDefinition	ConditionDefinition	3071b2bf-0d83-5f1d-9eba-07f2c5c52bc5
+ConditionHelpPower	ConditionDefinition	ConditionDefinition	cbc0e166-7927-5321-9fff-f78c8d7d7e0d
 ConditionInfuseAmuletOfHealth	ConditionDefinition	ConditionDefinition	1987d833-9460-5472-812a-cf673836cacf
 ConditionInfuseBeltOfGiantHillStrength	ConditionDefinition	ConditionDefinition	3a3a1fa8-fa39-52fa-913c-b6cbe3dbbdad
 ConditionInfuseBootsOfElvenKind	ConditionDefinition	ConditionDefinition	e5478be7-b8bb-55ba-9af2-145ea2eb3150
@@ -1226,6 +1226,8 @@ LivewoodStaff	ItemDefinition	ItemDefinition	ff3ec29c-734f-4ef6-8d6e-ceb961d9a8a0
 ScoutSuitWeapon	ItemDefinition	ItemDefinition	21f90fad-b039-4efe-bee8-5afd44453664
 SentinelSuitWeapon	ItemDefinition	ItemDefinition	c86a1f25-3364-42bc-92b8-64f1358cbf15
 WandIdentify	ItemDefinition	ItemDefinition	46ae7624-4d24-455a-98f9-d41403b0ae19
+PickPocketLoot	LootPackDefinition	LootPackDefinition	30c308db-1ad7-4f93-9431-43ce32358493
+PickPocketUndead	LootPackDefinition	LootPackDefinition	af2eb8e0-6a5a-40e2-8a62-160f80e2453e
 ArtificialServantAttacksList	MonsterAttackDefinition	MonsterAttackDefinition	86840282-4d84-44b7-a4fd-6bf6b598f776
 AttackWitchOwlTalons	MonsterAttackDefinition	MonsterAttackDefinition	02743cb9-5f9d-5c2c-8a6e-da4e92242eb4
 ForceArtilleryAttack	MonsterAttackDefinition	MonsterAttackDefinition	39c5b7ef-47f9-462c-9f24-accaee85d325
@@ -1440,3 +1442,5 @@ WitchFamiliar	SpellDefinition	SpellDefinition	07e56c1a-9211-5f6d-add9-e85a5321d2
 DHCouatlSpellList	SpellListDefinition	SpellListDefinition	9c861b19-ef70-5207-b1b4-d779a6c0d1aa
 SpellListTinkerer	SpellListDefinition	SpellListDefinition	5f26ef4a-30cc-56f9-9d31-ad3ecce7d2fe
 WitchSpellList	SpellListDefinition	SpellListDefinition	2c02f236-7ebc-5063-84ac-0ea562968319
+PickPocketTable	TreasureTableDefinition	TreasureTableDefinition	79cac3e5-0f00-4062-b263-adbc854223d7
+PickPocketTableC	TreasureTableDefinition	TreasureTableDefinition	f1bbd8e5-3e05-48da-9c70-2db676a280b4

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ConditionDefinition/ConditionHelpPower.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ConditionDefinition/ConditionHelpPower.json
@@ -272,7 +272,7 @@
     "unusedInSolastaCOTM": false
   },
   "contentCopyright": "OpenGameContentModified",
-  "guid": "3071b2bf-0d83-5f1d-9eba-07f2c5c52bc5",
+  "guid": "cbc0e166-7927-5321-9fff-f78c8d7d7e0d",
   "contentPack": "BaseGame",
   "name": "ConditionHelpPower"
 }

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/FeatureDefinitionPower/HelpAction.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/FeatureDefinitionPower/HelpAction.json
@@ -76,7 +76,7 @@
           "$id": "3",
           "$type": "ConditionForm, Assembly-CSharp",
           "conditionDefinitionName": "ConditionTrueStrike",
-          "conditionDefinition": "Definition:ConditionHelpPower:3071b2bf-0d83-5f1d-9eba-07f2c5c52bc5",
+          "conditionDefinition": "Definition:ConditionHelpPower:cbc0e166-7927-5321-9fff-f78c8d7d7e0d",
           "operation": "Add",
           "conditionsList": [],
           "applyToSelf": false,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Acuteness.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Acuteness.json
@@ -379,7 +379,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "35",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -387,19 +393,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "35",
+    "$id": "36",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "36",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "37",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -409,22 +405,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "38",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "39",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -439,17 +430,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "40",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "41",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -459,7 +455,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "42",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -469,8 +465,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "43",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -481,10 +487,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "44",
+    "$id": "45",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "45",
+      "$id": "46",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -500,13 +506,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "46",
+    "$id": "47",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "47",
+      "$id": "48",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -526,20 +532,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Acuteness_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Acuteness_Description",
     "spriteReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "50",
+      "$id": "51",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Dragonblade.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Dragonblade.json
@@ -427,7 +427,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "38",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -435,19 +441,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "38",
+    "$id": "39",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "39",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "40",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -457,22 +453,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "41",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "42",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -487,17 +478,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "43",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -507,7 +503,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "45",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -517,8 +513,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "46",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "47",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -529,10 +535,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "47",
+    "$id": "48",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "48",
+      "$id": "49",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -548,13 +554,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "49",
+    "$id": "50",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "50",
+      "$id": "51",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -574,20 +580,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "51",
+    "$id": "52",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Dragonblade_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Dragonblade_Description",
     "spriteReference": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "53",
+      "$id": "54",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Frostburn.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Frostburn.json
@@ -411,7 +411,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "37",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -419,19 +425,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "37",
+    "$id": "38",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "38",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "39",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -441,22 +437,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "40",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "41",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -471,17 +462,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "42",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "43",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -491,7 +487,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -501,8 +497,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "45",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -513,10 +519,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "46",
+    "$id": "47",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "47",
+      "$id": "48",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -532,13 +538,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -558,20 +564,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Frostburn_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Frostburn_Description",
     "spriteReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Lightbringer.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Lightbringer.json
@@ -411,7 +411,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "37",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -419,19 +425,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "37",
+    "$id": "38",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "38",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "39",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -441,22 +437,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "40",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "41",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -471,17 +462,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "42",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "43",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -491,7 +487,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -501,8 +497,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "45",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -513,10 +519,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "46",
+    "$id": "47",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "47",
+      "$id": "48",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -532,13 +538,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -558,20 +564,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Lightbringer_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Lightbringer_Description",
     "spriteReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Souldrinker.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Souldrinker.json
@@ -411,7 +411,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "37",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -419,19 +425,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "37",
+    "$id": "38",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "38",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "39",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -441,22 +437,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "40",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "41",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -471,17 +462,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "42",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "43",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -491,7 +487,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -501,8 +497,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "45",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -513,10 +519,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "46",
+    "$id": "47",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "47",
+      "$id": "48",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -532,13 +538,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -558,20 +564,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Souldrinker_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Souldrinker_Description",
     "spriteReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Stormblade.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Stormblade.json
@@ -411,7 +411,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "37",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -419,19 +425,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "37",
+    "$id": "38",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "38",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "39",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -441,22 +437,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "40",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "41",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -471,17 +462,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "42",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "43",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -491,7 +487,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -501,8 +497,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "45",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -513,10 +519,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "46",
+    "$id": "47",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "47",
+      "$id": "48",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -532,13 +538,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -558,20 +564,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Stormblade_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Stormblade_Description",
     "spriteReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Warden.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Warden.json
@@ -427,7 +427,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "39",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -435,19 +441,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "39",
+    "$id": "40",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "40",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "41",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -457,22 +453,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "42",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "43",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -487,17 +478,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "44",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "45",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -507,7 +503,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -517,8 +513,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "47",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "48",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -529,10 +535,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "48",
+    "$id": "49",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "49",
+      "$id": "50",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -548,13 +554,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -574,20 +580,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "52",
+    "$id": "53",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Warden_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Warden_Description",
     "spriteReference": {
-      "$id": "53",
+      "$id": "54",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "54",
+      "$id": "55",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Whiteburn.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/ItemDefinition/Enchanted_Quarterstaff_Whiteburn.json
@@ -411,7 +411,13 @@
   "isStarterPack": false,
   "isContainerItem": false,
   "isLightSourceItem": false,
-  "isFocusItem": false,
+  "isFocusItem": true,
+  "focusItemDefinition": {
+    "$id": "37",
+    "$type": "FocusItemDescription, Assembly-CSharp",
+    "focusType": "Arcane",
+    "shownAsFocus": true
+  },
   "isWealthPile": false,
   "isSpellbook": false,
   "isDocument": false,
@@ -419,19 +425,9 @@
   "isFactionRelic": false,
   "personalityFlagOccurences": [],
   "soundEffectDescriptionOverride": {
-    "$id": "37",
+    "$id": "38",
     "$type": "SoundEffectDescription, Assembly-CSharp",
     "startEvent": {
-      "$id": "38",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
-      "WwiseObjectReference": null,
-      "idInternal": 0,
-      "valueGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      }
-    },
-    "stopEvent": {
       "$id": "39",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -441,22 +437,17 @@
         "$value": ""
       }
     },
-    "startSwitch": {
+    "stopEvent": {
       "$id": "40",
-      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
-      "groupIdInternal": 0,
-      "groupGuidInternal": {
-        "$type": "System.Byte[], mscorlib",
-        "$value": ""
-      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "stopSwitch": {
+    "startSwitch": {
       "$id": "41",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -471,17 +462,22 @@
         "$value": ""
       }
     },
-    "guiStoreBody": {
+    "stopSwitch": {
       "$id": "42",
-      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
+      "groupIdInternal": 0,
+      "groupGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      },
       "idInternal": 0,
       "valueGuidInternal": {
         "$type": "System.Byte[], mscorlib",
         "$value": ""
       }
     },
-    "guiPickBody": {
+    "guiStoreBody": {
       "$id": "43",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -491,7 +487,7 @@
         "$value": ""
       }
     },
-    "guiStoreOther": {
+    "guiPickBody": {
       "$id": "44",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
@@ -501,8 +497,18 @@
         "$value": ""
       }
     },
-    "guiPickOther": {
+    "guiStoreOther": {
       "$id": "45",
+      "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
+      "WwiseObjectReference": null,
+      "idInternal": 0,
+      "valueGuidInternal": {
+        "$type": "System.Byte[], mscorlib",
+        "$value": ""
+      }
+    },
+    "guiPickOther": {
+      "$id": "46",
       "$type": "AK.Wwise.Event, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "idInternal": 0,
@@ -513,10 +519,10 @@
     }
   },
   "soundEffectOnHitDescriptionOverride": {
-    "$id": "46",
+    "$id": "47",
     "$type": "SoundEffectOnHitDescription, Assembly-CSharp",
     "switchOnHit": {
-      "$id": "47",
+      "$id": "48",
       "$type": "AK.Wwise.Switch, AK.Wwise.Unity.API.WwiseTypes",
       "WwiseObjectReference": null,
       "groupIdInternal": 0,
@@ -532,13 +538,13 @@
     }
   },
   "itemPresentation": {
-    "$id": "48",
+    "$id": "49",
     "$type": "ItemPresentation, Assembly-CSharp",
     "unidentifiedTitle": "",
     "unidentifiedDescription": "",
     "overrideSubtype": "None",
     "assetReference": {
-      "$id": "49",
+      "$id": "50",
       "$type": "UnityEngine.AddressableAssets.AssetReference, Unity.Addressables",
       "m_AssetGUID": "1110be87443300f46976c1b313fa6d8e",
       "m_SubObjectName": "",
@@ -558,20 +564,20 @@
     "serializedVersion": 1
   },
   "guiPresentation": {
-    "$id": "50",
+    "$id": "51",
     "$type": "GuiPresentation, Assembly-CSharp",
     "hidden": false,
     "title": "Equipment/&Enchanted_Quarterstaff_Whiteburn_Title",
     "description": "Equipment/&Enchanted_Quarterstaff_Whiteburn_Description",
     "spriteReference": {
-      "$id": "51",
+      "$id": "52",
       "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
       "m_AssetGUID": "",
       "m_SubObjectName": null,
       "m_SubObjectType": null
     },
     "color": {
-      "$id": "52",
+      "$id": "53",
       "$type": "UnityEngine.Color, UnityEngine.CoreModule",
       "r": 1.0,
       "g": 1.0,

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/LootPackDefinition/PickPocketLoot.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/LootPackDefinition/PickPocketLoot.json
@@ -1,0 +1,48 @@
+{
+  "$type": "LootPackDefinition, Assembly-CSharp",
+  "inDungeonEditor": false,
+  "lootSpawnMode": "ItemList",
+  "itemOccurencesList": [
+    {
+      "$id": "1",
+      "$type": "ItemOccurence, Assembly-CSharp",
+      "diceNumber": 1,
+      "diceType": "D1",
+      "additiveModifier": 0,
+      "itemMode": "TreasureTable",
+      "itemDefinition": null,
+      "treasureTableDefinition": "Definition:PickPocketTable:79cac3e5-0f00-4062-b263-adbc854223d7"
+    }
+  ],
+  "lootMagnitudeMode": "Individual",
+  "lootChallengeMode": "ByPartyLevel",
+  "guiPresentation": {
+    "$id": "2",
+    "$type": "GuiPresentation, Assembly-CSharp",
+    "hidden": false,
+    "title": "Feature/&NoContentTitle",
+    "description": "Feature/&NoContentTitle",
+    "spriteReference": {
+      "$id": "3",
+      "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
+      "m_AssetGUID": "",
+      "m_SubObjectName": null,
+      "m_SubObjectType": null
+    },
+    "color": {
+      "$id": "4",
+      "$type": "UnityEngine.Color, UnityEngine.CoreModule",
+      "r": 1.0,
+      "g": 1.0,
+      "b": 1.0,
+      "a": 1.0
+    },
+    "symbolChar": "221E",
+    "sortOrder": 0,
+    "unusedInSolastaCOTM": false
+  },
+  "contentCopyright": "TacticalAdventuresContent",
+  "guid": "30c308db-1ad7-4f93-9431-43ce32358493",
+  "contentPack": "BaseGame",
+  "name": "PickPocketLoot"
+}

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/LootPackDefinition/PickPocketUndead.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/LootPackDefinition/PickPocketUndead.json
@@ -1,0 +1,48 @@
+{
+  "$type": "LootPackDefinition, Assembly-CSharp",
+  "inDungeonEditor": false,
+  "lootSpawnMode": "ItemList",
+  "itemOccurencesList": [
+    {
+      "$id": "1",
+      "$type": "ItemOccurence, Assembly-CSharp",
+      "diceNumber": 1,
+      "diceType": "D1",
+      "additiveModifier": 0,
+      "itemMode": "TreasureTable",
+      "itemDefinition": null,
+      "treasureTableDefinition": "Definition:PickPocketTableC:f1bbd8e5-3e05-48da-9c70-2db676a280b4"
+    }
+  ],
+  "lootMagnitudeMode": "Individual",
+  "lootChallengeMode": "ByPartyLevel",
+  "guiPresentation": {
+    "$id": "2",
+    "$type": "GuiPresentation, Assembly-CSharp",
+    "hidden": false,
+    "title": "Feature/&NoContentTitle",
+    "description": "Feature/&NoContentTitle",
+    "spriteReference": {
+      "$id": "3",
+      "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
+      "m_AssetGUID": "",
+      "m_SubObjectName": null,
+      "m_SubObjectType": null
+    },
+    "color": {
+      "$id": "4",
+      "$type": "UnityEngine.Color, UnityEngine.CoreModule",
+      "r": 1.0,
+      "g": 1.0,
+      "b": 1.0,
+      "a": 1.0
+    },
+    "symbolChar": "221E",
+    "sortOrder": 0,
+    "unusedInSolastaCOTM": false
+  },
+  "contentCopyright": "TacticalAdventuresContent",
+  "guid": "af2eb8e0-6a5a-40e2-8a62-160f80e2453e",
+  "contentPack": "BaseGame",
+  "name": "PickPocketUndead"
+}

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/TreasureTableDefinition/PickPocketTable.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/TreasureTableDefinition/PickPocketTable.json
@@ -1,0 +1,202 @@
+{
+  "$type": "TreasureTableDefinition, Assembly-CSharp",
+  "treasureOptions": [
+    {
+      "$id": "1",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_BronzeStatuette:af02ae2a4b9317b459d2db55c1335c0f",
+      "amount": 1
+    },
+    {
+      "$id": "2",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_EngraveBoneDice:28a34361e0d67b74a9ecdb523215d9a5",
+      "amount": 1
+    },
+    {
+      "$id": "3",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_GoldBracelet:b5eb965df15a17e4fb9fb75ae0069c44",
+      "amount": 1
+    },
+    {
+      "$id": "4",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_GoldLocket:fbf29c0c18c788d4b8a662ae9377ec79",
+      "amount": 1
+    },
+    {
+      "$id": "5",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_Mirror:3bb92fecf1ea7e24983e745cb2af446a",
+      "amount": 1
+    },
+    {
+      "$id": "6",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilkScarf:59d02f829c147b54ea6f4f525d3cd031",
+      "amount": 1
+    },
+    {
+      "$id": "7",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverBrooch:b0ae9ad3c2268434da513d75bf340628",
+      "amount": 1
+    },
+    {
+      "$id": "8",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverChalice:a9707c20b22715a489559045256ab383",
+      "amount": 1
+    },
+    {
+      "$id": "9",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverComb:28d8a4421d21c8648949ef1ec438b620",
+      "amount": 1
+    },
+    {
+      "$id": "10",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_VelvetMask:dc6b48e28ceb98f48b3a9225a3fcc61d",
+      "amount": 1
+    },
+    {
+      "$id": "11",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 10,
+      "itemDefinition": "Definition:1_Gold_Coin:57c20fc9e4b72724da48c916f89925c6",
+      "amount": 1
+    },
+    {
+      "$id": "12",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 30,
+      "itemDefinition": "Definition:1D6_Copper_Coins:294c5f98752753b4c905c3992c1d6431",
+      "amount": 3
+    },
+    {
+      "$id": "13",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 12,
+      "itemDefinition": "Definition:1D6_Silver_Coins:e85db9af5ca820f439fd455e1aa2fc83",
+      "amount": 2
+    },
+    {
+      "$id": "14",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 8,
+      "itemDefinition": "Definition:1D6_Gold_Coins:2bdca0eb1bf4b8344917184db67273ba",
+      "amount": 1
+    },
+    {
+      "$id": "15",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:ScrollBless:e53758827b2062f4d9a298d74256d7ab",
+      "amount": 1
+    },
+    {
+      "$id": "16",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:ScrollCureWounds:c11582501e7be5c4aae745008bf0b4e8",
+      "amount": 1
+    },
+    {
+      "$id": "17",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:ScrollDetectMagic:310603be831f9f54ab7e4ece1dcf2ea7",
+      "amount": 1
+    },
+    {
+      "$id": "18",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:ScrollIdentify:0d401a88655da224193b17adeae3cd0a",
+      "amount": 1
+    },
+    {
+      "$id": "19",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Poison_Basic:b5b96717da1f5114abfa3b097bc1db7d",
+      "amount": 1
+    },
+    {
+      "$id": "20",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:PotionRemedy:1ac685f6f87c5c247ad4332f6b4d08b7",
+      "amount": 1
+    },
+    {
+      "$id": "21",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 4,
+      "itemDefinition": "Definition:Dagger:a6eba377e5a35ad43a0e27441766735e",
+      "amount": 1
+    },
+    {
+      "$id": "22",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Ingredient_RefinedOil:cd3fc4d6eb31a454d8e213653c4970d7",
+      "amount": 1
+    },
+    {
+      "$id": "23",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Ingredient_Acid:bd7e07506aad3a244807052e95004020",
+      "amount": 1
+    },
+    {
+      "$id": "24",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:20_GP_Amethyst:8f7795d6772e6584c856e1240ce99fdb",
+      "amount": 1
+    }
+  ],
+  "guiPresentation": {
+    "$id": "25",
+    "$type": "GuiPresentation, Assembly-CSharp",
+    "hidden": false,
+    "title": "Feature/&NoContentTitle",
+    "description": "Feature/&NoContentTitle",
+    "spriteReference": {
+      "$id": "26",
+      "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
+      "m_AssetGUID": "",
+      "m_SubObjectName": null,
+      "m_SubObjectType": null
+    },
+    "color": {
+      "$id": "27",
+      "$type": "UnityEngine.Color, UnityEngine.CoreModule",
+      "r": 1.0,
+      "g": 1.0,
+      "b": 1.0,
+      "a": 1.0
+    },
+    "symbolChar": "221E",
+    "sortOrder": 0,
+    "unusedInSolastaCOTM": false
+  },
+  "contentCopyright": "OpenGameContent",
+  "guid": "79cac3e5-0f00-4062-b263-adbc854223d7",
+  "contentPack": "BaseGame",
+  "name": "PickPocketTable"
+}

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/TreasureTableDefinition/PickPocketTableC.json
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/TreasureTableDefinition/PickPocketTableC.json
@@ -1,0 +1,139 @@
+{
+  "$type": "TreasureTableDefinition, Assembly-CSharp",
+  "treasureOptions": [
+    {
+      "$id": "1",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_BronzeStatuette:af02ae2a4b9317b459d2db55c1335c0f",
+      "amount": 1
+    },
+    {
+      "$id": "2",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_EngraveBoneDice:28a34361e0d67b74a9ecdb523215d9a5",
+      "amount": 1
+    },
+    {
+      "$id": "3",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_GoldBracelet:b5eb965df15a17e4fb9fb75ae0069c44",
+      "amount": 1
+    },
+    {
+      "$id": "4",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_GoldLocket:fbf29c0c18c788d4b8a662ae9377ec79",
+      "amount": 1
+    },
+    {
+      "$id": "5",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_Mirror:3bb92fecf1ea7e24983e745cb2af446a",
+      "amount": 1
+    },
+    {
+      "$id": "6",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilkScarf:59d02f829c147b54ea6f4f525d3cd031",
+      "amount": 1
+    },
+    {
+      "$id": "7",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverBrooch:b0ae9ad3c2268434da513d75bf340628",
+      "amount": 1
+    },
+    {
+      "$id": "8",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverChalice:a9707c20b22715a489559045256ab383",
+      "amount": 1
+    },
+    {
+      "$id": "9",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_SilverComb:28d8a4421d21c8648949ef1ec438b620",
+      "amount": 1
+    },
+    {
+      "$id": "10",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 1,
+      "itemDefinition": "Definition:Art_Item_25_GP_VelvetMask:dc6b48e28ceb98f48b3a9225a3fcc61d",
+      "amount": 1
+    },
+    {
+      "$id": "11",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 10,
+      "itemDefinition": "Definition:1_Gold_Coin:57c20fc9e4b72724da48c916f89925c6",
+      "amount": 1
+    },
+    {
+      "$id": "12",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 30,
+      "itemDefinition": "Definition:1D6_Copper_Coins:294c5f98752753b4c905c3992c1d6431",
+      "amount": 3
+    },
+    {
+      "$id": "13",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 20,
+      "itemDefinition": "Definition:Ingredient_AbyssMoss:b066ff3c236988e4a9520cf44b555395",
+      "amount": 1
+    },
+    {
+      "$id": "14",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 20,
+      "itemDefinition": "Definition:Ingredient_DeepRootLichen:95b954de7fac7c94b8a5888e53c3097b",
+      "amount": 1
+    },
+    {
+      "$id": "15",
+      "$type": "TreasureOption, Assembly-CSharp",
+      "odds": 20,
+      "itemDefinition": "Definition:Ingredient_GoblinHairFungus:80cf95eb060947a4eadc3aa64dcd59c2",
+      "amount": 1
+    }
+  ],
+  "guiPresentation": {
+    "$id": "16",
+    "$type": "GuiPresentation, Assembly-CSharp",
+    "hidden": false,
+    "title": "Feature/&NoContentTitle",
+    "description": "Feature/&NoContentTitle",
+    "spriteReference": {
+      "$id": "17",
+      "$type": "UnityEngine.AddressableAssets.AssetReferenceSprite, Unity.Addressables",
+      "m_AssetGUID": "",
+      "m_SubObjectName": null,
+      "m_SubObjectType": null
+    },
+    "color": {
+      "$id": "18",
+      "$type": "UnityEngine.Color, UnityEngine.CoreModule",
+      "r": 1.0,
+      "g": 1.0,
+      "b": 1.0,
+      "a": 1.0
+    },
+    "symbolChar": "221E",
+    "sortOrder": 0,
+    "unusedInSolastaCOTM": false
+  },
+  "contentCopyright": "OpenGameContent",
+  "guid": "f1bbd8e5-3e05-48da-9c70-2db676a280b4",
+  "contentPack": "BaseGame",
+  "name": "PickPocketTableC"
+}

--- a/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/Types.txt
+++ b/SolastaCommunityExpansion/Diagnostics/CommunityExpansionBlueprints/Types.txt
@@ -33,6 +33,7 @@ FeatureDefinitionSavingThrowAffinity
 FeatureDefinitionSubclassChoice
 FeatureDefinitionSummoningAffinity
 ItemDefinition
+LootPackDefinition
 MonsterAttackDefinition
 MonsterDefinition
 RecipeDefinition
@@ -51,3 +52,4 @@ SolastaCommunityExpansion.Subclasses.Barbarian.PathOfTheLight+IlluminatingBurstP
 SolastaCommunityExpansion.Subclasses.Barbarian.PathOfTheLight+IlluminatingStrikeAdditionalDamage
 SpellDefinition
 SpellListDefinition
+TreasureTableDefinition


### PR DESCRIPTION
Done to match BetaWarlock branch.
This changes the guids of the two new blueprints  added recently.
Other blueprints added because I have more options checked in settings.  

_The set of CE blueprints generated and TA blueprints modified will differ depending on which settings are checked.  The current set isn't everything._