### PR TITLE
Allow Shift-R to rotate item

### DIFF
--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -32,6 +32,9 @@ namespace SolastaCommunityExpansion.Models
         {
             var inputService = ServiceRepository.GetService<IInputService>();
 
+            // Dungeon Maker
+            inputService.RegisterCommand(InputCommands.Id.EditorRotate, 114, (int)KeyCode.LeftShift, -1, -1, -1, -1);
+
             // HUD
             inputService.RegisterCommand(Hotkeys.CTRL_SHIFT_C, (int)KeyCode.C, (int)KeyCode.LeftShift, (int)KeyCode.LeftControl, -1, -1, -1);
             inputService.RegisterCommand(Hotkeys.CTRL_SHIFT_L, (int)KeyCode.L, (int)KeyCode.LeftShift, (int)KeyCode.LeftControl, -1, -1, -1);

--- a/SolastaCommunityExpansion/Models/GameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/GameUiContext.cs
@@ -33,7 +33,7 @@ namespace SolastaCommunityExpansion.Models
             var inputService = ServiceRepository.GetService<IInputService>();
 
             // Dungeon Maker
-            inputService.RegisterCommand(InputCommands.Id.EditorRotate, 114, (int)KeyCode.LeftShift, -1, -1, -1, -1);
+            inputService.RegisterCommand(InputCommands.Id.EditorRotate, (int)KeyCode.R, (int)KeyCode.LeftShift, -1, -1, -1, -1);
 
             // HUD
             inputService.RegisterCommand(Hotkeys.CTRL_SHIFT_C, (int)KeyCode.C, (int)KeyCode.LeftShift, (int)KeyCode.LeftControl, -1, -1, -1);


### PR DESCRIPTION
Tiny QOL.  Allow Shift-R to rotate say a wall-blocker, so when dropping loads of wall blockers we can rotate the dragged blocker without releasing shift.